### PR TITLE
feat: DM import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,517 +1,381 @@
 {
   "name": "keyteki-json-data",
   "version": "1.0.0",
-  "lockfileVersion": 3,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "keyteki-json-data",
-      "version": "1.0.0",
-      "license": "MIT",
-      "devDependencies": {
-        "eslint": "^4.18.2",
-        "jsonschema": "^1.2.2",
-        "request": "^2.87.0"
-      }
-    },
-    "node_modules/acorn": {
+  "dependencies": {
+    "acorn": {
       "version": "5.7.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
       "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
+      "dev": true
     },
-    "node_modules/acorn-jsx": {
+    "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "acorn": "^3.0.4"
-      }
-    },
-    "node_modules/acorn-jsx/node_modules/acorn": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
       },
-      "engines": {
-        "node": ">=0.4.0"
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
       }
     },
-    "node_modules/ajv": {
+    "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "co": "^4.6.0",
         "fast-deep-equal": "^1.0.0",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.3.0"
       }
     },
-    "node_modules/ajv-keywords": {
+    "ajv-keywords": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha512-ZFztHzVRdGLAzJmpUT9LNFLe1YiVOEylcaNpEutM26PVTCtOD919IMfD01CgbRouB42Dd9atjx1HseC15DgOZA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^5.0.0"
-      }
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
     },
-    "node_modules/ansi-escapes": {
+    "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
       "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
+      "dev": true
     },
-    "node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
-    "node_modules/argparse": {
+    "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "safer-buffer": "~2.1.0"
       }
     },
-    "node_modules/assert-plus": {
+    "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
-    "node_modules/asynckit": {
+    "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
-    "node_modules/aws-sign2": {
+    "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "dev": true,
-      "license": "MIT"
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
     },
-    "node_modules/babel-code-frame": {
+    "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
         "js-tokens": "^3.0.2"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
-    "node_modules/babel-code-frame/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
+    "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
+      "requires": {
         "tweetnacl": "^0.14.3"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "license": "MIT"
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
-    "node_modules/caller-path": {
+    "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha512-UJiE1otjXPF5/x+T3zTnSFiTOEmJoGTD9HmBoxnCUwho61a2eSNn/VwtwuIBDAo2SEOv1AJ7ARI5gCmohFLu/g==",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "callsites": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
-    "node_modules/callsites": {
+    "callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha512-Zv4Dns9IbXXmPkgRRUjAaJQgfN4xX5p6+RQFhWUqscdvvK2xK/ZL8b3IXIJsj+4sD+f24NwnWy2BY8AJ82JB0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
     },
-    "node_modules/caseless": {
+    "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true,
-      "license": "Apache-2.0"
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
-    "node_modules/chalk": {
+    "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       },
-      "engines": {
-        "node": ">=4"
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
-    "node_modules/chardet": {
+    "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha512-j/Toj7f1z98Hh2cYo2BVr85EpIRWqUi7rtRSGxh/cqUjqrnJe9l9UE7IUGd2vQ2p+kSHLkSzObQPZPLUC6TQwg==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
     },
-    "node_modules/circular-json": {
+    "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "deprecated": "CircularJSON is in maintenance only, flatted is its successor.",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
-    "node_modules/cli-cursor": {
+    "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "restore-cursor": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
-    "node_modules/cli-width": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
-      "dev": true,
-      "license": "ISC"
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
     },
-    "node_modules/co": {
+    "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
-      }
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
-    "node_modules/color-convert": {
+    "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "color-name": "1.1.3"
       }
     },
-    "node_modules/color-name": {
+    "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
-    "node_modules/combined-stream": {
+    "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
-    "node_modules/concat-map": {
+    "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
-    "node_modules/concat-stream": {
+    "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
-      "license": "MIT"
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
-    "node_modules/cross-spawn": {
+    "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
     },
-    "node_modules/dashdash": {
+    "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
-    "node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "ms": "^2.1.1"
       }
     },
-    "node_modules/deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
-      "license": "MIT"
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
-    "node_modules/delayed-stream": {
+    "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
-    "node_modules/doctrine": {
+    "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
+      "requires": {
         "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
-    "node_modules/ecc-jsbn": {
+    "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
     },
-    "node_modules/escape-string-regexp": {
+    "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
-    "node_modules/eslint": {
+    "eslint": {
       "version": "4.19.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
-      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "ajv": "^5.3.0",
         "babel-code-frame": "^6.22.0",
         "chalk": "^2.1.0",
@@ -550,477 +414,317 @@
         "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
         "text-table": "~0.2.0"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
-    "node_modules/eslint-scope": {
+    "eslint-scope": {
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
       "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
+      "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
-    "node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=4"
-      }
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
     },
-    "node_modules/espree": {
+    "espree": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
+      "requires": {
         "acorn": "^5.5.0",
         "acorn-jsx": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
-    "node_modules/esprima": {
+    "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
+      "requires": {
+        "estraverse": "^4.0.0"
       }
     },
-    "node_modules/esquery": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
-      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "estraverse": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
+      "requires": {
+        "estraverse": "^4.1.0"
       }
     },
-    "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
     },
-    "node_modules/esrecurse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
-    "node_modules/esrecurse/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extend": {
+    "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
-    "node_modules/external-editor": {
+    "external-editor": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "chardet": "^0.4.0",
         "iconv-lite": "^0.4.17",
         "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=0.12"
       }
     },
-    "node_modules/extsprintf": {
+    "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
-    "node_modules/fast-deep-equal": {
+    "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
     },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
-      "license": "MIT"
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
-    "node_modules/fast-levenshtein": {
+    "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
-    "node_modules/figures": {
+    "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
-    "node_modules/file-entry-cache": {
+    "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha512-uXP/zGzxxFvFfcZGgBIwotm+Tdc55ddPAzF7iHshP4YGaXMww7rSF9peD9D1sui5ebONg5UobsZv+FfgEpGv/w==",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
-    "node_modules/flat-cache": {
+    "flat-cache": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "circular-json": "^0.3.1",
         "graceful-fs": "^4.1.2",
         "rimraf": "~2.6.2",
         "write": "^0.2.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
-    "node_modules/forever-agent": {
+    "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
-    "node_modules/form-data": {
+    "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
-    "node_modules/fs.realpath": {
+    "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
-    "node_modules/functional-red-black-tree": {
+    "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
-    "node_modules/getpass": {
+    "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "assert-plus": "^1.0.0"
       }
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
+      "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/globals": {
+    "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
+      "dev": true
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
+    "graceful-fs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "dev": true
     },
-    "node_modules/har-schema": {
+    "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
+      "requires": {
+        "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
       },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/har-validator/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
       }
     },
-    "node_modules/har-validator/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/har-validator/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/has-ansi": {
+    "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
-    "node_modules/has-ansi/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-flag": {
+    "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
-    "node_modules/http-signature": {
+    "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
-    "node_modules/iconv-lite": {
+    "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
-    "node_modules/ignore": {
+    "ignore": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
-    "node_modules/imurmurhash": {
+    "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
-    "node_modules/inflight": {
+    "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
+      "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "node_modules/inherits": {
+    "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
-    "node_modules/inquirer": {
+    "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.0",
         "cli-cursor": "^2.1.0",
@@ -1037,433 +741,323 @@
         "through": "^2.3.6"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
+    "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
-    "node_modules/is-resolvable": {
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
-    "node_modules/is-typedarray": {
+    "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
-    "node_modules/isarray": {
+    "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
-    "node_modules/isexe": {
+    "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
-    "node_modules/isstream": {
+    "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
-    "node_modules/js-tokens": {
+    "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
-    "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
+    "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true,
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
-    "node_modules/json-schema-traverse": {
+    "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
     },
-    "node_modules/json-stable-stringify-without-jsonify": {
+    "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
-    "node_modules/json-stringify-safe": {
+    "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
-      "license": "ISC"
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
-    "node_modules/jsonschema": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
-      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
+    "jsonschema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
+      "dev": true
     },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
+        "json-schema": "0.2.3",
         "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
-    "node_modules/levn": {
+    "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT"
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
-    "node_modules/lru-cache": {
+    "lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
+      "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
+      "requires": {
+        "mime-db": "1.40.0"
       }
     },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimic-fn": {
+    "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
+      "dev": true
     },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
+      "requires": {
         "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "requires": {
+        "minimist": "^1.2.5"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mute-stream": {
+    "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
-      "dev": true,
-      "license": "ISC"
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
     },
-    "node_modules/natural-compare": {
+    "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
-    "node_modules/oauth-sign": {
+    "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
+      "dev": true
     },
-    "node_modules/object-assign": {
+    "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
-    "node_modules/once": {
+    "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
+      "requires": {
         "wrappy": "1"
       }
     },
-    "node_modules/onetime": {
+    "onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "mimic-fn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
-    "node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
+        "fast-levenshtein": "~2.0.4",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
+        "wordwrap": "~1.0.0"
       }
     },
-    "node_modules/os-tmpdir": {
+    "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
-    "node_modules/path-is-absolute": {
+    "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
-    "node_modules/path-is-inside": {
+    "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
-      "dev": true,
-      "license": "(WTFPL OR MIT)"
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
     },
-    "node_modules/performance-now": {
+    "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
-    "node_modules/pluralize": {
+    "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
+      "dev": true
     },
-    "node_modules/prelude-ls": {
+    "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
-    "node_modules/process-nextick-args": {
+    "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
-    "node_modules/progress": {
+    "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
+      "dev": true
     },
-    "node_modules/pseudomap": {
+    "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "dev": true,
-      "license": "ISC"
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
+    "psl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
+      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
+      "dev": true
     },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
-    "node_modules/qs": {
+    "qs": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
+      "dev": true
     },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
         "isarray": "~1.0.0",
@@ -1473,24 +1067,18 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/regexpp": {
+    "regexpp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
+      "dev": true
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
+      "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
         "caseless": "~0.12.0",
@@ -1498,7 +1086,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
+        "har-validator": "~5.1.0",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -1508,172 +1096,130 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
-    "node_modules/require-uncached": {
+    "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha512-Xct+41K3twrbBHdxAgMoOS+cNcoqIjfM2/VxBF4LL2hVph7YsF8VSKyQ3BDFZwEVbok9yeDl2le/qo0S77WG2w==",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve-from": {
+    "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha512-kT10v4dhrlLNcnO084hEjvXCI1wUG9qZLoz2RogxqDQQYy7IxjI/iMUkOtQTNEh6rzHxvdQWHsJyel1pKOVCxg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
     },
-    "node_modules/restore-cursor": {
+    "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
-    "node_modules/rimraf": {
+    "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
+      "requires": {
         "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
-    "node_modules/run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
+      "requires": {
+        "is-promise": "^2.1.0"
       }
     },
-    "node_modules/rx-lite": {
+    "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha512-Cun9QucwK6MIrp3mry/Y7hqD1oFqTYLQ4pGxaHTjIdaFDWRGGLikqp6u8LcWJnzpoALg9hap+JGk8sFIUuEGNA==",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
       "dev": true
     },
-    "node_modules/rx-lite-aggregates": {
+    "rx-lite-aggregates": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha512-3xPNZGW93oCjiO7PtKxRK6iOVYBWBvtf9QHDfU23Oc+dLIQmAV//UnyXV/yihv81VS/UqoQPk4NegS8EFi55Hg==",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
-      "dependencies": {
+      "requires": {
         "rx-lite": "*"
       }
     },
-    "node_modules/safe-buffer": {
+    "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
-    "node_modules/safer-buffer": {
+    "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
-    "node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
+    "semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
     },
-    "node_modules/shebang-command": {
+    "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
-    "node_modules/shebang-regex": {
+    "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
-    "node_modules/slice-ansi": {
+    "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "is-fullwidth-code-point": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
-    "node_modules/sprintf-js": {
+    "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
         "bcrypt-pbkdf": "^1.0.0",
@@ -1683,83 +1229,62 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/string-width": {
+    "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
-    "node_modules/strip-ansi": {
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "ansi-regex": "^3.0.0"
       },
-      "engines": {
-        "node": ">=4"
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
       }
     },
-    "node_modules/strip-json-comments": {
+    "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
-    "node_modules/table": {
+    "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
+      "requires": {
         "ajv": "^5.2.3",
         "ajv-keywords": "^2.1.0",
         "chalk": "^2.1.0",
@@ -1768,186 +1293,142 @@
         "string-width": "^2.1.1"
       }
     },
-    "node_modules/text-table": {
+    "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
-    "node_modules/through": {
+    "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
-    "node_modules/tmp": {
+    "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
       },
-      "engines": {
-        "node": ">=0.8"
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
       }
     },
-    "node_modules/tunnel-agent": {
+    "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
+      "requires": {
         "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
-    "node_modules/tweetnacl": {
+    "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "dev": true,
-      "license": "Unlicense"
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
-    "node_modules/type-check": {
+    "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
-    "node_modules/typedarray": {
+    "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
+      "requires": {
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/util-deprecate": {
+    "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
-    "node_modules/verror": {
+    "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
     },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/which": {
+    "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
+      "requires": {
         "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
       }
     },
-    "node_modules/word-wrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
-    "node_modules/wrappy": {
+    "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
-    "node_modules/write": {
+    "write": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha512-CJ17OoULEKXpA5pef3qLj5AxTJ6mSt7g84he2WIskKwqFO4T97d5V7Tadl0DYDk7qyUOQD5WlUlOMChaYrhxeA==",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
+      "requires": {
         "mkdirp": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
-    "node_modules/yallist": {
+    "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-      "dev": true,
-      "license": "ISC"
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
       "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -29,8 +30,9 @@
     "node_modules/acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "integrity": "sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "acorn": "^3.0.4"
       }
@@ -38,8 +40,9 @@
     "node_modules/acorn-jsx/node_modules/acorn": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "integrity": "sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -50,8 +53,9 @@
     "node_modules/ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "co": "^4.6.0",
         "fast-deep-equal": "^1.0.0",
@@ -62,8 +66,9 @@
     "node_modules/ajv-keywords": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "integrity": "sha512-ZFztHzVRdGLAzJmpUT9LNFLe1YiVOEylcaNpEutM26PVTCtOD919IMfD01CgbRouB42Dd9atjx1HseC15DgOZA==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "ajv": "^5.0.0"
       }
@@ -73,26 +78,32 @@
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
       "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=4"
       }
     },
     "node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=4"
       }
     },
     "node_modules/argparse": {
@@ -100,15 +111,17 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -116,8 +129,9 @@
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -125,40 +139,65 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-      "dev": true
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
         "js-tokens": "^3.0.2"
       }
     },
+    "node_modules/babel-code-frame/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/babel-code-frame/node_modules/chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -173,8 +212,9 @@
     "node_modules/babel-code-frame/node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -182,42 +222,57 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/babel-code-frame/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "integrity": "sha512-UJiE1otjXPF5/x+T3zTnSFiTOEmJoGTD9HmBoxnCUwho61a2eSNn/VwtwuIBDAo2SEOv1AJ7ARI5gCmohFLu/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^0.2.0"
       },
@@ -228,8 +283,9 @@
     "node_modules/callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "integrity": "sha512-Zv4Dns9IbXXmPkgRRUjAaJQgfN4xX5p6+RQFhWUqscdvvK2xK/ZL8b3IXIJsj+4sD+f24NwnWy2BY8AJ82JB0A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -237,14 +293,16 @@
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -254,48 +312,27 @@
         "node": ">=4"
       }
     },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-      "dev": true
+      "integrity": "sha512-j/Toj7f1z98Hh2cYo2BVr85EpIRWqUi7rtRSGxh/cqUjqrnJe9l9UE7IUGd2vQ2p+kSHLkSzObQPZPLUC6TQwg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "deprecated": "CircularJSON is in maintenance only, flatted is its successor.",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "restore-cursor": "^2.0.0"
       },
@@ -304,16 +341,18 @@
       }
     },
     "node_modules/cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -324,6 +363,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -331,14 +371,16 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -349,8 +391,9 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -360,6 +403,7 @@
       "engines": [
         "node >= 0.8"
       ],
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -368,16 +412,18 @@
       }
     },
     "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
@@ -387,8 +433,9 @@
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -397,26 +444,28 @@
       }
     },
     "node_modules/debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -426,6 +475,7 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -436,8 +486,9 @@
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -446,8 +497,9 @@
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -458,6 +510,7 @@
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^5.3.0",
         "babel-code-frame": "^6.22.0",
@@ -510,6 +563,7 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
       "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
@@ -519,10 +573,11 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
       }
@@ -532,6 +587,7 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^5.5.0",
         "acorn-jsx": "^3.0.0"
@@ -545,6 +601,7 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -554,43 +611,67 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.1.0"
       },
       "engines": {
-        "node": ">=0.6"
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
       },
       "engines": {
         "node": ">=4.0"
       }
     },
-    "node_modules/estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -599,13 +680,15 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/external-editor": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chardet": "^0.4.0",
         "iconv-lite": "^0.4.17",
@@ -618,35 +701,40 @@
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-      "dev": true
+      "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -657,8 +745,9 @@
     "node_modules/file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "integrity": "sha512-uXP/zGzxxFvFfcZGgBIwotm+Tdc55ddPAzF7iHshP4YGaXMww7rSF9peD9D1sui5ebONg5UobsZv+FfgEpGv/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
@@ -672,6 +761,7 @@
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "circular-json": "^0.3.1",
         "graceful-fs": "^4.1.2",
@@ -685,8 +775,9 @@
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
@@ -696,6 +787,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -708,40 +800,47 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
     },
     "node_modules/glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -749,33 +848,37 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
-      "dev": true
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "deprecated": "this library is no longer supported",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       },
       "engines": {
@@ -783,34 +886,42 @@
       }
     },
     "node_modules/har-validator/node_modules/ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/har-validator/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/har-validator/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -818,11 +929,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -830,8 +952,9 @@
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -847,6 +970,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -858,13 +982,15 @@
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
@@ -872,9 +998,10 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -884,13 +1011,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.0",
@@ -911,59 +1040,61 @@
     "node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
     },
     "node_modules/is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -975,62 +1106,70 @@
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jsonschema": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -1040,37 +1179,41 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
     },
     "node_modules/mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "mime-db": "1.40.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -1081,15 +1224,17 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1098,46 +1243,55 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
+      "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
@@ -1145,8 +1299,9 @@
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1154,8 +1309,9 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
@@ -1163,8 +1319,9 @@
     "node_modules/onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^1.0.0"
       },
@@ -1173,17 +1330,18 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -1192,8 +1350,9 @@
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1201,8 +1360,9 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1210,20 +1370,23 @@
     "node_modules/path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -1231,7 +1394,7 @@
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -1241,13 +1404,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1255,20 +1420,29 @@
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/psl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
-      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
-      "dev": true
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1278,15 +1452,17 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1302,16 +1478,18 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -1320,7 +1498,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -1330,19 +1508,20 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
       "engines": {
-        "node": ">= 4"
+        "node": ">= 6"
       }
     },
     "node_modules/require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "integrity": "sha512-Xct+41K3twrbBHdxAgMoOS+cNcoqIjfM2/VxBF4LL2hVph7YsF8VSKyQ3BDFZwEVbok9yeDl2le/qo0S77WG2w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
@@ -1354,8 +1533,9 @@
     "node_modules/resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "integrity": "sha512-kT10v4dhrlLNcnO084hEjvXCI1wUG9qZLoz2RogxqDQQYy7IxjI/iMUkOtQTNEh6rzHxvdQWHsJyel1pKOVCxg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1363,8 +1543,9 @@
     "node_modules/restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -1379,6 +1560,7 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -1387,13 +1569,11 @@
       }
     },
     "node_modules/run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "dev": true,
-      "dependencies": {
-        "is-promise": "^2.1.0"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1401,13 +1581,13 @@
     "node_modules/rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "integrity": "sha512-Cun9QucwK6MIrp3mry/Y7hqD1oFqTYLQ4pGxaHTjIdaFDWRGGLikqp6u8LcWJnzpoALg9hap+JGk8sFIUuEGNA==",
       "dev": true
     },
     "node_modules/rx-lite-aggregates": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "integrity": "sha512-3xPNZGW93oCjiO7PtKxRK6iOVYBWBvtf9QHDfU23Oc+dLIQmAV//UnyXV/yihv81VS/UqoQPk4NegS8EFi55Hg==",
       "dev": true,
       "dependencies": {
         "rx-lite": "*"
@@ -1417,19 +1597,22 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -1437,8 +1620,9 @@
     "node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -1449,23 +1633,26 @@
     "node_modules/shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-fullwidth-code-point": "^2.0.0"
       },
@@ -1476,14 +1663,16 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -1509,6 +1698,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -1518,6 +1708,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -1529,8 +1720,9 @@
     "node_modules/strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^3.0.0"
       },
@@ -1538,31 +1730,27 @@
         "node": ">=4"
       }
     },
-    "node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=4"
       }
     },
     "node_modules/table": {
@@ -1570,6 +1758,7 @@
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^5.2.3",
         "ajv-keywords": "^2.1.0",
@@ -1582,20 +1771,23 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -1604,29 +1796,25 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       },
       "engines": {
         "node": ">=0.8"
       }
     },
-    "node_modules/tough-cookie/node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -1637,14 +1825,16 @@
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "~1.1.2"
       },
@@ -1655,14 +1845,16 @@
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -1670,15 +1862,17 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -1686,22 +1880,31 @@
     "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -1709,23 +1912,29 @@
         "which": "bin/which"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/write": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "integrity": "sha512-CJ17OoULEKXpA5pef3qLj5AxTJ6mSt7g84he2WIskKwqFO4T97d5V7Tadl0DYDk7qyUOQD5WlUlOMChaYrhxeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mkdirp": "^0.5.1"
       },
@@ -1736,8 +1945,9 @@
     "node_modules/yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,381 +1,464 @@
 {
   "name": "keyteki-json-data",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "acorn": {
+  "packages": {
+    "": {
+      "name": "keyteki-json-data",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^4.18.2",
+        "jsonschema": "^1.2.2",
+        "request": "^2.87.0"
+      }
+    },
+    "node_modules/acorn": {
       "version": "5.7.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
       "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "acorn-jsx": {
+    "node_modules/acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
-      "requires": {
-        "acorn": "^3.0.4"
-      },
       "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
+        "acorn": "^3.0.4"
       }
     },
-    "ajv": {
+    "node_modules/acorn-jsx/node_modules/acorn": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "co": "^4.6.0",
         "fast-deep-equal": "^1.0.0",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.3.0"
       }
     },
-    "ajv-keywords": {
+    "node_modules/ajv-keywords": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^5.0.0"
+      }
     },
-    "ansi-escapes": {
+    "node_modules/ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
       "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "ansi-regex": {
+    "node_modules/ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "ansi-styles": {
+    "node_modules/ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "argparse": {
+    "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
-    "asn1": {
+    "node_modules/asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "safer-buffer": "~2.1.0"
       }
     },
-    "assert-plus": {
+    "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
     },
-    "asynckit": {
+    "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
-    "aws-sign2": {
+    "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "aws4": {
+    "node_modules/aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
-    "babel-code-frame": {
+    "node_modules/babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
         "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
       }
     },
-    "balanced-match": {
+    "node_modules/babel-code-frame/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "bcrypt-pbkdf": {
+    "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "tweetnacl": "^0.14.3"
       }
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "buffer-from": {
+    "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "caller-path": {
+    "node_modules/caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "callsites": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "callsites": {
+    "node_modules/callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "caseless": {
+    "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "chalk": {
+    "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+      "engines": {
+        "node": ">=4"
       }
     },
-    "chardet": {
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
-    "circular-json": {
+    "node_modules/circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "deprecated": "CircularJSON is in maintenance only, flatted is its successor.",
       "dev": true
     },
-    "cli-cursor": {
+    "node_modules/cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "cli-width": {
+    "node_modules/cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
-    "co": {
+    "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
     },
-    "color-convert": {
+    "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "color-name": "1.1.3"
       }
     },
-    "color-name": {
+    "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "combined-stream": {
+    "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "concat-stream": {
+    "node_modules/concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
-      "requires": {
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
       }
     },
-    "core-util-is": {
+    "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "cross-spawn": {
+    "node_modules/cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
     },
-    "dashdash": {
+    "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
-    "debug": {
+    "node_modules/debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ms": "^2.1.1"
       }
     },
-    "deep-is": {
+    "node_modules/deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "delayed-stream": {
+    "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "doctrine": {
+    "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "ecc-jsbn": {
+    "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
     },
-    "escape-string-regexp": {
+    "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
-    "eslint": {
+    "node_modules/eslint": {
       "version": "4.19.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ajv": "^5.3.0",
         "babel-code-frame": "^6.22.0",
         "chalk": "^2.1.0",
@@ -414,317 +497,401 @@
         "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
         "text-table": "~0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "eslint-scope": {
+    "node_modules/eslint-scope": {
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
       "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
-    "eslint-visitor-keys": {
+    "node_modules/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "espree": {
+    "node_modules/espree": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "acorn": "^5.5.0",
         "acorn-jsx": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "esprima": {
+    "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "esquery": {
+    "node_modules/esquery": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "estraverse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.6"
       }
     },
-    "esrecurse": {
+    "node_modules/esrecurse": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "estraverse": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
-    "estraverse": {
+    "node_modules/estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "esutils": {
+    "node_modules/esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "extend": {
+    "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
-    "external-editor": {
+    "node_modules/external-editor": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "chardet": "^0.4.0",
         "iconv-lite": "^0.4.17",
         "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
-    "extsprintf": {
+    "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ]
     },
-    "fast-deep-equal": {
+    "node_modules/fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
-    "fast-json-stable-stringify": {
+    "node_modules/fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
-    "fast-levenshtein": {
+    "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "figures": {
+    "node_modules/figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "file-entry-cache": {
+    "node_modules/file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "flat-cache": {
+    "node_modules/flat-cache": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "circular-json": "^0.3.1",
         "graceful-fs": "^4.1.2",
         "rimraf": "~2.6.2",
         "write": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "forever-agent": {
+    "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "form-data": {
+    "node_modules/form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
       }
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "functional-red-black-tree": {
+    "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "getpass": {
+    "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "assert-plus": "^1.0.0"
       }
     },
-    "glob": {
+    "node_modules/glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "globals": {
+    "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "graceful-fs": {
+    "node_modules/graceful-fs": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
       "dev": true
     },
-    "har-schema": {
+    "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "har-validator": {
+    "node_modules/har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "deprecated": "this library is no longer supported",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
       },
-      "dependencies": {
-        "ajv": {
-          "version": "6.10.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=6"
       }
     },
-    "has-ansi": {
+    "node_modules/har-validator/node_modules/ajv": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "node_modules/har-validator/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "node_modules/har-validator/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "has-flag": {
+    "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "http-signature": {
+    "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
       }
     },
-    "iconv-lite": {
+    "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "ignore": {
+    "node_modules/ignore": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
-    "imurmurhash": {
+    "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
     },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "inquirer": {
+    "node_modules/inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.0",
         "cli-cursor": "^2.1.0",
@@ -741,323 +908,386 @@
         "through": "^2.3.6"
       }
     },
-    "is-fullwidth-code-point": {
+    "node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "is-promise": {
+    "node_modules/is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-resolvable": {
+    "node_modules/is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
-    "is-typedarray": {
+    "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
-    "isarray": {
+    "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
-    "isexe": {
+    "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "isstream": {
+    "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "js-tokens": {
+    "node_modules/js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
-    "js-yaml": {
+    "node_modules/js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
-    "jsbn": {
+    "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
-    "json-schema": {
+    "node_modules/json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
-    "json-schema-traverse": {
+    "node_modules/json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
-    "json-stable-stringify-without-jsonify": {
+    "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
-    "json-stringify-safe": {
+    "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "jsonschema": {
+    "node_modules/jsonschema": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
       "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "jsprim": {
+    "node_modules/jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
-      "requires": {
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
     },
-    "levn": {
+    "node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "lodash": {
+    "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lru-cache": {
+    "node_modules/lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
     },
-    "mime-db": {
+    "node_modules/mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
       "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "mime-types": {
+    "node_modules/mime-types": {
       "version": "2.1.24",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "mime-db": "1.40.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "mimic-fn": {
+    "node_modules/mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "minimist": {
+    "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
-    "mkdirp": {
+    "node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
-    "ms": {
+    "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "mute-stream": {
+    "node_modules/mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "natural-compare": {
+    "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "oauth-sign": {
+    "node_modules/oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "object-assign": {
+    "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "onetime": {
+    "node_modules/onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "optionator": {
+    "node_modules/optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.4",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
         "wordwrap": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "os-tmpdir": {
+    "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "path-is-absolute": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "path-is-inside": {
+    "node_modules/path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
-    "performance-now": {
+    "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
-    "pluralize": {
+    "node_modules/pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "prelude-ls": {
+    "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
-    "process-nextick-args": {
+    "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "progress": {
+    "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "pseudomap": {
+    "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
-    "psl": {
+    "node_modules/psl": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
       "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
       "dev": true
     },
-    "punycode": {
+    "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "qs": {
+    "node_modules/qs": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
     },
-    "readable-stream": {
+    "node_modules/readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
         "isarray": "~1.0.0",
@@ -1067,18 +1297,22 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "regexpp": {
+    "node_modules/regexpp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
-    "request": {
+    "node_modules/request": {
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
         "caseless": "~0.12.0",
@@ -1099,127 +1333,158 @@
         "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 4"
       }
     },
-    "require-uncached": {
+    "node_modules/require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "resolve-from": {
+    "node_modules/resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "restore-cursor": {
+    "node_modules/restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "rimraf": {
+    "node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
-    "run-async": {
+    "node_modules/run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "is-promise": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
-    "rx-lite": {
+    "node_modules/rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
       "dev": true
     },
-    "rx-lite-aggregates": {
+    "node_modules/rx-lite-aggregates": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "rx-lite": "*"
       }
     },
-    "safe-buffer": {
+    "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
-    "safer-buffer": {
+    "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "semver": {
+    "node_modules/semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
-    "shebang-command": {
+    "node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "shebang-regex": {
+    "node_modules/shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "signal-exit": {
+    "node_modules/signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
-    "slice-ansi": {
+    "node_modules/slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "is-fullwidth-code-point": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "sprintf-js": {
+    "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sshpk": {
+    "node_modules/sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
         "bcrypt-pbkdf": "^1.0.0",
@@ -1229,62 +1494,83 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      }
-    },
-    "string_decoder": {
+    "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
-    "strip-ansi": {
+    "node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ansi-regex": "^3.0.0"
       },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=4"
       }
     },
-    "strip-json-comments": {
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "supports-color": {
+    "node_modules/supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
-    "table": {
+    "node_modules/table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ajv": "^5.2.3",
         "ajv-keywords": "^2.1.0",
         "chalk": "^2.1.0",
@@ -1293,138 +1579,161 @@
         "string-width": "^2.1.1"
       }
     },
-    "text-table": {
+    "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "through": {
+    "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
-    "tmp": {
+    "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
-    "tough-cookie": {
+    "node_modules/tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
       },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=0.8"
       }
     },
-    "tunnel-agent": {
+    "node_modules/tough-cookie/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "tweetnacl": {
+    "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
-    "type-check": {
+    "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "typedarray": {
+    "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "uri-js": {
+    "node_modules/uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "punycode": "^2.1.0"
       }
     },
-    "util-deprecate": {
+    "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "uuid": {
+    "node_modules/uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
-    "verror": {
+    "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
-      "requires": {
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
     },
-    "which": {
+    "node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
-    "wordwrap": {
+    "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "write": {
+    "node_modules/write": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "mkdirp": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "yallist": {
+    "node_modules/yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",

--- a/packs/DM.json
+++ b/packs/DM.json
@@ -3975,7 +3975,7 @@
             }
         },
         {
-            "id": "luis-compère",
+            "id": "luis-compere",
             "name": "Luis Compère",
             "number": "167",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_167_03b2dc801255_en.png",

--- a/packs/DM.json
+++ b/packs/DM.json
@@ -1,0 +1,6826 @@
+{
+    "ids": [
+        "928"
+    ],
+    "code": "DM",
+    "name": "Draconian Measures",
+    "cardCount": "370",
+    "releaseDate": "2026-04-28",
+    "cards": [
+        {
+            "id": "build-your-champion",
+            "name": "Build Your Champion",
+            "number": "001",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_001_fe78c9ba5cff_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
+            "locale": {
+                "en": {
+                    "name": "Build Your Champion"
+                }
+            }
+        },
+        {
+            "id": "build-your-champion",
+            "name": "Build Your Champion",
+            "number": "001",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_001_fe78c9ba5cff_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
+            "locale": {
+                "en": {
+                    "name": "Build Your Champion"
+                }
+            }
+        },
+        {
+            "id": "build-your-champion",
+            "name": "Build Your Champion",
+            "number": "001",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_001_fe78c9ba5cff_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
+            "locale": {
+                "en": {
+                    "name": "Build Your Champion"
+                }
+            }
+        },
+        {
+            "id": "build-your-champion",
+            "name": "Build Your Champion",
+            "number": "001",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_001_fe78c9ba5cff_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
+            "locale": {
+                "en": {
+                    "name": "Build Your Champion"
+                }
+            }
+        },
+        {
+            "id": "build-your-champion",
+            "name": "Build Your Champion",
+            "number": "001",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_001_fe78c9ba5cff_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
+            "locale": {
+                "en": {
+                    "name": "Build Your Champion"
+                }
+            }
+        },
+        {
+            "id": "build-your-champion",
+            "name": "Build Your Champion",
+            "number": "001",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_001_fe78c9ba5cff_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
+            "locale": {
+                "en": {
+                    "name": "Build Your Champion"
+                }
+            }
+        },
+        {
+            "id": "build-your-champion",
+            "name": "Build Your Champion",
+            "number": "001",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_001_fe78c9ba5cff_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
+            "locale": {
+                "en": {
+                    "name": "Build Your Champion"
+                }
+            }
+        },
+        {
+            "id": "digging-up-the-monster",
+            "name": "Digging Up the Monster",
+            "number": "002",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_002_2259df6cd35c_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
+            "locale": {
+                "en": {
+                    "name": "Digging Up the Monster"
+                }
+            }
+        },
+        {
+            "id": "digging-up-the-monster",
+            "name": "Digging Up the Monster",
+            "number": "002",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_002_2259df6cd35c_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
+            "locale": {
+                "en": {
+                    "name": "Digging Up the Monster"
+                }
+            }
+        },
+        {
+            "id": "digging-up-the-monster",
+            "name": "Digging Up the Monster",
+            "number": "002",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_002_2259df6cd35c_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
+            "locale": {
+                "en": {
+                    "name": "Digging Up the Monster"
+                }
+            }
+        },
+        {
+            "id": "digging-up-the-monster",
+            "name": "Digging Up the Monster",
+            "number": "002",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_002_2259df6cd35c_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
+            "locale": {
+                "en": {
+                    "name": "Digging Up the Monster"
+                }
+            }
+        },
+        {
+            "id": "digging-up-the-monster",
+            "name": "Digging Up the Monster",
+            "number": "002",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_002_2259df6cd35c_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
+            "locale": {
+                "en": {
+                    "name": "Digging Up the Monster"
+                }
+            }
+        },
+        {
+            "id": "digging-up-the-monster",
+            "name": "Digging Up the Monster",
+            "number": "002",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_002_2259df6cd35c_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
+            "locale": {
+                "en": {
+                    "name": "Digging Up the Monster"
+                }
+            }
+        },
+        {
+            "id": "digging-up-the-monster",
+            "name": "Digging Up the Monster",
+            "number": "002",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_002_2259df6cd35c_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
+            "locale": {
+                "en": {
+                    "name": "Digging Up the Monster"
+                }
+            }
+        },
+        {
+            "id": "tomes-gigantica",
+            "name": "Tomes Gigantica",
+            "number": "003",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_003_1dba13d6ad45_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
+            "locale": {
+                "en": {
+                    "name": "Tomes Gigantica"
+                }
+            }
+        },
+        {
+            "id": "tomes-gigantica",
+            "name": "Tomes Gigantica",
+            "number": "003",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_003_1dba13d6ad45_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
+            "locale": {
+                "en": {
+                    "name": "Tomes Gigantica"
+                }
+            }
+        },
+        {
+            "id": "tomes-gigantica",
+            "name": "Tomes Gigantica",
+            "number": "003",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_003_1dba13d6ad45_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
+            "locale": {
+                "en": {
+                    "name": "Tomes Gigantica"
+                }
+            }
+        },
+        {
+            "id": "tomes-gigantica",
+            "name": "Tomes Gigantica",
+            "number": "003",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_003_1dba13d6ad45_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
+            "locale": {
+                "en": {
+                    "name": "Tomes Gigantica"
+                }
+            }
+        },
+        {
+            "id": "tomes-gigantica",
+            "name": "Tomes Gigantica",
+            "number": "003",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_003_1dba13d6ad45_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
+            "locale": {
+                "en": {
+                    "name": "Tomes Gigantica"
+                }
+            }
+        },
+        {
+            "id": "tomes-gigantica",
+            "name": "Tomes Gigantica",
+            "number": "003",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_003_1dba13d6ad45_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
+            "locale": {
+                "en": {
+                    "name": "Tomes Gigantica"
+                }
+            }
+        },
+        {
+            "id": "tomes-gigantica",
+            "name": "Tomes Gigantica",
+            "number": "003",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_003_1dba13d6ad45_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
+            "locale": {
+                "en": {
+                    "name": "Tomes Gigantica"
+                }
+            }
+        },
+        {
+            "id": "art-project",
+            "name": "Art Project",
+            "number": "004",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_004_a91d223d694a_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Unforge an opponent’s key. If you do, purge Art Project, and your opponent draws 10 cards.\n",
+            "locale": {
+                "en": {
+                    "name": "Art Project"
+                }
+            }
+        },
+        {
+            "id": "barter-and-games",
+            "name": "Barter and Games",
+            "number": "005",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_005_baad59318086_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Each player reveals a random card from their hand or archives. Each player gains 1 for each  bonus icon on their revealed card. Destroy each creature that shares a house with at least one of the revealed cards. Discard the revealed cards.\n",
+            "locale": {
+                "en": {
+                    "name": "Barter and Games"
+                }
+            }
+        },
+        {
+            "id": "elenya-the-charming",
+            "name": "Elenya the Charming",
+            "number": "006",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_006_6cdd45601d9e_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [
+                "treachery"
+            ],
+            "traits": [
+                "human",
+                "merchant"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "Treachery. (This card enters play under your opponent’s control.)\nAfter you forge a key, give control of the most powerful friendly creature to your opponent.\n",
+            "locale": {
+                "en": {
+                    "name": "Elenya the Charming"
+                }
+            }
+        },
+        {
+            "id": "even-swap",
+            "name": "Even Swap",
+            "number": "007",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_007_25086e57673f_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Give control of two friendly creatures to your opponent, one at a time. If you do, take control of two enemy creatures, one at a time.\n",
+            "locale": {
+                "en": {
+                    "name": "Even Swap"
+                }
+            }
+        },
+        {
+            "id": "fiat-transcoder",
+            "name": "Fiat Transcoder",
+            "number": "008",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_008_a22c30adfcb1_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "item"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Action: Lose 1. If you do, take control of an enemy creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Fiat Transcoder"
+                }
+            }
+        },
+        {
+            "id": "forged-currency",
+            "name": "Forged Currency",
+            "number": "009",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_009_1ebd487a1b92_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Move each +1 power counter and each  from friendly creatures to the common supply. Forge a key at +6 current cost, reduced by 1 for the total number of +1 power counters and  moved to the common supply this way (to a minimum of 6).\n",
+            "locale": {
+                "en": {
+                    "name": "Forged Currency"
+                }
+            }
+        },
+        {
+            "id": "freelancer",
+            "name": "Freelancer",
+            "number": "010",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_010_ec7cad6f0c87_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "upgrade",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "At the start of each turn, the active player takes control of this creature.\nThis creature may be used as if it belonged to the active house.\n",
+            "locale": {
+                "en": {
+                    "name": "Freelancer"
+                }
+            }
+        },
+        {
+            "id": "game-changer",
+            "name": "Game Changer",
+            "number": "011",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_011_81caf1e49501_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "getrookya",
+                "analyst"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Enhance  . (These icons have already been added to cards in your deck.)\nEach friendly Ekwidon creature cannot reap and gains, “Action: Steal 1.”\n",
+            "locale": {
+                "en": {
+                    "name": "Game Changer"
+                }
+            }
+        },
+        {
+            "id": "midyear-festivities",
+            "name": "Midyear Festivities",
+            "number": "012",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_012_4ef5a8b2ea9c_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Choose 9 creatures. Move all  on the chosen creatures to their controllers’ pools. Destroy the chosen creatures.\n",
+            "locale": {
+                "en": {
+                    "name": "Midyear Festivities"
+                }
+            }
+        },
+        {
+            "id": "oŏni-lars",
+            "name": "Oŏni-Lars",
+            "number": "013",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_013_75e1a0d9e214_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "getrookya",
+                "politician"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 6,
+            "text": "After Reap: You may pay your opponent 1. If you do, your opponent’s keys cost +4 during their next turn.\n",
+            "locale": {
+                "en": {
+                    "name": "Oŏni-Lars"
+                }
+            }
+        },
+        {
+            "id": "talent-scout",
+            "name": "Talent Scout",
+            "number": "014",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_014_ed69cdec7dca_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [
+                "versatile"
+            ],
+            "traits": [
+                "getrookya"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": 0,
+            "power": 2,
+            "text": "Versatile. (This card may be used as if it belonged to the active house.)\nPlay: Look at your opponent’s hand and play a creature from it as if it were yours. Your opponent takes control of Talent Scout.\n",
+            "locale": {
+                "en": {
+                    "name": "Talent Scout"
+                }
+            }
+        },
+        {
+            "id": "the-golden-queen",
+            "name": "The Golden Queen",
+            "number": "015",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_015_917550b3fe8f_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "insect",
+                "cyborg"
+            ],
+            "type": "gigantic creature base",
+            "rarity": "Special",
+            "amber": 0,
+            "armor": null,
+            "power": 10,
+            "text": "(Play only with the other half of The Golden Queen.)\nEach player refills their hand to 1 additional card during their “draw cards” step.\nAfter Fight/After Reap: Each player discards a random card from their hand. For each non-Ekwidon card discarded this way, gain 1.\n",
+            "locale": {
+                "en": {
+                    "name": "The Golden Queen"
+                }
+            }
+        },
+        {
+            "id": "the-golden-queen",
+            "name": "The Golden Queen",
+            "number": "015",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_015_6c53d8681450_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "gigantic creature art",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "",
+            "locale": {
+                "en": {
+                    "name": "The Golden Queen"
+                }
+            }
+        },
+        {
+            "id": "three-sheets-to-the-wind",
+            "name": "Three Sheets to the Wind",
+            "number": "016",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_016_4d8b3cbc878b_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Your opponent draws 3 cards, discards a random card from their hand, puts a random card from their hand on top of their deck, and purges a random card from their hand.\n",
+            "locale": {
+                "en": {
+                    "name": "Three Sheets to the Wind"
+                }
+            }
+        },
+        {
+            "id": "zavel-archaeologist",
+            "name": "Zavel, “Archaeologist”",
+            "number": "017",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_017_f2f1c44d5506_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "human",
+                "scientist"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "Each time you play an artifact from your discard pile, gain 1.\nPlay/After Reap: You may play an artifact from your discard pile.\n",
+            "locale": {
+                "en": {
+                    "name": "Zavel, “Archaeologist”"
+                }
+            }
+        },
+        {
+            "id": "æmbitrage",
+            "name": "Æmbitrage",
+            "number": "018",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_018_491a7b93b723_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "power"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Your keys cost +1. \nDuring your “draw cards” step, refill your hand to 1 additional card.\n",
+            "locale": {
+                "en": {
+                    "name": "Æmbitrage"
+                }
+            }
+        },
+        {
+            "id": "authorized-requisitions",
+            "name": "Authorized Requisitions",
+            "number": "019",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_019_3392a0d38916_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: A friendly creature captures 2. Draw a card.\n",
+            "locale": {
+                "en": {
+                    "name": "Authorized Requisitions"
+                }
+            }
+        },
+        {
+            "id": "change-agent",
+            "name": "Change Agent",
+            "number": "020",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_020_0a690c8e298a_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "getrookya",
+                "merchant"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 1,
+            "power": 4,
+            "text": "After Fight/After Reap: For each card in your opponent’s hand in excess of 5, they lose 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Change Agent"
+                }
+            }
+        },
+        {
+            "id": "dapper-chapeau",
+            "name": "Dapper Chapeau",
+            "number": "021",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_021_a6bc01271bfc_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "upgrade",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "This creature gains, “Action: Deal 4 to a creature. If this damage destroys that creature, return Dapper Chapeau to its owner’s hand. Otherwise, attach Dapper Chapeau to that creature.”\n",
+            "locale": {
+                "en": {
+                    "name": "Dapper Chapeau"
+                }
+            }
+        },
+        {
+            "id": "drastic-measures",
+            "name": "Drastic Measures",
+            "number": "022",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_022_6d9f64568635_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Purge up to 2 cards from your hand. For each card purged this way, gain 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Drastic Measures"
+                }
+            }
+        },
+        {
+            "id": "exeldon-yash",
+            "name": "Exeldon Yash",
+            "number": "023",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_023_8a5b172ab156_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "human",
+                "merchant"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "After Reap: Capture 2. You may discard a card. If you do, move 1 from Exeldon Yash to your pool.\n",
+            "locale": {
+                "en": {
+                    "name": "Exeldon Yash"
+                }
+            }
+        },
+        {
+            "id": "fortune-reverser",
+            "name": "Fortune Reverser",
+            "number": "024",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_024_d17f665bc499_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "upgrade",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "This creature's text box is considered blank, except for traits.\nPlay: Destroy all other upgrades attached to this creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Fortune Reverser"
+                }
+            }
+        },
+        {
+            "id": "gegrrŏkŭŭ-sapper",
+            "name": "Gegrrŏkŭŭ Sapper",
+            "number": "025",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_025_7c383d24a498_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "getrookya",
+                "soldier"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 3,
+            "power": 3,
+            "text": "Play/After Fight: Take control of an enemy artifact. Give your opponent control of Gegrrŏkŭŭ Sapper.\nScrap: Destroy a friendly artifact. If you do, destroy an enemy artifact.\n",
+            "locale": {
+                "en": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                }
+            }
+        },
+        {
+            "id": "krisper-ruld",
+            "name": "Krisper Ruld",
+            "number": "026",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_026_6e9d9da2f718_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "human"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 1,
+            "power": 4,
+            "text": "After Fight: Take control of an enemy artifact.\n",
+            "locale": {
+                "en": {
+                    "name": "Krisper Ruld"
+                }
+            }
+        },
+        {
+            "id": "pen-pal",
+            "name": "Pen Pal",
+            "number": "027",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_027_303b40c4b495_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "human"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 5,
+            "text": "Action: Exhaust an enemy creature. If you do, each player gains 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Pen Pal"
+                }
+            }
+        },
+        {
+            "id": "reap-the-wild-wind",
+            "name": "Reap the Wild Wind",
+            "number": "028",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_028_9b2d81ff5146_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Enhance .\nPlay: Each player reveals a random card from their hand and gains 1 for each  bonus icon on their revealed card.\n",
+            "locale": {
+                "en": {
+                    "name": "Reap the Wild Wind"
+                }
+            }
+        },
+        {
+            "id": "technorachnophobia",
+            "name": "Technorachnophobia",
+            "number": "029",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_029_521ac31dcaf1_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Discard the top 10 cards of your deck. If you discard 5 or more cards of the same house this way, steal 2.\n",
+            "locale": {
+                "en": {
+                    "name": "Technorachnophobia"
+                }
+            }
+        },
+        {
+            "id": "waspscream",
+            "name": "Waspscream",
+            "number": "030",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_030_6a9967a856dc_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [
+                "poison"
+            ],
+            "traits": [
+                "insect",
+                "cyborg"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Entrench. Poison.\nAt the start of your turn, if Waspscream is exhausted, take control of an enemy creature. \n",
+            "locale": {
+                "en": {
+                    "name": "Waspscream"
+                }
+            }
+        },
+        {
+            "id": "bleă-fŏrh",
+            "name": "Bleă-Fŏrh",
+            "number": "031",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_031_1f7b48b50bd8_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "getrookya",
+                "soldier"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 2,
+            "power": 4,
+            "text": "After Fight: Heal up to 2 damage from a creature. For each damage healed this way, exalt that creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Bleă-Fŏrh"
+                }
+            }
+        },
+        {
+            "id": "bypass-burglar",
+            "name": "Bypass Burglar",
+            "number": "032",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_032_ff278f1127e6_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "getrookya",
+                "thief"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Entrench.\nWhile Bypass Burglar is exhausted, each of its neighbors gains, “Action: Steal 1. Deal 1 to this creature.”\n",
+            "locale": {
+                "en": {
+                    "name": "Bypass Burglar"
+                }
+            }
+        },
+        {
+            "id": "chromatic-guardian",
+            "name": "Chromatic Guardian",
+            "number": "033",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_033_a053b4a387eb_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "getrookya",
+                "soldier"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 1,
+            "power": 4,
+            "text": "After Fight/After Reap: If you are overwhelmed, destroy an enemy creature. Otherwise, destroy an enemy artifact.\n",
+            "locale": {
+                "en": {
+                    "name": "Chromatic Guardian"
+                }
+            }
+        },
+        {
+            "id": "cŏnrăd-fisiquĕ",
+            "name": "Cŏnrăd Fisiquĕ",
+            "number": "034",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_034_286c5f9020b9_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "getrookya"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Enhance .\nPlay: You may move each +1 power counter from a creature to another creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                }
+            }
+        },
+        {
+            "id": "gemcoat-vendor",
+            "name": "Gemcoat Vendor",
+            "number": "035",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_035_93acc275a5d9_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "getrookya",
+                "merchant"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 6,
+            "text": "Action: Steal 1. Deal 1 to Gemcoat Vendor.\n",
+            "locale": {
+                "en": {
+                    "name": "Gemcoat Vendor"
+                }
+            }
+        },
+        {
+            "id": "golden-dagger",
+            "name": "Golden Dagger",
+            "number": "036",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_036_f3060cb6d7c6_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [
+                "getrookya",
+                "merchant"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "After Reap: Deal 3 to a creature. If this damage destroys that creature, its owner gains 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Golden Dagger"
+                }
+            }
+        },
+        {
+            "id": "hoist-operations",
+            "name": "Hoist Operations",
+            "number": "037",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_037_c97cfd9731c6_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Put a creature into its owner’s archives.\n",
+            "locale": {
+                "en": {
+                    "name": "Hoist Operations"
+                }
+            }
+        },
+        {
+            "id": "hot-bunk",
+            "name": "Hot Bunk",
+            "number": "038",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_038_1512708ae4ed_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Exhaust a creature. If you do, ready a creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Hot Bunk"
+                }
+            }
+        },
+        {
+            "id": "nada-tax",
+            "name": "Nada Tax",
+            "number": "039",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_039_abfc672280c0_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Your opponent discards a random card from their hand. For each bonus icon on the discarded card, they lose 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Nada Tax"
+                }
+            }
+        },
+        {
+            "id": "now-and-later",
+            "name": "Now and Later",
+            "number": "040",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_040_734e56f759dd_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Return a creature to its owner’s hand and archive a card. If you are overwhelmed, repeat the preceding effect.\n",
+            "locale": {
+                "en": {
+                    "name": "Now and Later"
+                }
+            }
+        },
+        {
+            "id": "permanent-record",
+            "name": "Permanent Record",
+            "number": "041",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_041_0b7846dddbf8_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Exhaust a friendly creature. If you do, steal 2.\n",
+            "locale": {
+                "en": {
+                    "name": "Permanent Record"
+                }
+            }
+        },
+        {
+            "id": "văst-stŏik",
+            "name": "Văst Stŏik",
+            "number": "042",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_042_9360c260fee2_en.png",
+            "expansion": 928,
+            "house": "ekwidon",
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "getrookya",
+                "soldier"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 1,
+            "power": 4,
+            "text": "Taunt.\nAfter Fight: Move 1 from a creature to the common supply. If you do, draw a card.\n",
+            "locale": {
+                "en": {
+                    "name": "Văst Stŏik"
+                }
+            }
+        },
+        {
+            "id": "aurascope",
+            "name": "Aurascope",
+            "number": "043",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_043_7f12a11de0d1_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "item"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Action: Discard a card. If you do, purge a card of the same type as the discarded card from a discard pile.\n",
+            "locale": {
+                "en": {
+                    "name": "Aurascope"
+                }
+            }
+        },
+        {
+            "id": "empathic-malice",
+            "name": "Empathic Malice",
+            "number": "044",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_044_78206a0f9940_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Enhance .\nPlay: A friendly creature captures 3. If you are haunted, put Empathic Malice on the bottom of your deck.\n",
+            "locale": {
+                "en": {
+                    "name": "Empathic Malice"
+                }
+            }
+        },
+        {
+            "id": "future-is-past",
+            "name": "Future is Past",
+            "number": "045",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_045_c76501586816_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Swap each player's deck with their discard pile. Shuffle each player's deck.\n",
+            "locale": {
+                "en": {
+                    "name": "Future is Past"
+                }
+            }
+        },
+        {
+            "id": "ghost-town",
+            "name": "Ghost Town",
+            "number": "046",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_046_4145e8747915_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "location"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Action: If you are haunted, archive a card. Otherwise, discard a card. \n",
+            "locale": {
+                "en": {
+                    "name": "Ghost Town"
+                }
+            }
+        },
+        {
+            "id": "gigantor",
+            "name": "Gigantor",
+            "number": "047",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_047_f40b13355020_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "robot"
+            ],
+            "type": "gigantic creature base",
+            "rarity": "Special",
+            "amber": 0,
+            "armor": null,
+            "power": 8,
+            "text": "(Play only with the other half of Gigantor.)\nAfter Fight/After Reap: Purge up to 3 cards from a discard pile. For each card purged this way, draw a card.\n",
+            "locale": {
+                "en": {
+                    "name": "Gigantor"
+                }
+            }
+        },
+        {
+            "id": "gigantor",
+            "name": "Gigantor",
+            "number": "047",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_047_876e0e294701_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "gigantic creature art",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "",
+            "locale": {
+                "en": {
+                    "name": "Gigantor"
+                }
+            }
+        },
+        {
+            "id": "holographic-banshee",
+            "name": "Holographic Banshee",
+            "number": "048",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_048_7a40e11bd082_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "ai",
+                "specter"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Enhance .\nEach friendly Geistoid creature gains versatile.\n",
+            "locale": {
+                "en": {
+                    "name": "Holographic Banshee"
+                }
+            }
+        },
+        {
+            "id": "jahneerie",
+            "name": "Jahneerie",
+            "number": "049",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_049_7fafd66119bc_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "robot"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Enhance .\nEach friendly creature with  on it gains, “After Reap: Move 1 from this creature to your pool.”\n",
+            "locale": {
+                "en": {
+                    "name": "Jahneerie"
+                }
+            }
+        },
+        {
+            "id": "miss-chievous",
+            "name": "Miss Chievous",
+            "number": "050",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_050_e189888ae88a_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "robot"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "After a friendly Geistoid creature enters play, each player discards the top 2 cards of their deck.\nAfter Reap: Play the topmost creature from your discard pile.\n",
+            "locale": {
+                "en": {
+                    "name": "Miss Chievous"
+                }
+            }
+        },
+        {
+            "id": "pke-syphonator",
+            "name": "P.K.E. Syphonator",
+            "number": "051",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_051_d219d7433a3f_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Play: Gain 1 for each card in your opponent’s archives. Your opponent discards each card in their archives.\n",
+            "locale": {
+                "en": {
+                    "name": "P.K.E. Syphonator"
+                }
+            }
+        },
+        {
+            "id": "phantasm-cloak",
+            "name": "Phantasm Cloak",
+            "number": "052",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_052_aab32d81d9d2_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "upgrade",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "This creature gains, “After Reap: If you are haunted, gain 2.”\n",
+            "locale": {
+                "en": {
+                    "name": "Phantasm Cloak"
+                }
+            }
+        },
+        {
+            "id": "poltergeistoids",
+            "name": "Poltergeistoids",
+            "number": "053",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_053_97f9331d19ea_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Purge a card from a discard pile. If you do, play a creature or artifact from your purged zone as if it were in your hand. Attach Poltergeistoids to it as an upgrade with the text, “This card belongs to house Geistoid.”\n",
+            "locale": {
+                "en": {
+                    "name": "Poltergeistoids"
+                }
+            }
+        },
+        {
+            "id": "protective-playmate",
+            "name": "Protective Playmate",
+            "number": "054",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_054_b147e0a64fe2_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "specter"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Taunt.\nWhile you are haunted, Protective Playmate gets +6 power. Otherwise, Protective Playmate gains elusive.\n",
+            "locale": {
+                "en": {
+                    "name": "Protective Playmate"
+                }
+            }
+        },
+        {
+            "id": "shell-of-a-ghost",
+            "name": "Shell of a Ghost",
+            "number": "055",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_055_b547251b17d0_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Destroy each creature that is not on a flank. Put a creature from any discard pile into play under your control. Gain 2 chains.\n",
+            "locale": {
+                "en": {
+                    "name": "Shell of a Ghost"
+                }
+            }
+        },
+        {
+            "id": "trash-heap",
+            "name": "Trash Heap",
+            "number": "056",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_056_a22fade28642_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Destroy each creature. Each player reveals their hand and discards each creature revealed this way. Each player refills their hand as if it were their “draw cards” step.\n",
+            "locale": {
+                "en": {
+                    "name": "Trash Heap"
+                }
+            }
+        },
+        {
+            "id": "varad-the-indulgent",
+            "name": "Varad the Indulgent",
+            "number": "057",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_057_629aea18b752_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "robot"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "Varad the Indulgent gets +1 power for each  on it.\nAfter another friendly Geistoid creature fights, Varad the Indulgent captures 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Varad the Indulgent"
+                }
+            }
+        },
+        {
+            "id": "varghast-s-vengeance",
+            "name": "Varghast’s Vengeance",
+            "number": "058",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_058_8290fd671ea6_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "power"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Omni: Name a card. Until the start of your next turn, cards with that name cannot be played or used. Gain 2 chains.\nScrap: Purge a card from your opponent's discard pile. Your opponent shuffles their discard pile into their deck.\n",
+            "locale": {
+                "en": {
+                    "name": "Varghast’s Vengeance"
+                }
+            }
+        },
+        {
+            "id": "apoptosis",
+            "name": "Apoptosis",
+            "number": "059",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_059_b50504492954_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Purge a card from your discard pile. If you do, a friendly creature captures 2.\n",
+            "locale": {
+                "en": {
+                    "name": "Apoptosis"
+                }
+            }
+        },
+        {
+            "id": "boiler",
+            "name": "Boiler",
+            "number": "060",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_060_60726bbde94c_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "robot"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 4,
+            "power": 2,
+            "text": "Destroyed: Deal 6 to each enemy flank creature.\nScrap: Deal 1 to each enemy creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Boiler"
+                }
+            }
+        },
+        {
+            "id": "crepuscular-rays",
+            "name": "Crepuscular Rays",
+            "number": "061",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_061_af836115b0fb_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Choose a friendly creature. Move each  from that creature to your pool. Destroy that creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Crepuscular Rays"
+                }
+            }
+        },
+        {
+            "id": "dammater",
+            "name": "Dammater",
+            "number": "062",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_062_74130efe8049_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "ai"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Play: Draw 3 cards. Discard 2 cards. Archive a card.\n",
+            "locale": {
+                "en": {
+                    "name": "Dammater"
+                }
+            }
+        },
+        {
+            "id": "out-of-ideas",
+            "name": "Out of Ideas",
+            "number": "063",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_063_ef22b800bfd1_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Shuffle Out of Ideas and the top card of your discard pile into their owner’s deck.\n",
+            "locale": {
+                "en": {
+                    "name": "Out of Ideas"
+                }
+            }
+        },
+        {
+            "id": "paranormal-palisade",
+            "name": "Paranormal Palisade",
+            "number": "064",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_064_dc904f55b95a_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "item"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Entrench.\nWhile Paranormal Palisade is exhausted, it gets +4 armor and gains taunt.\n",
+            "locale": {
+                "en": {
+                    "name": "Paranormal Palisade"
+                }
+            }
+        },
+        {
+            "id": "return-to-rubble",
+            "name": "Return to Rubble",
+            "number": "065",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_065_878eef50f376_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Shuffle the top 10 cards of your discard pile into your deck. If you do, destroy each creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Return to Rubble"
+                }
+            }
+        },
+        {
+            "id": "spontaneous-awakening",
+            "name": "Spontaneous Awakening",
+            "number": "066",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_066_8f6015437824_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: If your opponent is haunted, destroy an enemy artifact, Cyborg creature, or Robot creature. If you do, play that card as if it were in your hand. Attach Spontaneous Awakening to it as an upgrade with the text, “This card belongs to house Geistoid.”\n",
+            "locale": {
+                "en": {
+                    "name": "Spontaneous Awakening"
+                }
+            }
+        },
+        {
+            "id": "techno-shade",
+            "name": "Techno-Shade",
+            "number": "067",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_067_5a2281d50bb8_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "robot"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 1,
+            "power": 3,
+            "text": "After Fight/After Reap: Your opponent shuffles a random card from their hand into their deck.\n",
+            "locale": {
+                "en": {
+                    "name": "Techno-Shade"
+                }
+            }
+        },
+        {
+            "id": "thoughtcatcher",
+            "name": "Thoughtcatcher",
+            "number": "068",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_068_54bef3fbbccd_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "robot"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 5,
+            "text": "Enhance .\nEach friendly creature with  on it gains, “Destroyed: Draw 1 card.”\n",
+            "locale": {
+                "en": {
+                    "name": "Thoughtcatcher"
+                }
+            }
+        },
+        {
+            "id": "titan-apparition",
+            "name": "Titan Apparition",
+            "number": "069",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_069_d555c9c62e62_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "specter",
+                "cyborg"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 6,
+            "text": "Taunt.\nDestroyed: If it is not your turn, your opponent discards 5 cards from the top of their deck. Otherwise, discard 5 cards from the top of your deck.\n",
+            "locale": {
+                "en": {
+                    "name": "Titan Apparition"
+                }
+            }
+        },
+        {
+            "id": "tribute-collector",
+            "name": "Tribute Collector",
+            "number": "070",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_070_6168d3d312c9_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "specter",
+                "robot"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 2,
+            "power": 4,
+            "text": "Taunt.\nPlay/After Fight: A friendly creature captures 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Tribute Collector"
+                }
+            }
+        },
+        {
+            "id": "ecto-charge",
+            "name": "Ecto-Charge",
+            "number": "071",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_071_091a2b6250e0_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Forge a key at +20 current cost, reduced by 1 for each card in your discard pile (to a minimum of 6). If you do, purge Ecto-Charge.\n",
+            "locale": {
+                "en": {
+                    "name": "Ecto-Charge"
+                }
+            }
+        },
+        {
+            "id": "fading-apparition",
+            "name": "Fading Apparition",
+            "number": "072",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_072_3ca64451692d_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "robot"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Entrench.\nWhile Fading Apparition is exhausted, any  you would gain by reaping may be taken from  among friendly creatures instead of the common supply.\n",
+            "locale": {
+                "en": {
+                    "name": "Fading Apparition"
+                }
+            }
+        },
+        {
+            "id": "hammer-smythe",
+            "name": "Hammer Smythe",
+            "number": "073",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_073_bb22099c49e8_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "robot"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "After Reap: Deal 2 to a creature. If this damage destroys that creature, give a friendly creature two +1 power counters.\n",
+            "locale": {
+                "en": {
+                    "name": "Hammer Smythe"
+                }
+            }
+        },
+        {
+            "id": "haunting-deck",
+            "name": "Haunting Deck",
+            "number": "074",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_074_eb53c2835e14_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Enhance . (These icons have already been added to cards in your deck.)\nPlay: If you are haunted, purge a card from a discard pile.\n",
+            "locale": {
+                "en": {
+                    "name": "Haunting Deck"
+                }
+            }
+        },
+        {
+            "id": "haunting-measures",
+            "name": "Haunting Measures",
+            "number": "075",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_075_fa79c53ebb63_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Discard the top 6 cards of your deck. You may put a non-Geistoid card discarded this way into your hand.\n",
+            "locale": {
+                "en": {
+                    "name": "Haunting Measures"
+                }
+            }
+        },
+        {
+            "id": "janky-jimmy",
+            "name": "Janky Jimmy",
+            "number": "076",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_076_224717cef9aa_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "robot"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 2,
+            "power": 3,
+            "text": "After Fight: If you are overwhelmed, an enemy creature captures 1 from its own side. Otherwise, capture 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Janky Jimmy"
+                }
+            }
+        },
+        {
+            "id": "memette",
+            "name": "Memette",
+            "number": "077",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_077_8d988aa0b840_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "faerie"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 1,
+            "text": "Play/Destroyed: Archive the top card of your discard pile.\n",
+            "locale": {
+                "en": {
+                    "name": "Memette"
+                }
+            }
+        },
+        {
+            "id": "ol--switcheroo",
+            "name": "Ol’ Switcheroo",
+            "number": "078",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_078_5816dcc7395c_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Enhance .\nPlay: A friendly creature captures 1. Give control of that creature to your opponent.\n",
+            "locale": {
+                "en": {
+                    "name": "Ol’ Switcheroo"
+                }
+            }
+        },
+        {
+            "id": "recyclops",
+            "name": "Recyclops",
+            "number": "079",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_079_8d66781e2c41_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "cyborg"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Enhance .\nAfter Reap: Discard a card. If you do, give a creature two +1 power counters.\n",
+            "locale": {
+                "en": {
+                    "name": "Recyclops"
+                }
+            }
+        },
+        {
+            "id": "reduce-reuse",
+            "name": "Reduce, Reuse",
+            "number": "080",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_080_5b18a1fd97af_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: If you are haunted, deal 5 to a creature. Otherwise, return a creature to its owner’s hand.\n",
+            "locale": {
+                "en": {
+                    "name": "Reduce, Reuse"
+                }
+            }
+        },
+        {
+            "id": "spikey-goeff",
+            "name": "Spikey Goeff",
+            "number": "081",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_081_b6cde23ea192_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "specter",
+                "robot"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "Taunt. \nIf you are overwhelmed, Spikey Goeff gains hazardous 2.\nScrap: Deal 2 to a creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Spikey Goeff"
+                }
+            }
+        },
+        {
+            "id": "wraith-construct",
+            "name": "Wraith Construct",
+            "number": "082",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_082_0bf3a9b7797b_en.png",
+            "expansion": 928,
+            "house": "geistoid",
+            "keywords": [],
+            "traits": [
+                "specter",
+                "robot"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "At the start of your turn, discard a card from your hand.\n",
+            "locale": {
+                "en": {
+                    "name": "Wraith Construct"
+                }
+            }
+        },
+        {
+            "id": "bartos-the-ruiner",
+            "name": "Bartos the Ruiner",
+            "number": "083",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_083_286e65652598_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "martian",
+                "soldier"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Each non-Mars creature and artifact gains, “After this card is used, destroy it.”\n",
+            "locale": {
+                "en": {
+                    "name": "Bartos the Ruiner"
+                }
+            }
+        },
+        {
+            "id": "brain-stem-antenna",
+            "name": "Brain Stem Antenna",
+            "number": "084",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_084_860d7d5889a8_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "upgrade",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "This creature gains, “After you play a Mars creature, ready this creature and for the remainder of the turn it belongs to house Mars.”",
+            "locale": {
+                "en": {
+                    "name": "Brain Stem Antenna"
+                }
+            }
+        },
+        {
+            "id": "eldest-batchminder",
+            "name": "Eldest Batchminder",
+            "number": "085",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_085_fa92a53db24b_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "elder",
+                "recruiter"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Enhance  . (These icons have already been added to cards in your deck.)\nAt the end of your turn, give each other Mars creature two +1 power counters.\n",
+            "locale": {
+                "en": {
+                    "name": "Eldest Batchminder"
+                }
+            }
+        },
+        {
+            "id": "emperor-memrox",
+            "name": "Emperor Memrox",
+            "number": "086",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_086_9dbe00e82363_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "martian",
+                "leader",
+                "elder"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 5,
+            "text": "While Emperor Memrox is in the center of your battleline, it gains invulnerable.\nAfter Reap: Archive a card. Gain 1 for each card in your archives.\n",
+            "locale": {
+                "en": {
+                    "name": "Emperor Memrox"
+                }
+            }
+        },
+        {
+            "id": "extinction",
+            "name": "Extinction",
+            "number": "087",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_087_1525e19fbdb3_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Destroy a creature and each creature that shares a trait with it. Gain 1 chain.",
+            "locale": {
+                "en": {
+                    "name": "Extinction"
+                }
+            }
+        },
+        {
+            "id": "hypnotic-command",
+            "name": "Hypnotic Command",
+            "number": "088",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_088_ce390ce023a9_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: For each friendly Mars creature, choose an enemy creature to capture 1 from its own side.",
+            "locale": {
+                "en": {
+                    "name": "Hypnotic Command"
+                }
+            }
+        },
+        {
+            "id": "martian-propagation",
+            "name": "Martian Propagation",
+            "number": "089",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_089_a74a5b9b5725_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Destroy each friendly creature. For each creature destroyed this way, draw 2 cards.\n",
+            "locale": {
+                "en": {
+                    "name": "Martian Propagation"
+                }
+            }
+        },
+        {
+            "id": "mass-abduction",
+            "name": "Mass Abduction",
+            "number": "090",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_090_1f03d6057431_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Put up to 3 damaged enemy creatures into your archives. If any of these creatures leave your archives, they are put into their owner’s hand instead.",
+            "locale": {
+                "en": {
+                    "name": "Mass Abduction"
+                }
+            }
+        },
+        {
+            "id": "monster-zero",
+            "name": "Monster Zero",
+            "number": "091",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_091_e35c857e4e4a_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [
+                "deploy"
+            ],
+            "traits": [
+                "beast",
+                "experiment"
+            ],
+            "type": "gigantic creature base",
+            "rarity": "Special",
+            "amber": 0,
+            "armor": null,
+            "power": 1,
+            "text": "(Play only with the other half of Monster Zero.)\nDeploy.\nEach of Monster Zero's neighbors belongs to house Mars (instead of its other houses).\nPlay: Give Monster Zero a number of +1 power counters equal to the most powerful friendly creature’s power.\n",
+            "locale": {
+                "en": {
+                    "name": "Monster Zero"
+                }
+            }
+        },
+        {
+            "id": "monster-zero",
+            "name": "Monster Zero",
+            "number": "091",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_091_7863a243829e_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "gigantic creature art",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "",
+            "locale": {
+                "en": {
+                    "name": "Monster Zero"
+                }
+            }
+        },
+        {
+            "id": "psychic-haze",
+            "name": "Psychic Haze",
+            "number": "092",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_092_60585e3bb855_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "power"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Enraged creatures cannot be used to fight friendly Mars creatures.\nAction: Enrage each enemy creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Psychic Haze"
+                }
+            }
+        },
+        {
+            "id": "tangrant",
+            "name": "Tangrant",
+            "number": "093",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_093_95c4f2907709_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "beast"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "You may play a Mars card during each turn in which Mars is not your active house.\n",
+            "locale": {
+                "en": {
+                    "name": "Tangrant"
+                }
+            }
+        },
+        {
+            "id": "the-body-snatchers",
+            "name": "The Body Snatchers",
+            "number": "094",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_094_0b1c68dedc93_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: For the remainder of the turn, each enemy creature gains, “Destroyed: Fully heal this creature and give control of it to your opponent instead.”\n",
+            "locale": {
+                "en": {
+                    "name": "The Body Snatchers"
+                }
+            }
+        },
+        {
+            "id": "urxym-the-diplomat",
+            "name": "Urxym the “Diplomat”",
+            "number": "095",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_095_82674306632c_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "martian",
+                "politician"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Elusive.\nAfter Reap: Lose all your . Destroy an enemy non-Mars creature for each  lost this way.\n",
+            "locale": {
+                "en": {
+                    "name": "Urxym the “Diplomat”"
+                }
+            }
+        },
+        {
+            "id": "zzyszz-s-compactor",
+            "name": "Zzyszz’s Compactor",
+            "number": "096",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_096_0a826ca23ce1_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "power"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Action: Put a creature on the bottom of its owner’s deck. If you do, give a creature two +1 power counters.\n",
+            "locale": {
+                "en": {
+                    "name": "Zzyszz’s Compactor"
+                }
+            }
+        },
+        {
+            "id": "all-are-mars",
+            "name": "All Are Mars",
+            "number": "097",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_097_7b2a27fb9bcc_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "power"
+            ],
+            "type": "artifact",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Action: Ready and use a friendly creature.\n",
+            "locale": {
+                "en": {
+                    "name": "All Are Mars"
+                }
+            }
+        },
+        {
+            "id": "destroy-them-all",
+            "name": "Destroy Them All!",
+            "number": "098",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_098_4d8892dc4a51_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Destroy an artifact, a creature, and an upgrade.",
+            "locale": {
+                "en": {
+                    "name": "Destroy Them All!"
+                }
+            }
+        },
+        {
+            "id": "edifice-for-mars",
+            "name": "Edifice for Mars",
+            "number": "099",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_099_0bc22f6a6c11_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Destroy a non-Mars artifact. If you do, you may ready a friendly card. \n",
+            "locale": {
+                "en": {
+                    "name": "Edifice for Mars"
+                }
+            }
+        },
+        {
+            "id": "empowered-zark",
+            "name": "Empowered Zark",
+            "number": "100",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_100_8b9e21ef1416_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "martian",
+                "agent"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 2,
+            "power": 3,
+            "text": "After Fight: Capture 2. If there are 3 or more on Empowered Zark, you may move 3 from it to the common supply and ready each non-Agent Mars creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Empowered Zark"
+                }
+            }
+        },
+        {
+            "id": "golden-k1-tt13",
+            "name": "Golden K1-TT13",
+            "number": "101",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_101_3c5e74d612ea_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "beast"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "Entrench.\nWhile Golden K1-TT13 is exhausted, each of its neighbors gains, “After Reap: Gain 1.”\n",
+            "locale": {
+                "en": {
+                    "name": "Golden K1-TT13"
+                }
+            }
+        },
+        {
+            "id": "iyxrenu-the-clever",
+            "name": "Iyxrenu the Clever",
+            "number": "102",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_102_9f799c3a38f5_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "martian"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Elusive. Enhance .\nAction: Lose 1. If you do, move all  from a creature to your pool.\n",
+            "locale": {
+                "en": {
+                    "name": "Iyxrenu the Clever"
+                }
+            }
+        },
+        {
+            "id": "key-drain",
+            "name": "Key Drain",
+            "number": "103",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_103_8bf640308232_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: You may discard any number of cards from your hand. Then, forge a key at +9 current cost, reduced by 1 for each card discarded this way.\n",
+            "locale": {
+                "en": {
+                    "name": "Key Drain"
+                }
+            }
+        },
+        {
+            "id": "nyzyk-resonator",
+            "name": "Nyzyk Resonator",
+            "number": "104",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_104_6043efa28909_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "martian",
+                "soldier"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 1,
+            "power": 2,
+            "text": "For each neighbor Nyzyk Resonator has, your opponent’s keys cost +2.",
+            "locale": {
+                "en": {
+                    "name": "Nyzyk Resonator"
+                }
+            }
+        },
+        {
+            "id": "orbital-bombardment",
+            "name": "Orbital Bombardment",
+            "number": "105",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_105_170e2851394e_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Reveal any number of Mars cards from your hand. For each card revealed this way, deal 2 to a creature. (You may choose a different creature each time.)",
+            "locale": {
+                "en": {
+                    "name": "Orbital Bombardment"
+                }
+            }
+        },
+        {
+            "id": "shark-bait",
+            "name": "Shark Bait",
+            "number": "106",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_106_d4a1bf863db5_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Deal 2 to a friendly non-Mars creature. If it is not destroyed, it captures 2.\n",
+            "locale": {
+                "en": {
+                    "name": "Shark Bait"
+                }
+            }
+        },
+        {
+            "id": "the-red-death",
+            "name": "The Red Death",
+            "number": "107",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_107_3672fc33d8b4_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "beast"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 12,
+            "text": "Enhance .\nThe Red Death cannot ready unless you are haunted.\nAfter Fight: Gain 1 and draw a card.\n",
+            "locale": {
+                "en": {
+                    "name": "The Red Death"
+                }
+            }
+        },
+        {
+            "id": "lyylyug",
+            "name": "lyylyug",
+            "number": "108",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_108_a15c49e6356e_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "martian",
+                "elder"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Elusive.\nAfter Reap: The least powerful enemy creature captures 1 from its own side.\n",
+            "locale": {
+                "en": {
+                    "name": "lyylyug"
+                }
+            }
+        },
+        {
+            "id": "agent-buuff",
+            "name": "Agent Buuff",
+            "number": "109",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_109_fbf40e46ccd3_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "martian",
+                "agent"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "After Reap: If you are overwhelmed, give a friendly creature three +1 power counters. Otherwise, give each friendly creature a +1 power counter.\n",
+            "locale": {
+                "en": {
+                    "name": "Agent Buuff"
+                }
+            }
+        },
+        {
+            "id": "arbiter-vyynx",
+            "name": "Arbiter Vyynx",
+            "number": "110",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_110_1724d0cf430b_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "robot"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "After Reap: Destroy a friendly non-Mars creature. If you do, take control of an enemy creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Arbiter Vyynx"
+                }
+            }
+        },
+        {
+            "id": "collector-worm",
+            "name": "Collector Worm",
+            "number": "111",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_111_6817210e5e24_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "beast"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 5,
+            "power": 2,
+            "text": "After Fight: Put the creature Collector Worm fights into your archives. (Both creatures must survive the fight.) If that creature leaves your archives, put it in its owner’s hand instead.\n",
+            "locale": {
+                "en": {
+                    "name": "Collector Worm"
+                }
+            }
+        },
+        {
+            "id": "digital-manipulation",
+            "name": "Digital Manipulation",
+            "number": "112",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_112_112837cf871f_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Discard the top card of your opponent’s deck. If it is not a Mars card, an enemy creature captures 1 from its own side.\n",
+            "locale": {
+                "en": {
+                    "name": "Digital Manipulation"
+                }
+            }
+        },
+        {
+            "id": "harmonic-pack",
+            "name": "Harmonic Pack",
+            "number": "113",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_113_3f029e8d1eb7_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Deal 2 to a creature. Reveal a random card from a player’s archives. If you do, deal an additional 3 to the same creature. Discard the revealed card.\n",
+            "locale": {
+                "en": {
+                    "name": "Harmonic Pack"
+                }
+            }
+        },
+        {
+            "id": "kaboom",
+            "name": "Kaboom!",
+            "number": "114",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_114_fe756f7e8985_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Put each Mars creature into its owner’s archives. Destroy each creature. Gain 3 chains.\n",
+            "locale": {
+                "en": {
+                    "name": "Kaboom!"
+                }
+            }
+        },
+        {
+            "id": "klyyhnug",
+            "name": "Klyyhnug",
+            "number": "115",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_115_3fa83c2bfe9a_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "martian",
+                "soldier"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Enhance .\nAfter Reap: You may remove each +1 power counter from a creature. If one or more counters are removed this way, archive a card.\n",
+            "locale": {
+                "en": {
+                    "name": "Klyyhnug"
+                }
+            }
+        },
+        {
+            "id": "operator-olluyyg",
+            "name": "Operator Olluyyg",
+            "number": "116",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_116_dda3661d5b7d_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "martian",
+                "elder"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Entrench.\nWhile Operator Olluyyg is exhausted, your opponent’s keys cost +3.\n",
+            "locale": {
+                "en": {
+                    "name": "Operator Olluyyg"
+                }
+            }
+        },
+        {
+            "id": "productive-trash",
+            "name": "Productive Trash",
+            "number": "117",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_117_84b6789065df_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: You may discard a non-Mars card. If you do, a friendly creature captures 1 for each bonus icon on the discarded card.\n",
+            "locale": {
+                "en": {
+                    "name": "Productive Trash"
+                }
+            }
+        },
+        {
+            "id": "replacement-targ",
+            "name": "Replacement Targ",
+            "number": "118",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_118_3a67c38224f0_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [
+                "deploy"
+            ],
+            "traits": [
+                "martian",
+                "soldier"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Deploy.\nPlay: Put a neighboring non-Soldier creature into its owner’s hand. If you do, the most powerful friendly creature captures 2.\n",
+            "locale": {
+                "en": {
+                    "name": "Replacement Targ"
+                }
+            }
+        },
+        {
+            "id": "transmutation",
+            "name": "Transmutation",
+            "number": "119",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_119_26c8e519a046_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Give a creature two +1 power counters. You may remove any number of +1 power counters from a friendly creature. That creature captures 1 for each counter removed this way.\n",
+            "locale": {
+                "en": {
+                    "name": "Transmutation"
+                }
+            }
+        },
+        {
+            "id": "ujkyytr-prime",
+            "name": "Ujkyytr Prime",
+            "number": "120",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_120_b8f00ad9f531_en.png",
+            "expansion": 928,
+            "house": "mars",
+            "keywords": [],
+            "traits": [
+                "martian",
+                "soldier"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "After Fight/After Reap: If you are overwhelmed, stun an enemy creature and each of its neighbors. Otherwise, stun a creature. \n",
+            "locale": {
+                "en": {
+                    "name": "Ujkyytr Prime"
+                }
+            }
+        },
+        {
+            "id": "agorim",
+            "name": "Agorim",
+            "number": "121",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_121_ef9f7b16982d_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon",
+                "leader"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 7,
+            "text": "While Agorim is in the center of your battleline, friendly creatures get +5 power.\n",
+            "locale": {
+                "en": {
+                    "name": "Agorim"
+                }
+            }
+        },
+        {
+            "id": "ashwing-protocol",
+            "name": "Ashwing Protocol",
+            "number": "122",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_122_e9f4bbc10648_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: If you are overwhelmed, draw 3 cards.\n",
+            "locale": {
+                "en": {
+                    "name": "Ashwing Protocol"
+                }
+            }
+        },
+        {
+            "id": "chlorodoze-vapor",
+            "name": "Chlorodoze Vapor",
+            "number": "123",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_123_264b936f4501_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Deal 3 to each creature. For each creature destroyed this way, exhaust a creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Chlorodoze Vapor"
+                }
+            }
+        },
+        {
+            "id": "cyn-dynasty",
+            "name": "Cyn Dynasty",
+            "number": "124",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_124_a7e67b9a2967_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "power"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Keys cost +2.\nAfter your opponent forges a key, gain 2, draw 4 cards, and destroy Cyn Dynasty.\n",
+            "locale": {
+                "en": {
+                    "name": "Cyn Dynasty"
+                }
+            }
+        },
+        {
+            "id": "dray-conis",
+            "name": "Dray Conis",
+            "number": "125",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_125_b2d19691951d_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 5,
+            "text": "Entrench.\nAt the start of your turn, if Dray Conis is exhausted, destroy each creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Dray Conis"
+                }
+            }
+        },
+        {
+            "id": "gilded-burden",
+            "name": "Gilded Burden",
+            "number": "126",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_126_cd8e28f817b5_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: For each forged key your opponent has, an enemy creature captures 2 from its own side.\n",
+            "locale": {
+                "en": {
+                    "name": "Gilded Burden"
+                }
+            }
+        },
+        {
+            "id": "hoardgouge",
+            "name": "Hoardgouge",
+            "number": "127",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_127_e087c0bb85ee_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "upgrade",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "This creature gains, “After Fight/After Reap: If you are overwhelmed, gain 1 and deal 3 to an enemy creature.”\n",
+            "locale": {
+                "en": {
+                    "name": "Hoardgouge"
+                }
+            }
+        },
+        {
+            "id": "kulsha",
+            "name": "Kulsha",
+            "number": "128",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_128_c5974a21655f_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "gigantic creature art",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "",
+            "locale": {
+                "en": {
+                    "name": "Kulsha"
+                }
+            }
+        },
+        {
+            "id": "kulsha",
+            "name": "Kulsha",
+            "number": "128",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_128_cbf554b78623_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "gigantic creature base",
+            "rarity": "Special",
+            "amber": 0,
+            "armor": null,
+            "power": 15,
+            "text": "(Play only with the other half of Kulsha.)\nYour opponent’s keys cost +2 for each forged key they have. \nAfter Fight/After Reap: Exhaust up to 3 creatures.\n",
+            "locale": {
+                "en": {
+                    "name": "Kulsha"
+                }
+            }
+        },
+        {
+            "id": "nizak-the-forgotten",
+            "name": "Nizak, The Forgotten",
+            "number": "129",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_129_56d75ce3cc70_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon",
+                "psion"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 6,
+            "text": "While fighting, Nizak, The Forgotten gains invulnerable. (It cannot be destroyed or dealt damage.)\nAfter an enemy creature is destroyed fighting Nizak, The Forgotten, return that creature to its owner’s hand.\n",
+            "locale": {
+                "en": {
+                    "name": "Nizak, The Forgotten"
+                }
+            }
+        },
+        {
+            "id": "prime-authority",
+            "name": "Prime Authority",
+            "number": "130",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_130_d3736111fd9e_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Ready or exhaust a creature. If there are more exhausted friendly creatures than exhausted enemy creatures, gain 2.\n",
+            "locale": {
+                "en": {
+                    "name": "Prime Authority"
+                }
+            }
+        },
+        {
+            "id": "seda-the-sleeper",
+            "name": "Seda the Sleeper",
+            "number": "131",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_131_5d560a0101c0_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 6,
+            "text": "While Seda the Sleeper is exhausted and on a flank, it gains invulnerable. \nAfter you ready Seda the Sleeper, you may deal 2 to it. If you do, exhaust it.\nPlay: Capture 6.\n",
+            "locale": {
+                "en": {
+                    "name": "Seda the Sleeper"
+                }
+            }
+        },
+        {
+            "id": "sleepwither",
+            "name": "Sleepwither",
+            "number": "132",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_132_d7a50eede3e9_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Enhance .\nPlay: Destroy an Ouboros creature. If you do, gain 2.\n",
+            "locale": {
+                "en": {
+                    "name": "Sleepwither"
+                }
+            }
+        },
+        {
+            "id": "spherular-gem",
+            "name": "Spherular Gem",
+            "number": "133",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_133_947db87a902c_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "treasure"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Action: Destroy Spherular Gem. If you do, gain  equal to the number of forged keys.\n",
+            "locale": {
+                "en": {
+                    "name": "Spherular Gem"
+                }
+            }
+        },
+        {
+            "id": "tranquil-reiner",
+            "name": "Tranquil Reiner",
+            "number": "134",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_134_a3801948fb73_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 6,
+            "text": "Tranquil Reiner does not ready during your “ready cards” step.\nAfter Fight/After Reap: Ready an exhausted non-Dragon creature. If you do, gain 3.\n",
+            "locale": {
+                "en": {
+                    "name": "Tranquil Reiner"
+                }
+            }
+        },
+        {
+            "id": "treok-the-wise",
+            "name": "Treok, The Wise",
+            "number": "135",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_135_715bbf48ee4f_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon",
+                "sage"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 6,
+            "text": "After Reap: Choose a creature. Until the start of your next turn, that creature gains invulnerable. (It cannot be destroyed or dealt damage.)\n",
+            "locale": {
+                "en": {
+                    "name": "Treok, The Wise"
+                }
+            }
+        },
+        {
+            "id": "bastionclaw",
+            "name": "Bastionclaw",
+            "number": "136",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_136_ed65bd8e3d02_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 1,
+            "power": 4,
+            "text": "Your keys cost –1 for each forged key your opponent has.\n",
+            "locale": {
+                "en": {
+                    "name": "Bastionclaw"
+                }
+            }
+        },
+        {
+            "id": "caspart",
+            "name": "Caspart",
+            "number": "137",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_137_604de4641871_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Entrench.\nAt the end of your turn, if Caspart is exhausted, exhaust 2 other creatures.\n",
+            "locale": {
+                "en": {
+                    "name": "Caspart"
+                }
+            }
+        },
+        {
+            "id": "dragons",
+            "name": "DRAGONS!!!",
+            "number": "138",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_138_1410c5ba34d5_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Shuffle any number of Dragon creatures from your discard pile into your deck.\n",
+            "locale": {
+                "en": {
+                    "name": "DRAGONS!!!"
+                }
+            }
+        },
+        {
+            "id": "doze-wing",
+            "name": "Doze Wing",
+            "number": "139",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_139_ce2e85b71cf6_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Exhaust each non-Dragon creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Doze Wing"
+                }
+            }
+        },
+        {
+            "id": "glittering-horde",
+            "name": "Glittering Horde",
+            "number": "140",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_140_74b8816777a3_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: For each color represented among forged keys, steal 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Glittering Horde"
+                }
+            }
+        },
+        {
+            "id": "ignitus",
+            "name": "Ignitus",
+            "number": "141",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_141_8dec2df120c6_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 1,
+            "power": 4,
+            "text": "Ignitus gains splash-attack X, where X is the number of exhausted creatures.\n",
+            "locale": {
+                "en": {
+                    "name": "Ignitus"
+                }
+            }
+        },
+        {
+            "id": "noxious-ionox",
+            "name": "Noxious Ionox",
+            "number": "142",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_142_04f306267c69_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "Entrench.\nAt the start of your turn, if Noxious Ionox is exhausted, destroy an enemy creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Noxious Ionox"
+                }
+            }
+        },
+        {
+            "id": "parasitic-charge",
+            "name": "Parasitic Charge",
+            "number": "143",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_143_e5d94619dbb7_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Forge a key at +8 current cost, reduced by 1 for each  in your opponent’s pool. If you do, purge Parasitic Charge.\n",
+            "locale": {
+                "en": {
+                    "name": "Parasitic Charge"
+                }
+            }
+        },
+        {
+            "id": "thermal-depletion",
+            "name": "Thermal Depletion",
+            "number": "144",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_144_315a605f47a3_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Until the start of your next turn, creatures cannot ready.\n",
+            "locale": {
+                "en": {
+                    "name": "Thermal Depletion"
+                }
+            }
+        },
+        {
+            "id": "timequake",
+            "name": "Timequake",
+            "number": "145",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_145_e1d09bea11e5_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Shuffle each friendly card in play into your deck. Draw a card for each card shuffled into your deck this way.\n",
+            "locale": {
+                "en": {
+                    "name": "Timequake"
+                }
+            }
+        },
+        {
+            "id": "voltash-coilbreath",
+            "name": "Voltash Coilbreath",
+            "number": "146",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_146_9b2fe26e4e17_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 5,
+            "text": "After Reap: Use an enemy artifact as if it were yours. Put that artifact on the bottom of its owner’s deck.\n",
+            "locale": {
+                "en": {
+                    "name": "Voltash Coilbreath"
+                }
+            }
+        },
+        {
+            "id": "zartoo-the-swift",
+            "name": "Zartoo, the Swift",
+            "number": "147",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_147_452ae85dc064_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 5,
+            "text": "After Reap: Ready and use a friendly non-Dragon creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Zartoo, the Swift"
+                }
+            }
+        },
+        {
+            "id": "arcane-relief",
+            "name": "Arcane Relief",
+            "number": "148",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_148_dcc21b70fd72_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Choose a friendly exhausted creature. Ready and use that creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Arcane Relief"
+                }
+            }
+        },
+        {
+            "id": "clawcloak-swipe",
+            "name": "Clawcloak Swipe",
+            "number": "149",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_149_9ec6735f562e_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: If you are overwhelmed, choose a friendly creature. For each creature your opponent controls in excess of you, the chosen creature captures 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Clawcloak Swipe"
+                }
+            }
+        },
+        {
+            "id": "cosmicrux",
+            "name": "Cosmicrux",
+            "number": "150",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_150_5781e70fbcae_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 6,
+            "text": "After a player readies a creature, deal 1 to it.\n",
+            "locale": {
+                "en": {
+                    "name": "Cosmicrux"
+                }
+            }
+        },
+        {
+            "id": "daring-delt",
+            "name": "Daring Delt",
+            "number": "151",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_151_628c0f3bdcce_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 1,
+            "power": 4,
+            "text": "After Fight: Gain 1 for each ready friendly creature of the active house.\n",
+            "locale": {
+                "en": {
+                    "name": "Daring Delt"
+                }
+            }
+        },
+        {
+            "id": "hoarding-the-goods",
+            "name": "Hoarding the Goods",
+            "number": "152",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_152_4d23dba16eaa_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Each friendly exhausted creature captures 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Hoarding the Goods"
+                }
+            }
+        },
+        {
+            "id": "ley-lines",
+            "name": "Ley Lines",
+            "number": "153",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_153_ae3d3962910a_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: If you are overwhelmed, exhaust each creature. Otherwise, exhaust a creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Ley Lines"
+                }
+            }
+        },
+        {
+            "id": "pip-the-pilferer",
+            "name": "Pip the Pilferer",
+            "number": "154",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_154_579f209da6df_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Play: If your opponent has more forged keys than you, steal 2. Otherwise, capture 2.\n",
+            "locale": {
+                "en": {
+                    "name": "Pip the Pilferer"
+                }
+            }
+        },
+        {
+            "id": "ria-bevy-gress",
+            "name": "Ria Bevy Gress",
+            "number": "155",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_155_0f8fc31c88ea_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 2,
+            "power": 2,
+            "text": "Enhance .\nAfter Fight/After Reap: If you are overwhelmed, capture 1 for each +1 power counter on friendly creatures. Otherwise, capture 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Ria Bevy Gress"
+                }
+            }
+        },
+        {
+            "id": "shadow-gloomcoil",
+            "name": "Shadow Gloomcoil",
+            "number": "156",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_156_4035d48321a1_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [
+                "treachery",
+                "versatile"
+            ],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "Treachery. Versatile.\nAfter a friendly creature is used, deal 1 to each friendly creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Shadow Gloomcoil"
+                }
+            }
+        },
+        {
+            "id": "snapper-dyn",
+            "name": "Snapper Dyn",
+            "number": "157",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_157_8a60e0c7e031_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Entrench.\nAt the end of your turn, if Snapper Dyn is exhausted, deal 1 to an enemy creature for each  in your opponent’s pool.\n",
+            "locale": {
+                "en": {
+                    "name": "Snapper Dyn"
+                }
+            }
+        },
+        {
+            "id": "sparkscheme",
+            "name": "Sparkscheme",
+            "number": "158",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_158_2834e0b3e8e7_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [
+                "dragon",
+                "cyborg"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 2,
+            "power": 3,
+            "text": "Entrench.\nAfter an enemy creature reaps, if Sparkscheme is exhausted, draw a card.\n",
+            "locale": {
+                "en": {
+                    "name": "Sparkscheme"
+                }
+            }
+        },
+        {
+            "id": "vanguard-wounds",
+            "name": "Vanguard Wounds",
+            "number": "159",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_159_a3ffbc10043e_en.png",
+            "expansion": 928,
+            "house": "ouboros",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Deal 3 to a creature. If this damage destroys that creature, draw a card.\n",
+            "locale": {
+                "en": {
+                    "name": "Vanguard Wounds"
+                }
+            }
+        },
+        {
+            "id": "boosted-b4-rry",
+            "name": "Boosted B4-RRY",
+            "number": "160",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_160_49980c56307d_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [
+                "robot"
+            ],
+            "type": "gigantic creature base",
+            "rarity": "Special",
+            "amber": 0,
+            "armor": null,
+            "power": 7,
+            "text": "(Play only with the other half of Boosted B4-RRY.)\nPlay/After Fight/After Reap: Choose one:\nTake control of an enemy artifact. While under your control, it belongs to house Shadows (instead of its original house).\nPlay a random card from your opponent’s archives as if it were yours.\n",
+            "locale": {
+                "en": {
+                    "name": "Boosted B4-RRY"
+                }
+            }
+        },
+        {
+            "id": "boosted-b4-rry",
+            "name": "Boosted B4-RRY",
+            "number": "160",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_160_67897e890546_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "gigantic creature art",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "",
+            "locale": {
+                "en": {
+                    "name": "Boosted B4-RRY"
+                }
+            }
+        },
+        {
+            "id": "bulleteye",
+            "name": "Bulleteye",
+            "number": "161",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_161_b2748bc619b2_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "elf",
+                "thief"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Elusive. (The first time this creature is attacked each turn, no damage is dealt.)\nAfter Reap: Destroy a flank creature.",
+            "locale": {
+                "en": {
+                    "name": "Bulleteye"
+                }
+            }
+        },
+        {
+            "id": "cheval-de-frise",
+            "name": "Cheval de Frise",
+            "number": "162",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_162_3e2953f69e7f_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [
+                "item"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Enhance .\nEach friendly Shadows creature gains hazardous 2.\n",
+            "locale": {
+                "en": {
+                    "name": "Cheval de Frise"
+                }
+            }
+        },
+        {
+            "id": "easy-marks",
+            "name": "Easy Marks",
+            "number": "163",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_163_9ec158e40490_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Exalt each damaged enemy creature.",
+            "locale": {
+                "en": {
+                    "name": "Easy Marks"
+                }
+            }
+        },
+        {
+            "id": "finishing-blow",
+            "name": "Finishing Blow",
+            "number": "164",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_164_f436a5672a51_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Destroy a damaged creature. If you do, steal 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Finishing Blow"
+                }
+            }
+        },
+        {
+            "id": "honorable-abagnale",
+            "name": "Honorable Abagnale",
+            "number": "165",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_165_a52b46ee6548_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "elf",
+                "politician"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Elusive.\nYou may spend up to 3 from your opponent’s pool when forging keys.\n",
+            "locale": {
+                "en": {
+                    "name": "Honorable Abagnale"
+                }
+            }
+        },
+        {
+            "id": "keep-the-change",
+            "name": "Keep the Change",
+            "number": "166",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_166_84692d633874_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Pay your opponent up to 6. For each  paid this way, draw a card.\n",
+            "locale": {
+                "en": {
+                    "name": "Keep the Change"
+                }
+            }
+        },
+        {
+            "id": "luis-compère",
+            "name": "Luis Compère",
+            "number": "167",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_167_03b2dc801255_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "elf",
+                "thief"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "Elusive.\nAt the end of your opponent's turn, if they drew 2 or more cards during their “draw cards” step, steal 2.\n",
+            "locale": {
+                "en": {
+                    "name": "Luis Compère"
+                }
+            }
+        },
+        {
+            "id": "ransom",
+            "name": "Ransom",
+            "number": "168",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_168_47c2e04de4c3_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "upgrade",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "This creature cannot be used and gains, “At the start of your turn, you may pay your opponent 2. If you do, destroy Ransom.”\n",
+            "locale": {
+                "en": {
+                    "name": "Ransom"
+                }
+            }
+        },
+        {
+            "id": "rein-and-cycle",
+            "name": "Rein and Cycle",
+            "number": "169",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_169_868803a37d32_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Pay your opponent 1. If you do, take control of an enemy creature or artifact.\n",
+            "locale": {
+                "en": {
+                    "name": "Rein and Cycle"
+                }
+            }
+        },
+        {
+            "id": "rigged-lottery",
+            "name": "Rigged Lottery",
+            "number": "170",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_170_5efb4d2886c0_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Each player discards the top 5 cards of their deck. For each Shadows card discarded, its owner gains 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Rigged Lottery"
+                }
+            }
+        },
+        {
+            "id": "routine-job",
+            "name": "Routine Job",
+            "number": "171",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_171_a435c1aac003_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Steal 1. Then, steal 1 for each copy of Routine Job in your discard pile.",
+            "locale": {
+                "en": {
+                    "name": "Routine Job"
+                }
+            }
+        },
+        {
+            "id": "selwyn-the-fence",
+            "name": "Selwyn the Fence",
+            "number": "172",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_172_2509535828c3_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [
+                "elf",
+                "thief"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "After Fight/After Reap: Move 1 from a friendly card to your pool.",
+            "locale": {
+                "en": {
+                    "name": "Selwyn the Fence"
+                }
+            }
+        },
+        {
+            "id": "sneklifter",
+            "name": "Sneklifter",
+            "number": "173",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_173_ea2b64821108_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [
+                "elf",
+                "thief"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Play: Take control of an enemy artifact. While under your control, if it does not belong to one of your three houses, it belongs to house Shadows.",
+            "locale": {
+                "en": {
+                    "name": "Sneklifter"
+                }
+            }
+        },
+        {
+            "id": "widespread-corruption",
+            "name": "Widespread Corruption",
+            "number": "174",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_174_519926249baf_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [
+                "power"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "After a player gains  by reaping, a creature they do not control captures that .\n",
+            "locale": {
+                "en": {
+                    "name": "Widespread Corruption"
+                }
+            }
+        },
+        {
+            "id": "blank-check",
+            "name": "Blank Check",
+            "number": "175",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_175_a37cd8c6508d_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Each player shuffles their archives and discard pile into their deck. Discard the top 5 cards of your opponent’s deck. Play the top card of their deck as if it were yours.\n",
+            "locale": {
+                "en": {
+                    "name": "Blank Check"
+                }
+            }
+        },
+        {
+            "id": "blatant-thievery",
+            "name": "Blatant Thievery",
+            "number": "176",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_176_496144bf6c82_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Enrage an enemy creature. Move all  from that creature to your pool.\n",
+            "locale": {
+                "en": {
+                    "name": "Blatant Thievery"
+                }
+            }
+        },
+        {
+            "id": "chain-gang",
+            "name": "Chain Gang",
+            "number": "177",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_177_11fe9cb17631_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [
+                "elf",
+                "thief"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "After you play Subtle Chain, ready Chain Gang. \nAction: Steal 1. Shuffle a Subtle Chain from your discard pile into your deck.\n",
+            "locale": {
+                "en": {
+                    "name": "Chain Gang"
+                }
+            }
+        },
+        {
+            "id": "counterfeit-controversy",
+            "name": "Counterfeit Controversy",
+            "number": "178",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_178_c597694013f9_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: If your opponent has more  than you, they lose half of their  (rounding down the loss).\n",
+            "locale": {
+                "en": {
+                    "name": "Counterfeit Controversy"
+                }
+            }
+        },
+        {
+            "id": "ditch-the-loot",
+            "name": "Ditch the Loot",
+            "number": "179",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_179_54ad6821ec11_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Enhance .\nPlay: Move all  from one creature to another creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Ditch the Loot"
+                }
+            }
+        },
+        {
+            "id": "ox-sarbane",
+            "name": "Ox Sarbane",
+            "number": "180",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_180_eaa317b0de71_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [
+                "elf",
+                "politician"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Each enemy creature gains, “After Fight/After Reap: Exhaust each friendly creature that shares a house with this creature.”\n",
+            "locale": {
+                "en": {
+                    "name": "Ox Sarbane"
+                }
+            }
+        },
+        {
+            "id": "perplexing-sophistry",
+            "name": "Perplexing Sophistry",
+            "number": "181",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_181_9d88929846d8_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: If you have more  than your opponent, they discard a random card from their hand and you draw a card.",
+            "locale": {
+                "en": {
+                    "name": "Perplexing Sophistry"
+                }
+            }
+        },
+        {
+            "id": "reckless-rizzo",
+            "name": "Reckless Rizzo",
+            "number": "182",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_182_89d39b7724d5_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "elf",
+                "thief"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 1,
+            "text": "Elusive. (The first time this creature is attacked each turn, no damage is dealt.)\nAction: Steal 2. Until the start of your next turn, Reckless Rizzo loses elusive.",
+            "locale": {
+                "en": {
+                    "name": "Reckless Rizzo"
+                }
+            }
+        },
+        {
+            "id": "subtle-chain",
+            "name": "Subtle Chain",
+            "number": "183",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_183_8b053c2c8aa6_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Your opponent discards a random card from their hand. \n",
+            "locale": {
+                "en": {
+                    "name": "Subtle Chain"
+                }
+            }
+        },
+        {
+            "id": "the-watch",
+            "name": "The Watch",
+            "number": "184",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_184_35b3374fb0e1_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "elf",
+                "cyborg"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Elusive. Entrench.\nWhile The Watch is exhausted, your  cannot be stolen.\n",
+            "locale": {
+                "en": {
+                    "name": "The Watch"
+                }
+            }
+        },
+        {
+            "id": "too-much-to-protect",
+            "name": "Too Much to Protect",
+            "number": "185",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_185_178e4843c304_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Steal all but 6 of your\nopponent’s .\n",
+            "locale": {
+                "en": {
+                    "name": "Too Much to Protect"
+                }
+            }
+        },
+        {
+            "id": "vaelra-whisperfang",
+            "name": "Vaelra Whisperfang",
+            "number": "186",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_186_33223b6330d3_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [
+                "elf",
+                "thief"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "After your opponent plays a creature, deal 2 to it.\n",
+            "locale": {
+                "en": {
+                    "name": "Vaelra Whisperfang"
+                }
+            }
+        },
+        {
+            "id": "victor-flux",
+            "name": "Victor Flux",
+            "number": "187",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_187_344d664bd341_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [
+                "human",
+                "scientist"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "After Reap: Purge a card from your discard pile. If you do, until the start of your next turn, your opponent cannot play cards of the purged card’s type.\n",
+            "locale": {
+                "en": {
+                    "name": "Victor Flux"
+                }
+            }
+        },
+        {
+            "id": "achromatic-basilisk",
+            "name": "Achromatic Basilisk",
+            "number": "188",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_188_842763412b46_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [
+                "skirmish"
+            ],
+            "traits": [
+                "beast"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Skirmish.\nAfter Fight: Exhaust an enemy creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Achromatic Basilisk"
+                }
+            }
+        },
+        {
+            "id": "caught-you-napping",
+            "name": "Caught You Napping",
+            "number": "189",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_189_3529d02c695a_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: If you are overwhelmed, exhaust an enemy creature. Steal 1 for each exhausted enemy creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Caught You Napping"
+                }
+            }
+        },
+        {
+            "id": "clay-more",
+            "name": "Clay More",
+            "number": "190",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_190_eab1d298b9dc_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [
+                "elf",
+                "soldier"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 1,
+            "text": "Enhance .\nDestroyed: Deal 2 to each enemy flank creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Clay More"
+                }
+            }
+        },
+        {
+            "id": "colt-sleven",
+            "name": "Colt Sleven",
+            "number": "191",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_191_5dd48e97eecf_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [
+                "elf",
+                "thief"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Enhance .\nPlay: For each +1 power counter on each creature, deal 1 to a creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Colt Sleven"
+                }
+            }
+        },
+        {
+            "id": "fallguy",
+            "name": "Fallguy",
+            "number": "192",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_192_67159b61a030_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "elf"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Taunt.\nDestroyed: Steal 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Fallguy"
+                }
+            }
+        },
+        {
+            "id": "grammy-taps",
+            "name": "Grammy Taps",
+            "number": "193",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_193_b8611631dec2_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "elf",
+                "thief"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Elusive. Entrench.\nWhile Grammy Taps is exhausted, each of its neighbors gains elusive.\n",
+            "locale": {
+                "en": {
+                    "name": "Grammy Taps"
+                }
+            }
+        },
+        {
+            "id": "life-for-a-life",
+            "name": "Life for a Life",
+            "number": "194",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_194_63568eec46ea_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Destroy a friendly creature. If you do, deal 6 to a creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Life for a Life"
+                }
+            }
+        },
+        {
+            "id": "nightmare-urchin",
+            "name": "Nightmare Urchin",
+            "number": "195",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_195_a6824ee26b31_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [
+                "elf",
+                "thief"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "After Reap: If you are overwhelmed, steal 2. Otherwise, steal 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Nightmare Urchin"
+                }
+            }
+        },
+        {
+            "id": "pincher-malloy",
+            "name": "Pincher Malloy",
+            "number": "196",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_196_e41af5027cab_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [
+                "elf",
+                "thief"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Play: If your opponent has more  than you, steal 2.\n",
+            "locale": {
+                "en": {
+                    "name": "Pincher Malloy"
+                }
+            }
+        },
+        {
+            "id": "pyrotechnic-flash",
+            "name": "Pyrotechnic Flash",
+            "number": "197",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_197_450ecec887ce_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Deal 2 to a creature, with 1 splash. If this damage destroys 2 or more creatures, steal 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Pyrotechnic Flash"
+                }
+            }
+        },
+        {
+            "id": "take-a-break",
+            "name": "Take a Break",
+            "number": "198",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_198_481de67e3267_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Exhaust the least powerful enemy creature and each of its neighbors.\n",
+            "locale": {
+                "en": {
+                    "name": "Take a Break"
+                }
+            }
+        },
+        {
+            "id": "throwing-stars",
+            "name": "Throwing Stars",
+            "number": "199",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_199_6cffb232f681_en.png",
+            "expansion": 928,
+            "house": "shadows",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Deal 1 to up to three creatures. Gain 1 for each creature destroyed this way.",
+            "locale": {
+                "en": {
+                    "name": "Throwing Stars"
+                }
+            }
+        },
+        {
+            "id": "aviatrix-virtuosa",
+            "name": "Aviatrix Virtuosa",
+            "number": "200",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_200_54d9e0fd8302_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [
+                "deploy"
+            ],
+            "traits": [
+                "alien",
+                "halyard"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Deploy.\nPlay: Exhaust each non-flank creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Aviatrix Virtuosa"
+                }
+            }
+        },
+        {
+            "id": "cloudburst-command",
+            "name": "Cloudburst Command",
+            "number": "201",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_201_a4ca9939fe91_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "location"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Your opponent’s keys cost +1 for each Skyborn creature on a flank.\n",
+            "locale": {
+                "en": {
+                    "name": "Cloudburst Command"
+                }
+            }
+        },
+        {
+            "id": "flip-stallard",
+            "name": "Flip Stallard",
+            "number": "202",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_202_2fd79cd49bfe_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "raptrix"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "Each enemy creature loses each of its destroyed abilities.\n",
+            "locale": {
+                "en": {
+                    "name": "Flip Stallard"
+                }
+            }
+        },
+        {
+            "id": "forged-bolt",
+            "name": "Forged Bolt",
+            "number": "203",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_203_006927a4ba12_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Deal 1 to each creature for each forged key.\n",
+            "locale": {
+                "en": {
+                    "name": "Forged Bolt"
+                }
+            }
+        },
+        {
+            "id": "han-peregrine",
+            "name": "Han Peregrine",
+            "number": "204",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_204_d4f9b4d7a5db_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "dinosaur",
+                "stormkin"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 6,
+            "text": "After Fight/After Reap: You may exalt Han Peregrine. If you do, fully heal a damaged creature and move it to either flank of its controller's battleline.\n",
+            "locale": {
+                "en": {
+                    "name": "Han Peregrine"
+                }
+            }
+        },
+        {
+            "id": "long-way-home",
+            "name": "Long Way Home",
+            "number": "205",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_205_07fa12c39022_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Put each friendly Skyborn creature into its owner’s archives.\n",
+            "locale": {
+                "en": {
+                    "name": "Long Way Home"
+                }
+            }
+        },
+        {
+            "id": "malforge",
+            "name": "Malforge",
+            "number": "206",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_206_7927e522d310_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [
+                "treachery",
+                "versatile"
+            ],
+            "traits": [
+                "beast",
+                "cyborg"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 5,
+            "text": "Treachery. Versatile.\nYou cannot forge keys.\nAt the end of your turn, deal 2 to Malforge.\n",
+            "locale": {
+                "en": {
+                    "name": "Malforge"
+                }
+            }
+        },
+        {
+            "id": "maqui-expedition",
+            "name": "Maqui Expedition",
+            "number": "207",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_207_a10ae8a3d2d3_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Gain control of an enemy flank creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Maqui Expedition"
+                }
+            }
+        },
+        {
+            "id": "razor-s-gambit",
+            "name": "Razor’s Gambit",
+            "number": "208",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_208_0885e96e079c_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "item"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Enhance  . (These icons have already been added to cards in your deck.)\nAction: Ready and fight with a friendly Skyborn creature. If your blue key is forged, repeat the preceding effect.\n",
+            "locale": {
+                "en": {
+                    "name": "Razor’s Gambit"
+                }
+            }
+        },
+        {
+            "id": "recreational-jettison",
+            "name": "Recreational Jettison",
+            "number": "209",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_209_6f8909d737fd_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Discard a card. Resolve its bonus icons as if you had played it. If a yellow key is forged, repeat the preceding effect.\n",
+            "locale": {
+                "en": {
+                    "name": "Recreational Jettison"
+                }
+            }
+        },
+        {
+            "id": "refined-adhesive",
+            "name": "Refined Adhesive",
+            "number": "210",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_210_8172515c068f_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "upgrade",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Each time a card would be discarded from a player's hand, reveal the card and put it facedown under this creature instead.\n",
+            "locale": {
+                "en": {
+                    "name": "Refined Adhesive"
+                }
+            }
+        },
+        {
+            "id": "universal-welcome",
+            "name": "Universal Welcome",
+            "number": "211",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_211_571d4bbcbbf9_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Take control of the enemy creature in the center of your opponent’s battleline.\n",
+            "locale": {
+                "en": {
+                    "name": "Universal Welcome"
+                }
+            }
+        },
+        {
+            "id": "viscount-of-aerys",
+            "name": "Viscount of Aerys",
+            "number": "212",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_212_efd4295b8fc6_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "adagion",
+                "artisan"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "While your yellow key is forged, each enemy creature enters play stunned. \nPlay: If your yellow key is forged, stun each enemy creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Viscount of Aerys"
+                }
+            }
+        },
+        {
+            "id": "zomok",
+            "name": "Zomok",
+            "number": "213",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_213_02de64b9d6a8_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "gigantic creature art",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "",
+            "locale": {
+                "en": {
+                    "name": "Zomok"
+                }
+            }
+        },
+        {
+            "id": "zomok",
+            "name": "Zomok",
+            "number": "213",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_213_c95fcac8441d_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "beast",
+                "cyborg"
+            ],
+            "type": "gigantic creature base",
+            "rarity": "Special",
+            "amber": 0,
+            "armor": null,
+            "power": 16,
+            "text": "(Play only with the other half of Zomok.)\nWhile Zomok is attacking, ignore taunt, elusive, poison, hazardous, and invulnerable.\nAfter Fight: Deal 2 to a creature for each forged key.\n",
+            "locale": {
+                "en": {
+                    "name": "Zomok"
+                }
+            }
+        },
+        {
+            "id": "æmber-airhart",
+            "name": "Æmber Airhart",
+            "number": "214",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_214_dca690b04229_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "getrookya",
+                "pilot"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": 1,
+            "power": 2,
+            "text": "After Fight/After Reap: Shuffle Æmber Airhart into its owner’s deck.\n",
+            "locale": {
+                "en": {
+                    "name": "Æmber Airhart"
+                }
+            }
+        },
+        {
+            "id": "cabochon",
+            "name": "Cabochon",
+            "number": "215",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_215_27bb4ff395af_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "halyard",
+                "cyborg"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Entrench.\nAt the start of your turn, if Cabochon is exhausted, gain 1 for each friendly Skyborn flank creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Cabochon"
+                }
+            }
+        },
+        {
+            "id": "edge-of-the-world",
+            "name": "Edge of the World",
+            "number": "216",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_216_a92584eb83f9_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Move a creature to a flank of its controller’s battleline. Steal 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Edge of the World"
+                }
+            }
+        },
+        {
+            "id": "embered-purse",
+            "name": "Embered Purse",
+            "number": "217",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_217_af158660676d_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Steal 1 for each ready Skyborn creature in play.\n",
+            "locale": {
+                "en": {
+                    "name": "Embered Purse"
+                }
+            }
+        },
+        {
+            "id": "gilt--em-good",
+            "name": "Gilt ’Em Good",
+            "number": "218",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_218_6ec9a0f36cc0_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Each friendly flank creature captures 1. If a yellow key is forged, repeat the preceding effect.\n",
+            "locale": {
+                "en": {
+                    "name": "Gilt ’Em Good"
+                }
+            }
+        },
+        {
+            "id": "hannibal-s-mark",
+            "name": "Hannibal’s Mark",
+            "number": "219",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_219_9966eb8fe23f_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Take control of an enemy flank creature and give it three +1 power counters. While under your control, it belongs to house Skyborn. (Instead of its original house.)\n",
+            "locale": {
+                "en": {
+                    "name": "Hannibal’s Mark"
+                }
+            }
+        },
+        {
+            "id": "navigator-ketarr",
+            "name": "Navigator Ketarr",
+            "number": "220",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_220_68760879e3d5_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "j'reen"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "After Reap: If Navigator Ketarr is on a flank, draw 2 cards and archive a card.\n",
+            "locale": {
+                "en": {
+                    "name": "Navigator Ketarr"
+                }
+            }
+        },
+        {
+            "id": "pirate-champion",
+            "name": "Pirate Champion",
+            "number": "221",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_221_e01ccd3b42f8_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "stormkin"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 6,
+            "text": "Taunt.\nAfter Fight: You may move Pirate Champion to a flank.\n",
+            "locale": {
+                "en": {
+                    "name": "Pirate Champion"
+                }
+            }
+        },
+        {
+            "id": "red-skies",
+            "name": "Red Skies",
+            "number": "222",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_222_a064f409c9ad_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Move a friendly Skyborn creature to a flank and ready it. If a red key is forged, repeat the preceding effect.\n",
+            "locale": {
+                "en": {
+                    "name": "Red Skies"
+                }
+            }
+        },
+        {
+            "id": "silver-linings",
+            "name": "Silver Linings",
+            "number": "223",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_223_2c84a25a4d74_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Gain 1 for each house represented among friendly flank creatures.\n",
+            "locale": {
+                "en": {
+                    "name": "Silver Linings"
+                }
+            }
+        },
+        {
+            "id": "sir-lorcas",
+            "name": "Sir Lorcas",
+            "number": "224",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_224_6dc8c1f4d73d_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "human",
+                "knight"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 1,
+            "power": 5,
+            "text": "If your red key is forged, Sir Lorcas gains skirmish. \nIf your yellow key is forged, Sir Lorcas gains elusive. \nIf your blue key is forged, Sir Lorcas gains taunt.\n",
+            "locale": {
+                "en": {
+                    "name": "Sir Lorcas"
+                }
+            }
+        },
+        {
+            "id": "tur-bo-prop",
+            "name": "Tur-bo-prop",
+            "number": "225",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_225_b79c00d40c96_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "robot",
+                "halyard"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 1,
+            "power": 4,
+            "text": "After Reap: If a blue key is forged, draw 2 cards. Otherwise, draw a card.\n",
+            "locale": {
+                "en": {
+                    "name": "Tur-bo-prop"
+                }
+            }
+        },
+        {
+            "id": "ty-lourd",
+            "name": "Ty Lourd",
+            "number": "226",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_226_630600e2d689_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "human",
+                "halyard"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "After your opponent discards a card from their hand, gain 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Ty Lourd"
+                }
+            }
+        },
+        {
+            "id": "against-all-flags",
+            "name": "Against All Flags",
+            "number": "227",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_227_59834adc27d1_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Steal 2 if any flank creature shares a house with another flank creature. Otherwise, steal 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Against All Flags"
+                }
+            }
+        },
+        {
+            "id": "barrel-roll",
+            "name": "Barrel Roll",
+            "number": "228",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_228_fae6cfc8ba39_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Move a creature to a flank of its controller’s battleline and exhaust it.\n",
+            "locale": {
+                "en": {
+                    "name": "Barrel Roll"
+                }
+            }
+        },
+        {
+            "id": "bloodwing",
+            "name": "Bloodwing",
+            "number": "229",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_229_203416ce186f_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "beast"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Enhance .\nAfter Fight/After Reap: Put a +1 power counter on each friendly flank creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Bloodwing"
+                }
+            }
+        },
+        {
+            "id": "cold-ropes",
+            "name": "Cold Ropes",
+            "number": "230",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_230_6b96c68f9c68_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: If you are overwhelmed, put an enemy creature on the bottom of its owner’s deck. Otherwise, move an enemy creature to a flank of its controller’s battleline and exhaust it.\n",
+            "locale": {
+                "en": {
+                    "name": "Cold Ropes"
+                }
+            }
+        },
+        {
+            "id": "deep-blue-bryn",
+            "name": "Deep Blue Bryn",
+            "number": "231",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_231_59e6b8ac4022_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "human",
+                "cyborg"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "After Fight: Steal 1. If a blue key is forged, ward Deep Blue Bryn.\n",
+            "locale": {
+                "en": {
+                    "name": "Deep Blue Bryn"
+                }
+            }
+        },
+        {
+            "id": "jeen-peary",
+            "name": "Jeen Peary",
+            "number": "232",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_232_24a0363cb238_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "cyborg",
+                "stormkin"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "After Reap: If Jeen Peary is on a flank, steal 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Jeen Peary"
+                }
+            }
+        },
+        {
+            "id": "jump-start",
+            "name": "Jump Start",
+            "number": "233",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_233_9cc0aa7e7661_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Ready and use a friendly flank creature. If you are overwhelmed, repeat the preceding effect.\n",
+            "locale": {
+                "en": {
+                    "name": "Jump Start"
+                }
+            }
+        },
+        {
+            "id": "leftenant-chars",
+            "name": "Leftenant Chars",
+            "number": "234",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_234_21833dde1e0c_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "human",
+                "stormkin"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 5,
+            "text": "After Fight: If you are overwhelmed, steal 2. Otherwise capture 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Leftenant Chars"
+                }
+            }
+        },
+        {
+            "id": "prop-dusting",
+            "name": "Prop Dusting",
+            "number": "235",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_235_8fbab4791a58_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Destroy an enemy flank creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Prop Dusting"
+                }
+            }
+        },
+        {
+            "id": "remmi-hound",
+            "name": "Remmi Hound",
+            "number": "236",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_236_f8c0933a3ed9_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "dinosaur",
+                "halyard"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "Entrench.\nWhile Remmi Hound is exhausted, each friendly flank creature gets +4 power.\n\n",
+            "locale": {
+                "en": {
+                    "name": "Remmi Hound"
+                }
+            }
+        },
+        {
+            "id": "ruby-rackham",
+            "name": "Ruby Rackham",
+            "number": "237",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_237_146229d63866_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [],
+            "traits": [
+                "human",
+                "stormkin"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 1,
+            "power": 3,
+            "text": "After Fight: If a red key is forged, deal 4 to each enemy flank creature. Otherwise, deal 1 to each enemy flank creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Ruby Rackham"
+                }
+            }
+        },
+        {
+            "id": "skulking-saboteurs",
+            "name": "Skulking Saboteurs",
+            "number": "238",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_238_80fde38668eb_en.png",
+            "expansion": 928,
+            "house": "skyborn",
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "stormkin"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Elusive.\nAfter Reap: If your red key is forged, destroy an enemy creature. If your yellow key is forged, destroy an enemy artifact. If your blue key is forged, destroy an enemy upgrade.\n",
+            "locale": {
+                "en": {
+                    "name": "Skulking Saboteurs"
+                }
+            }
+        },
+        {
+            "id": "brackish-shoreline",
+            "name": "Brackish Shoreline",
+            "number": "239",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_239_ae98d52a7407_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "location"
+            ],
+            "type": "artifact",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "After a creature fights, it doesn’t ready during the “ready cards” step this turn.\n",
+            "locale": {
+                "en": {
+                    "name": "Brackish Shoreline"
+                }
+            }
+        },
+        {
+            "id": "corrode",
+            "name": "Corrode",
+            "number": "240",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_240_a53aac434601_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Choose one:\nDestroy an artifact.\nDestroy an upgrade.\nDestroy a creature with armor.\n",
+            "locale": {
+                "en": {
+                    "name": "Corrode"
+                }
+            }
+        },
+        {
+            "id": "dazed-and-confused",
+            "name": "Dazed and Confused",
+            "number": "241",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_241_8c50e1f629ad_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Exhaust a creature and each of its neighbors. Stun 2 exhausted creatures.\n",
+            "locale": {
+                "en": {
+                    "name": "Dazed and Confused"
+                }
+            }
+        },
+        {
+            "id": "deep-priest-glebe",
+            "name": "Deep Priest Glebe",
+            "number": "242",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_242_8dd19c87d71b_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "aquan"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 5,
+            "text": "After you play an Aquan creature, exhaust an enemy creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Deep Priest Glebe"
+                }
+            }
+        },
+        {
+            "id": "flash-freeze",
+            "name": "Flash Freeze",
+            "number": "243",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_243_57846bc50d8a_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: For the remainder of the turn, after you play another card, exhaust a creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Flash Freeze"
+                }
+            }
+        },
+        {
+            "id": "hydrogan",
+            "name": "Hydrogan",
+            "number": "244",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_244_6fbbb8715d70_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "gigantic creature art",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "",
+            "locale": {
+                "en": {
+                    "name": "Hydrogan"
+                }
+            }
+        },
+        {
+            "id": "hydrogan",
+            "name": "Hydrogan",
+            "number": "244",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_244_42d0d54bfae2_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "beast",
+                "leviathan"
+            ],
+            "type": "gigantic creature base",
+            "rarity": "Special",
+            "amber": 0,
+            "armor": null,
+            "power": 10,
+            "text": "(Play only with the other half of Hydrogan.)\nPlay: Put each other creature faceup under Hydrogan.\nAfter Fight/After Reap: Put a creature from under Hydrogan into play under your control.\nDestroyed: Purge each card under Hydrogan.\n",
+            "locale": {
+                "en": {
+                    "name": "Hydrogan"
+                }
+            }
+        },
+        {
+            "id": "lateral-shift",
+            "name": "Lateral Shift",
+            "number": "245",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_245_caf0c66278c4_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Look at your opponent’s hand. Play a card from that hand as if it were yours.\n",
+            "locale": {
+                "en": {
+                    "name": "Lateral Shift"
+                }
+            }
+        },
+        {
+            "id": "plunder",
+            "name": "Plunder",
+            "number": "246",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_246_614b88ee0a04_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Reveal a random unrevealed card from your opponent’s hand. Then, you may either repeat this effect or your opponent discards the last revealed card.",
+            "locale": {
+                "en": {
+                    "name": "Plunder"
+                }
+            }
+        },
+        {
+            "id": "sand-in-your-eye",
+            "name": "Sand In Your Eye",
+            "number": "247",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_247_32c225c96d08_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Exhaust a creature. Draw a card for each exhausted creature. Destroy each exhausted creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Sand In Your Eye"
+                }
+            }
+        },
+        {
+            "id": "sibyl-waimare",
+            "name": "Sibyl Waimare",
+            "number": "248",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_248_f7078df3fde4_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "aquan"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 5,
+            "text": "At the start of your opponent’s turn, that player discards the top card of their deck and exhausts each creature of that card’s house.\n",
+            "locale": {
+                "en": {
+                    "name": "Sibyl Waimare"
+                }
+            }
+        },
+        {
+            "id": "starpatch",
+            "name": "Starpatch",
+            "number": "249",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_249_a30845b8883f_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "upgrade",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Enhance .\nThis creature gains, “At the start of your turn, if this creature is exhausted, purge another creature that shares a house with it.”\n",
+            "locale": {
+                "en": {
+                    "name": "Starpatch"
+                }
+            }
+        },
+        {
+            "id": "thalassophobia",
+            "name": "Thalassophobia",
+            "number": "250",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_250_d84d5a38ff9b_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Discard the top 10 cards of your opponent’s deck.",
+            "locale": {
+                "en": {
+                    "name": "Thalassophobia"
+                }
+            }
+        },
+        {
+            "id": "the-chosen-one",
+            "name": "The Chosen One",
+            "number": "251",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_251_e84ddf6d2bc2_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "aquan"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 9,
+            "text": "Instead of readying creatures they control during their “ready cards” step, your opponent deals 1 to The Chosen One for each exhausted creature they control.",
+            "locale": {
+                "en": {
+                    "name": "The Chosen One"
+                }
+            }
+        },
+        {
+            "id": "thing-from-the-deep",
+            "name": "Thing from the Deep",
+            "number": "252",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_252_68bcc075492b_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "beast"
+            ],
+            "type": "creature",
+            "rarity": "Rare",
+            "amber": 0,
+            "armor": 0,
+            "power": 30,
+            "text": "Thing from the Deep cannot be played unless Open the Seal is in your discard pile.\nAfter Fight: Steal 2.\n",
+            "locale": {
+                "en": {
+                    "name": "Thing from the Deep"
+                }
+            }
+        },
+        {
+            "id": "weak-link",
+            "name": "Weak Link",
+            "number": "253",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_253_7f9ed08fcfeb_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "upgrade",
+            "rarity": "Rare",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "This creature gains, “While this creature is exhausted, your keys cost +6.”\n",
+            "locale": {
+                "en": {
+                    "name": "Weak Link"
+                }
+            }
+        },
+        {
+            "id": "addlefish",
+            "name": "Addlefish",
+            "number": "254",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_254_be343afca6ed_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "beast"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 5,
+            "text": "After Fight: Your opponent discards\n2 random cards from their hand.\n",
+            "locale": {
+                "en": {
+                    "name": "Addlefish"
+                }
+            }
+        },
+        {
+            "id": "allusions-of-grandeur",
+            "name": "Allusions of Grandeur",
+            "number": "255",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_255_0d824b57442d_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Choose a house on your opponent’s identity card. If your opponent does not choose that house as their active house on their next turn, gain 3.",
+            "locale": {
+                "en": {
+                    "name": "Allusions of Grandeur"
+                }
+            }
+        },
+        {
+            "id": "azure-basin-outpost",
+            "name": "Azure Basin Outpost",
+            "number": "256",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_256_1422b9b72dd3_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "location"
+            ],
+            "type": "artifact",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Action: Put a friendly creature on the bottom of its owner’s deck. If you do, exhaust 3 enemy creatures.",
+            "locale": {
+                "en": {
+                    "name": "Azure Basin Outpost"
+                }
+            }
+        },
+        {
+            "id": "catch-and-release",
+            "name": "Catch and Release",
+            "number": "257",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_257_d71aa8f671cd_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "Play: Return each creature to its owner’s hand. Each player discards random cards from their hand until they have 6 or fewer cards in hand. Gain 2 chains.",
+            "locale": {
+                "en": {
+                    "name": "Catch and Release"
+                }
+            }
+        },
+        {
+            "id": "dreamcall",
+            "name": "Dreamcall",
+            "number": "258",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_258_ed1e717d0218_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Exhaust a creature. For each copy of Dreamcall in your discard pile, exhaust another creature and draw a card.\n",
+            "locale": {
+                "en": {
+                    "name": "Dreamcall"
+                }
+            }
+        },
+        {
+            "id": "fathomshare",
+            "name": "Fathomshare",
+            "number": "259",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_259_2da3d06f54a5_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Capture half of your opponent’s  (rounding down), distributed among any number of friendly creatures.\n",
+            "locale": {
+                "en": {
+                    "name": "Fathomshare"
+                }
+            }
+        },
+        {
+            "id": "hukaru-icefin",
+            "name": "Hukaru Icefin",
+            "number": "260",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_260_47cbd655f50f_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "aquan",
+                "scientist"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "After Reap: Choose a house. Exhaust each creature of that house.\nScrap: Exhaust a creature or an artifact.\n",
+            "locale": {
+                "en": {
+                    "name": "Hukaru Icefin"
+                }
+            }
+        },
+        {
+            "id": "kaipo",
+            "name": "Kaipo",
+            "number": "261",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_261_4e89d2db94ef_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "aquan"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 1,
+            "power": 5,
+            "text": "Taunt.\nAt the end of your turn, fully heal each of Kaipo’s neighbors.\n",
+            "locale": {
+                "en": {
+                    "name": "Kaipo"
+                }
+            }
+        },
+        {
+            "id": "malina",
+            "name": "Malina",
+            "number": "262",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_262_c1336dc81704_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "aquan"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "Entrench.\nWhile Malina is exhausted, your opponent cannot play creatures more powerful than the most powerful creature in play.\n",
+            "locale": {
+                "en": {
+                    "name": "Malina"
+                }
+            }
+        },
+        {
+            "id": "sparkfist",
+            "name": "Sparkfist",
+            "number": "263",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_263_ca130e963324_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [
+                "skirmish"
+            ],
+            "traits": [
+                "aquan"
+            ],
+            "type": "creature",
+            "rarity": "Uncommon",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Skirmish. (When you use this creature to fight, it is dealt no damage in return.)\nAfter Fight: Stun and exhaust the creature Sparkfist fights.",
+            "locale": {
+                "en": {
+                    "name": "Sparkfist"
+                }
+            }
+        },
+        {
+            "id": "tsunami",
+            "name": "Tsunami",
+            "number": "264",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_264_7a75c05054aa_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Deal 4 to each ready creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Tsunami"
+                }
+            }
+        },
+        {
+            "id": "under-pressure",
+            "name": "Under Pressure",
+            "number": "265",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_265_3fb7088a79df_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "upgrade",
+            "rarity": "Uncommon",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "This creature cannot ready.\n",
+            "locale": {
+                "en": {
+                    "name": "Under Pressure"
+                }
+            }
+        },
+        {
+            "id": "abyssal-sight",
+            "name": "Abyssal Sight",
+            "number": "266",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_266_42fbc3ae43df_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Destroy a friendly creature. If you do, look at your opponent’s hand and choose a card from it. That player discards that card.\n",
+            "locale": {
+                "en": {
+                    "name": "Abyssal Sight"
+                }
+            }
+        },
+        {
+            "id": "brine-reckoning",
+            "name": "Brine Reckoning",
+            "number": "267",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_267_e6e6799cf113_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Each player discards the top 5 cards of their deck.\n",
+            "locale": {
+                "en": {
+                    "name": "Brine Reckoning"
+                }
+            }
+        },
+        {
+            "id": "call-of-the-void",
+            "name": "Call of the Void",
+            "number": "268",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_268_d7d9fbf29591_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Play: Exhaust a creature. If it was already exhausted, destroy it instead and its controller loses 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Call of the Void"
+                }
+            }
+        },
+        {
+            "id": "frigorific-rod",
+            "name": "Frigorific Rod",
+            "number": "269",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_269_f766bea27531_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "item"
+            ],
+            "type": "artifact",
+            "rarity": "Common",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Action: Exhaust a creature or artifact.\n",
+            "locale": {
+                "en": {
+                    "name": "Frigorific Rod"
+                }
+            }
+        },
+        {
+            "id": "hemogrith",
+            "name": "Hemogrith",
+            "number": "270",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_270_767ab80d7840_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "beast"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Play: If there are no enemy exhausted creatures, your opponent loses 2.\n",
+            "locale": {
+                "en": {
+                    "name": "Hemogrith"
+                }
+            }
+        },
+        {
+            "id": "keenu",
+            "name": "Keenu",
+            "number": "271",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_271_3ed2e4738002_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "aquan"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 2,
+            "text": "Enhance .\nPlay: Choose an enemy creature with no +1 power counters on it. Exhaust that creature and each of its neighbors.\n",
+            "locale": {
+                "en": {
+                    "name": "Keenu"
+                }
+            }
+        },
+        {
+            "id": "knuckler",
+            "name": "Knuckler",
+            "number": "272",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_272_4fc0eb72b696_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [
+                "deploy"
+            ],
+            "traits": [
+                "beast"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 2,
+            "power": 3,
+            "text": "Deploy. Entrench.\nWhile Knuckler is exhausted, each of its neighbors gets +2 armor.\n",
+            "locale": {
+                "en": {
+                    "name": "Knuckler"
+                }
+            }
+        },
+        {
+            "id": "paralysis-synan",
+            "name": "Paralysis Synan",
+            "number": "273",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_273_8ed2a27d382f_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "beast"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "After Reap: Stun, enrage, and exhaust a creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Paralysis Synan"
+                }
+            }
+        },
+        {
+            "id": "priestess-leilani",
+            "name": "Priestess Leilani",
+            "number": "274",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_274_e08bdf4b0605_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "aquan",
+                "priest"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 3,
+            "text": "After Reap: Exhaust an enemy creature. If you do, ready a non-Priest creature.\n",
+            "locale": {
+                "en": {
+                    "name": "Priestess Leilani"
+                }
+            }
+        },
+        {
+            "id": "siphon-maw",
+            "name": "Siphon Maw",
+            "number": "275",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_275_37ff12dec8b0_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "vehicle"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 4,
+            "text": "After Fight/After Reap: Discard the top card of a player’s deck. For each bonus icon on the discarded card, your opponent loses 1.\n",
+            "locale": {
+                "en": {
+                    "name": "Siphon Maw"
+                }
+            }
+        },
+        {
+            "id": "slapdash-enamel",
+            "name": "Slapdash Enamel",
+            "number": "276",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_276_9a7d4dafb285_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "item"
+            ],
+            "type": "artifact",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": null,
+            "power": null,
+            "text": "At the start of your turn, destroy each card with a corrosion counter on it.\nAction: Put a corrosion counter on a card in play.\n",
+            "locale": {
+                "en": {
+                    "name": "Slapdash Enamel"
+                }
+            }
+        },
+        {
+            "id": "bubbles",
+            "name": "“Bubbles”",
+            "number": "277",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_277_be691ea3abed_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [
+                "aquan"
+            ],
+            "type": "creature",
+            "rarity": "Common",
+            "amber": 0,
+            "armor": 0,
+            "power": 5,
+            "text": "Play: Put an enemy creature on top of its owner’s deck.\n",
+            "locale": {
+                "en": {
+                    "name": "“Bubbles”"
+                }
+            }
+        },
+        {
+            "id": "open-the-seal",
+            "name": "Open the Seal",
+            "number": "278",
+            "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_278_804ac2c1381b_en.png",
+            "expansion": 928,
+            "house": "unfathomable",
+            "keywords": [],
+            "traits": [],
+            "type": "action",
+            "rarity": "Special",
+            "amber": 1,
+            "armor": null,
+            "power": null,
+            "text": "Enhance . (These icons have already been added to cards in your deck.)\n",
+            "locale": {
+                "en": {
+                    "name": "Open the Seal"
+                }
+            }
+        }
+    ]
+}

--- a/packs/DM.json
+++ b/packs/DM.json
@@ -1,10 +1,8 @@
 {
-    "ids": [
-        "928"
-    ],
+    "ids": ["928"],
     "code": "DM",
     "name": "Draconian Measures",
-    "cardCount": "303",
+    "cardCount": "370",
     "releaseDate": "2026-04-28",
     "cards": [
         {
@@ -23,37 +21,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
-                "de": {
-                    "name": "Build Your Champion"
-                },
                 "en": {
-                    "name": "Build Your Champion"
-                },
-                "es": {
-                    "name": "Build Your Champion"
-                },
-                "fr": {
-                    "name": "Build Your Champion"
-                },
-                "it": {
-                    "name": "Build Your Champion"
-                },
-                "pl": {
-                    "name": "Build Your Champion"
-                },
-                "pt": {
-                    "name": "Build Your Champion"
-                },
-                "th": {
-                    "name": "Build Your Champion"
-                },
-                "vi": {
-                    "name": "Build Your Champion"
-                },
-                "zhhans": {
-                    "name": "Build Your Champion"
-                },
-                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -74,37 +42,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
-                "de": {
-                    "name": "Build Your Champion"
-                },
                 "en": {
-                    "name": "Build Your Champion"
-                },
-                "es": {
-                    "name": "Build Your Champion"
-                },
-                "fr": {
-                    "name": "Build Your Champion"
-                },
-                "it": {
-                    "name": "Build Your Champion"
-                },
-                "pl": {
-                    "name": "Build Your Champion"
-                },
-                "pt": {
-                    "name": "Build Your Champion"
-                },
-                "th": {
-                    "name": "Build Your Champion"
-                },
-                "vi": {
-                    "name": "Build Your Champion"
-                },
-                "zhhans": {
-                    "name": "Build Your Champion"
-                },
-                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -125,37 +63,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
-                "de": {
-                    "name": "Build Your Champion"
-                },
                 "en": {
-                    "name": "Build Your Champion"
-                },
-                "es": {
-                    "name": "Build Your Champion"
-                },
-                "fr": {
-                    "name": "Build Your Champion"
-                },
-                "it": {
-                    "name": "Build Your Champion"
-                },
-                "pl": {
-                    "name": "Build Your Champion"
-                },
-                "pt": {
-                    "name": "Build Your Champion"
-                },
-                "th": {
-                    "name": "Build Your Champion"
-                },
-                "vi": {
-                    "name": "Build Your Champion"
-                },
-                "zhhans": {
-                    "name": "Build Your Champion"
-                },
-                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -176,37 +84,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
-                "de": {
-                    "name": "Build Your Champion"
-                },
                 "en": {
-                    "name": "Build Your Champion"
-                },
-                "es": {
-                    "name": "Build Your Champion"
-                },
-                "fr": {
-                    "name": "Build Your Champion"
-                },
-                "it": {
-                    "name": "Build Your Champion"
-                },
-                "pl": {
-                    "name": "Build Your Champion"
-                },
-                "pt": {
-                    "name": "Build Your Champion"
-                },
-                "th": {
-                    "name": "Build Your Champion"
-                },
-                "vi": {
-                    "name": "Build Your Champion"
-                },
-                "zhhans": {
-                    "name": "Build Your Champion"
-                },
-                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -227,37 +105,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
-                "de": {
-                    "name": "Build Your Champion"
-                },
                 "en": {
-                    "name": "Build Your Champion"
-                },
-                "es": {
-                    "name": "Build Your Champion"
-                },
-                "fr": {
-                    "name": "Build Your Champion"
-                },
-                "it": {
-                    "name": "Build Your Champion"
-                },
-                "pl": {
-                    "name": "Build Your Champion"
-                },
-                "pt": {
-                    "name": "Build Your Champion"
-                },
-                "th": {
-                    "name": "Build Your Champion"
-                },
-                "vi": {
-                    "name": "Build Your Champion"
-                },
-                "zhhans": {
-                    "name": "Build Your Champion"
-                },
-                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -278,37 +126,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
-                "de": {
-                    "name": "Build Your Champion"
-                },
                 "en": {
-                    "name": "Build Your Champion"
-                },
-                "es": {
-                    "name": "Build Your Champion"
-                },
-                "fr": {
-                    "name": "Build Your Champion"
-                },
-                "it": {
-                    "name": "Build Your Champion"
-                },
-                "pl": {
-                    "name": "Build Your Champion"
-                },
-                "pt": {
-                    "name": "Build Your Champion"
-                },
-                "th": {
-                    "name": "Build Your Champion"
-                },
-                "vi": {
-                    "name": "Build Your Champion"
-                },
-                "zhhans": {
-                    "name": "Build Your Champion"
-                },
-                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -329,37 +147,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
-                "de": {
-                    "name": "Build Your Champion"
-                },
                 "en": {
-                    "name": "Build Your Champion"
-                },
-                "es": {
-                    "name": "Build Your Champion"
-                },
-                "fr": {
-                    "name": "Build Your Champion"
-                },
-                "it": {
-                    "name": "Build Your Champion"
-                },
-                "pl": {
-                    "name": "Build Your Champion"
-                },
-                "pt": {
-                    "name": "Build Your Champion"
-                },
-                "th": {
-                    "name": "Build Your Champion"
-                },
-                "vi": {
-                    "name": "Build Your Champion"
-                },
-                "zhhans": {
-                    "name": "Build Your Champion"
-                },
-                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -380,37 +168,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
-                "de": {
-                    "name": "Digging Up the Monster"
-                },
                 "en": {
-                    "name": "Digging Up the Monster"
-                },
-                "es": {
-                    "name": "Digging Up the Monster"
-                },
-                "fr": {
-                    "name": "Digging Up the Monster"
-                },
-                "it": {
-                    "name": "Digging Up the Monster"
-                },
-                "pl": {
-                    "name": "Digging Up the Monster"
-                },
-                "pt": {
-                    "name": "Digging Up the Monster"
-                },
-                "th": {
-                    "name": "Digging Up the Monster"
-                },
-                "vi": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhans": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -431,37 +189,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
-                "de": {
-                    "name": "Digging Up the Monster"
-                },
                 "en": {
-                    "name": "Digging Up the Monster"
-                },
-                "es": {
-                    "name": "Digging Up the Monster"
-                },
-                "fr": {
-                    "name": "Digging Up the Monster"
-                },
-                "it": {
-                    "name": "Digging Up the Monster"
-                },
-                "pl": {
-                    "name": "Digging Up the Monster"
-                },
-                "pt": {
-                    "name": "Digging Up the Monster"
-                },
-                "th": {
-                    "name": "Digging Up the Monster"
-                },
-                "vi": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhans": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -482,37 +210,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
-                "de": {
-                    "name": "Digging Up the Monster"
-                },
                 "en": {
-                    "name": "Digging Up the Monster"
-                },
-                "es": {
-                    "name": "Digging Up the Monster"
-                },
-                "fr": {
-                    "name": "Digging Up the Monster"
-                },
-                "it": {
-                    "name": "Digging Up the Monster"
-                },
-                "pl": {
-                    "name": "Digging Up the Monster"
-                },
-                "pt": {
-                    "name": "Digging Up the Monster"
-                },
-                "th": {
-                    "name": "Digging Up the Monster"
-                },
-                "vi": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhans": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -533,37 +231,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
-                "de": {
-                    "name": "Digging Up the Monster"
-                },
                 "en": {
-                    "name": "Digging Up the Monster"
-                },
-                "es": {
-                    "name": "Digging Up the Monster"
-                },
-                "fr": {
-                    "name": "Digging Up the Monster"
-                },
-                "it": {
-                    "name": "Digging Up the Monster"
-                },
-                "pl": {
-                    "name": "Digging Up the Monster"
-                },
-                "pt": {
-                    "name": "Digging Up the Monster"
-                },
-                "th": {
-                    "name": "Digging Up the Monster"
-                },
-                "vi": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhans": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -584,37 +252,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
-                "de": {
-                    "name": "Digging Up the Monster"
-                },
                 "en": {
-                    "name": "Digging Up the Monster"
-                },
-                "es": {
-                    "name": "Digging Up the Monster"
-                },
-                "fr": {
-                    "name": "Digging Up the Monster"
-                },
-                "it": {
-                    "name": "Digging Up the Monster"
-                },
-                "pl": {
-                    "name": "Digging Up the Monster"
-                },
-                "pt": {
-                    "name": "Digging Up the Monster"
-                },
-                "th": {
-                    "name": "Digging Up the Monster"
-                },
-                "vi": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhans": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -635,37 +273,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
-                "de": {
-                    "name": "Digging Up the Monster"
-                },
                 "en": {
-                    "name": "Digging Up the Monster"
-                },
-                "es": {
-                    "name": "Digging Up the Monster"
-                },
-                "fr": {
-                    "name": "Digging Up the Monster"
-                },
-                "it": {
-                    "name": "Digging Up the Monster"
-                },
-                "pl": {
-                    "name": "Digging Up the Monster"
-                },
-                "pt": {
-                    "name": "Digging Up the Monster"
-                },
-                "th": {
-                    "name": "Digging Up the Monster"
-                },
-                "vi": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhans": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -686,37 +294,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
-                "de": {
-                    "name": "Digging Up the Monster"
-                },
                 "en": {
-                    "name": "Digging Up the Monster"
-                },
-                "es": {
-                    "name": "Digging Up the Monster"
-                },
-                "fr": {
-                    "name": "Digging Up the Monster"
-                },
-                "it": {
-                    "name": "Digging Up the Monster"
-                },
-                "pl": {
-                    "name": "Digging Up the Monster"
-                },
-                "pt": {
-                    "name": "Digging Up the Monster"
-                },
-                "th": {
-                    "name": "Digging Up the Monster"
-                },
-                "vi": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhans": {
-                    "name": "Digging Up the Monster"
-                },
-                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -737,37 +315,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
-                "de": {
-                    "name": "Tomes Gigantica"
-                },
                 "en": {
-                    "name": "Tomes Gigantica"
-                },
-                "es": {
-                    "name": "Tomes Gigantica"
-                },
-                "fr": {
-                    "name": "Tomes Gigantica"
-                },
-                "it": {
-                    "name": "Tomes Gigantica"
-                },
-                "pl": {
-                    "name": "Tomes Gigantica"
-                },
-                "pt": {
-                    "name": "Tomes Gigantica"
-                },
-                "th": {
-                    "name": "Tomes Gigantica"
-                },
-                "vi": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhans": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -788,37 +336,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
-                "de": {
-                    "name": "Tomes Gigantica"
-                },
                 "en": {
-                    "name": "Tomes Gigantica"
-                },
-                "es": {
-                    "name": "Tomes Gigantica"
-                },
-                "fr": {
-                    "name": "Tomes Gigantica"
-                },
-                "it": {
-                    "name": "Tomes Gigantica"
-                },
-                "pl": {
-                    "name": "Tomes Gigantica"
-                },
-                "pt": {
-                    "name": "Tomes Gigantica"
-                },
-                "th": {
-                    "name": "Tomes Gigantica"
-                },
-                "vi": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhans": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -839,37 +357,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
-                "de": {
-                    "name": "Tomes Gigantica"
-                },
                 "en": {
-                    "name": "Tomes Gigantica"
-                },
-                "es": {
-                    "name": "Tomes Gigantica"
-                },
-                "fr": {
-                    "name": "Tomes Gigantica"
-                },
-                "it": {
-                    "name": "Tomes Gigantica"
-                },
-                "pl": {
-                    "name": "Tomes Gigantica"
-                },
-                "pt": {
-                    "name": "Tomes Gigantica"
-                },
-                "th": {
-                    "name": "Tomes Gigantica"
-                },
-                "vi": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhans": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -890,37 +378,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
-                "de": {
-                    "name": "Tomes Gigantica"
-                },
                 "en": {
-                    "name": "Tomes Gigantica"
-                },
-                "es": {
-                    "name": "Tomes Gigantica"
-                },
-                "fr": {
-                    "name": "Tomes Gigantica"
-                },
-                "it": {
-                    "name": "Tomes Gigantica"
-                },
-                "pl": {
-                    "name": "Tomes Gigantica"
-                },
-                "pt": {
-                    "name": "Tomes Gigantica"
-                },
-                "th": {
-                    "name": "Tomes Gigantica"
-                },
-                "vi": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhans": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -941,37 +399,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
-                "de": {
-                    "name": "Tomes Gigantica"
-                },
                 "en": {
-                    "name": "Tomes Gigantica"
-                },
-                "es": {
-                    "name": "Tomes Gigantica"
-                },
-                "fr": {
-                    "name": "Tomes Gigantica"
-                },
-                "it": {
-                    "name": "Tomes Gigantica"
-                },
-                "pl": {
-                    "name": "Tomes Gigantica"
-                },
-                "pt": {
-                    "name": "Tomes Gigantica"
-                },
-                "th": {
-                    "name": "Tomes Gigantica"
-                },
-                "vi": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhans": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -992,37 +420,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
-                "de": {
-                    "name": "Tomes Gigantica"
-                },
                 "en": {
-                    "name": "Tomes Gigantica"
-                },
-                "es": {
-                    "name": "Tomes Gigantica"
-                },
-                "fr": {
-                    "name": "Tomes Gigantica"
-                },
-                "it": {
-                    "name": "Tomes Gigantica"
-                },
-                "pl": {
-                    "name": "Tomes Gigantica"
-                },
-                "pt": {
-                    "name": "Tomes Gigantica"
-                },
-                "th": {
-                    "name": "Tomes Gigantica"
-                },
-                "vi": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhans": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -1043,37 +441,7 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
-                "de": {
-                    "name": "Tomes Gigantica"
-                },
                 "en": {
-                    "name": "Tomes Gigantica"
-                },
-                "es": {
-                    "name": "Tomes Gigantica"
-                },
-                "fr": {
-                    "name": "Tomes Gigantica"
-                },
-                "it": {
-                    "name": "Tomes Gigantica"
-                },
-                "pl": {
-                    "name": "Tomes Gigantica"
-                },
-                "pt": {
-                    "name": "Tomes Gigantica"
-                },
-                "th": {
-                    "name": "Tomes Gigantica"
-                },
-                "vi": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhans": {
-                    "name": "Tomes Gigantica"
-                },
-                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -1094,37 +462,7 @@
             "power": null,
             "text": "Play: Unforge an opponent’s key. If you do, purge Art Project, and your opponent draws 10 cards.\n",
             "locale": {
-                "de": {
-                    "name": "Kunstprojekt"
-                },
                 "en": {
-                    "name": "Art Project"
-                },
-                "es": {
-                    "name": "Art Project"
-                },
-                "fr": {
-                    "name": "Projet Artistique"
-                },
-                "it": {
-                    "name": "Art Project"
-                },
-                "pl": {
-                    "name": "Art Project"
-                },
-                "pt": {
-                    "name": "Art Project"
-                },
-                "th": {
-                    "name": "Art Project"
-                },
-                "vi": {
-                    "name": "Art Project"
-                },
-                "zhhans": {
-                    "name": "Art Project"
-                },
-                "zhhant": {
                     "name": "Art Project"
                 }
             }
@@ -1145,37 +483,7 @@
             "power": null,
             "text": "Play: Each player reveals a random card from their hand or archives. Each player gains 1 for each  bonus icon on their revealed card. Destroy each creature that shares a house with at least one of the revealed cards. Discard the revealed cards.\n",
             "locale": {
-                "de": {
-                    "name": "Tausch und Spiele"
-                },
                 "en": {
-                    "name": "Barter and Games"
-                },
-                "es": {
-                    "name": "Barter and Games"
-                },
-                "fr": {
-                    "name": "Jeux de Troc"
-                },
-                "it": {
-                    "name": "Barter and Games"
-                },
-                "pl": {
-                    "name": "Barter and Games"
-                },
-                "pt": {
-                    "name": "Barter and Games"
-                },
-                "th": {
-                    "name": "Barter and Games"
-                },
-                "vi": {
-                    "name": "Barter and Games"
-                },
-                "zhhans": {
-                    "name": "Barter and Games"
-                },
-                "zhhant": {
                     "name": "Barter and Games"
                 }
             }
@@ -1187,13 +495,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_006_6cdd45601d9e_en.png",
             "expansion": 928,
             "house": "ekwidon",
-            "keywords": [
-                "treachery"
-            ],
-            "traits": [
-                "human",
-                "merchant"
-            ],
+            "keywords": ["treachery"],
+            "traits": ["human", "merchant"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -1201,37 +504,7 @@
             "power": 4,
             "text": "Treachery. (This card enters play under your opponent’s control.)\nAfter you forge a key, give control of the most powerful friendly creature to your opponent.\n",
             "locale": {
-                "de": {
-                    "name": "Elenya die Bezaubernde"
-                },
                 "en": {
-                    "name": "Elenya the Charming"
-                },
-                "es": {
-                    "name": "Elenya the Charming"
-                },
-                "fr": {
-                    "name": "Hĕlĕnya la Charmante"
-                },
-                "it": {
-                    "name": "Elenya the Charming"
-                },
-                "pl": {
-                    "name": "Elenya the Charming"
-                },
-                "pt": {
-                    "name": "Elenya the Charming"
-                },
-                "th": {
-                    "name": "Elenya the Charming"
-                },
-                "vi": {
-                    "name": "Elenya the Charming"
-                },
-                "zhhans": {
-                    "name": "Elenya the Charming"
-                },
-                "zhhant": {
                     "name": "Elenya the Charming"
                 }
             }
@@ -1252,37 +525,7 @@
             "power": null,
             "text": "Play: Give control of two friendly creatures to your opponent, one at a time. If you do, take control of two enemy creatures, one at a time.\n",
             "locale": {
-                "de": {
-                    "name": "Fairer Tausch"
-                },
                 "en": {
-                    "name": "Even Swap"
-                },
-                "es": {
-                    "name": "Even Swap"
-                },
-                "fr": {
-                    "name": "Échange Équitable"
-                },
-                "it": {
-                    "name": "Even Swap"
-                },
-                "pl": {
-                    "name": "Even Swap"
-                },
-                "pt": {
-                    "name": "Even Swap"
-                },
-                "th": {
-                    "name": "Even Swap"
-                },
-                "vi": {
-                    "name": "Even Swap"
-                },
-                "zhhans": {
-                    "name": "Even Swap"
-                },
-                "zhhant": {
                     "name": "Even Swap"
                 }
             }
@@ -1295,9 +538,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "item"
-            ],
+            "traits": ["item"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -1305,37 +546,7 @@
             "power": null,
             "text": "Action: Lose 1. If you do, take control of an enemy creature.\n",
             "locale": {
-                "de": {
-                    "name": "Willenskodierer"
-                },
                 "en": {
-                    "name": "Fiat Transcoder"
-                },
-                "es": {
-                    "name": "Fiat Transcoder"
-                },
-                "fr": {
-                    "name": "Transcodeur Fiduciaire"
-                },
-                "it": {
-                    "name": "Fiat Transcoder"
-                },
-                "pl": {
-                    "name": "Fiat Transcoder"
-                },
-                "pt": {
-                    "name": "Fiat Transcoder"
-                },
-                "th": {
-                    "name": "Fiat Transcoder"
-                },
-                "vi": {
-                    "name": "Fiat Transcoder"
-                },
-                "zhhans": {
-                    "name": "Fiat Transcoder"
-                },
-                "zhhant": {
                     "name": "Fiat Transcoder"
                 }
             }
@@ -1356,37 +567,7 @@
             "power": null,
             "text": "Play: Move each +1 power counter and each  from friendly creatures to the common supply. Forge a key at +6 current cost, reduced by 1 for the total number of +1 power counters and  moved to the common supply this way (to a minimum of 6).\n",
             "locale": {
-                "de": {
-                    "name": "Falsche Währung"
-                },
                 "en": {
-                    "name": "Forged Currency"
-                },
-                "es": {
-                    "name": "Forged Currency"
-                },
-                "fr": {
-                    "name": "Monnaie Contrefaite"
-                },
-                "it": {
-                    "name": "Forged Currency"
-                },
-                "pl": {
-                    "name": "Forged Currency"
-                },
-                "pt": {
-                    "name": "Forged Currency"
-                },
-                "th": {
-                    "name": "Forged Currency"
-                },
-                "vi": {
-                    "name": "Forged Currency"
-                },
-                "zhhans": {
-                    "name": "Forged Currency"
-                },
-                "zhhant": {
                     "name": "Forged Currency"
                 }
             }
@@ -1407,37 +588,7 @@
             "power": null,
             "text": "At the start of each turn, the active player takes control of this creature.\nThis creature may be used as if it belonged to the active house.\n",
             "locale": {
-                "de": {
-                    "name": "Freiberufler"
-                },
                 "en": {
-                    "name": "Freelancer"
-                },
-                "es": {
-                    "name": "Freelancer"
-                },
-                "fr": {
-                    "name": "Franc-Tireur"
-                },
-                "it": {
-                    "name": "Freelancer"
-                },
-                "pl": {
-                    "name": "Freelancer"
-                },
-                "pt": {
-                    "name": "Freelancer"
-                },
-                "th": {
-                    "name": "Freelancer"
-                },
-                "vi": {
-                    "name": "Freelancer"
-                },
-                "zhhans": {
-                    "name": "Freelancer"
-                },
-                "zhhant": {
                     "name": "Freelancer"
                 }
             }
@@ -1450,10 +601,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "getrookya",
-                "analyst"
-            ],
+            "traits": ["getrookya", "analyst"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -1461,37 +609,7 @@
             "power": 3,
             "text": "Enhance  . (These icons have already been added to cards in your deck.)\nEach friendly Ekwidon creature cannot reap and gains, “Action: Steal 1.”\n",
             "locale": {
-                "de": {
-                    "name": "Spielveränderer"
-                },
                 "en": {
-                    "name": "Game Changer"
-                },
-                "es": {
-                    "name": "Game Changer"
-                },
-                "fr": {
-                    "name": "Dĕs Sizĩph"
-                },
-                "it": {
-                    "name": "Game Changer"
-                },
-                "pl": {
-                    "name": "Game Changer"
-                },
-                "pt": {
-                    "name": "Game Changer"
-                },
-                "th": {
-                    "name": "Game Changer"
-                },
-                "vi": {
-                    "name": "Game Changer"
-                },
-                "zhhans": {
-                    "name": "Game Changer"
-                },
-                "zhhant": {
                     "name": "Game Changer"
                 }
             }
@@ -1512,37 +630,7 @@
             "power": null,
             "text": "Play: Choose 9 creatures. Move all  on the chosen creatures to their controllers’ pools. Destroy the chosen creatures.\n",
             "locale": {
-                "de": {
-                    "name": "Festlichkeiten zur Jahresmitte"
-                },
                 "en": {
-                    "name": "Midyear Festivities"
-                },
-                "es": {
-                    "name": "Midyear Festivities"
-                },
-                "fr": {
-                    "name": "Festival des Héritiers"
-                },
-                "it": {
-                    "name": "Midyear Festivities"
-                },
-                "pl": {
-                    "name": "Midyear Festivities"
-                },
-                "pt": {
-                    "name": "Midyear Festivities"
-                },
-                "th": {
-                    "name": "Midyear Festivities"
-                },
-                "vi": {
-                    "name": "Midyear Festivities"
-                },
-                "zhhans": {
-                    "name": "Midyear Festivities"
-                },
-                "zhhant": {
                     "name": "Midyear Festivities"
                 }
             }
@@ -1555,10 +643,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "getrookya",
-                "politician"
-            ],
+            "traits": ["getrookya", "politician"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -1566,37 +651,7 @@
             "power": 6,
             "text": "After Reap: You may pay your opponent 1. If you do, your opponent’s keys cost +4 during their next turn.\n",
             "locale": {
-                "de": {
-                    "name": "Oŏni-Lars"
-                },
                 "en": {
-                    "name": "Oŏni-Lars"
-                },
-                "es": {
-                    "name": "Oŏni-Lars"
-                },
-                "fr": {
-                    "name": "Oŏni-Lars"
-                },
-                "it": {
-                    "name": "Oŏni-Lars"
-                },
-                "pl": {
-                    "name": "Oŏni-Lars"
-                },
-                "pt": {
-                    "name": "Oŏni-Lars"
-                },
-                "th": {
-                    "name": "Oŏni-Lars"
-                },
-                "vi": {
-                    "name": "Oŏni-Lars"
-                },
-                "zhhans": {
-                    "name": "Oŏni-Lars"
-                },
-                "zhhant": {
                     "name": "Oŏni-Lars"
                 }
             }
@@ -1608,12 +663,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_014_ed69cdec7dca_en.png",
             "expansion": 928,
             "house": "ekwidon",
-            "keywords": [
-                "versatile"
-            ],
-            "traits": [
-                "getrookya"
-            ],
+            "keywords": ["versatile"],
+            "traits": ["getrookya"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 1,
@@ -1621,37 +672,7 @@
             "power": 2,
             "text": "Versatile. (This card may be used as if it belonged to the active house.)\nPlay: Look at your opponent’s hand and play a creature from it as if it were yours. Your opponent takes control of Talent Scout.\n",
             "locale": {
-                "de": {
-                    "name": "Talentsucher"
-                },
                 "en": {
-                    "name": "Talent Scout"
-                },
-                "es": {
-                    "name": "Talent Scout"
-                },
-                "fr": {
-                    "name": "Dénicheur de Talents"
-                },
-                "it": {
-                    "name": "Talent Scout"
-                },
-                "pl": {
-                    "name": "Talent Scout"
-                },
-                "pt": {
-                    "name": "Talent Scout"
-                },
-                "th": {
-                    "name": "Talent Scout"
-                },
-                "vi": {
-                    "name": "Talent Scout"
-                },
-                "zhhans": {
-                    "name": "Talent Scout"
-                },
-                "zhhant": {
                     "name": "Talent Scout"
                 }
             }
@@ -1664,10 +685,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "insect",
-                "cyborg"
-            ],
+            "traits": ["insect", "cyborg"],
             "type": "gigantic creature base",
             "rarity": "Special",
             "amber": 0,
@@ -1675,37 +693,7 @@
             "power": 10,
             "text": "(Play only with the other half of The Golden Queen.)\nEach player refills their hand to 1 additional card during their “draw cards” step.\nAfter Fight/After Reap: Each player discards a random card from their hand. For each non-Ekwidon card discarded this way, gain 1.\n",
             "locale": {
-                "de": {
-                    "name": "Die Goldene Königin"
-                },
                 "en": {
-                    "name": "The Golden Queen"
-                },
-                "es": {
-                    "name": "The Golden Queen"
-                },
-                "fr": {
-                    "name": "La Reine Dorée"
-                },
-                "it": {
-                    "name": "The Golden Queen"
-                },
-                "pl": {
-                    "name": "The Golden Queen"
-                },
-                "pt": {
-                    "name": "The Golden Queen"
-                },
-                "th": {
-                    "name": "The Golden Queen"
-                },
-                "vi": {
-                    "name": "The Golden Queen"
-                },
-                "zhhans": {
-                    "name": "The Golden Queen"
-                },
-                "zhhant": {
                     "name": "The Golden Queen"
                 }
             }
@@ -1726,37 +714,7 @@
             "power": null,
             "text": "",
             "locale": {
-                "de": {
-                    "name": "Die Goldene Königin"
-                },
                 "en": {
-                    "name": "The Golden Queen"
-                },
-                "es": {
-                    "name": "The Golden Queen"
-                },
-                "fr": {
-                    "name": "La Reine Dorée"
-                },
-                "it": {
-                    "name": "The Golden Queen"
-                },
-                "pl": {
-                    "name": "The Golden Queen"
-                },
-                "pt": {
-                    "name": "The Golden Queen"
-                },
-                "th": {
-                    "name": "The Golden Queen"
-                },
-                "vi": {
-                    "name": "The Golden Queen"
-                },
-                "zhhans": {
-                    "name": "The Golden Queen"
-                },
-                "zhhant": {
                     "name": "The Golden Queen"
                 }
             }
@@ -1777,37 +735,7 @@
             "power": null,
             "text": "Play: Your opponent draws 3 cards, discards a random card from their hand, puts a random card from their hand on top of their deck, and purges a random card from their hand.\n",
             "locale": {
-                "de": {
-                    "name": "Ganz schön betrunken"
-                },
                 "en": {
-                    "name": "Three Sheets to the Wind"
-                },
-                "es": {
-                    "name": "Three Sheets to the Wind"
-                },
-                "fr": {
-                    "name": "Torchon Chiffon Carpette"
-                },
-                "it": {
-                    "name": "Three Sheets to the Wind"
-                },
-                "pl": {
-                    "name": "Three Sheets to the Wind"
-                },
-                "pt": {
-                    "name": "Three Sheets to the Wind"
-                },
-                "th": {
-                    "name": "Three Sheets to the Wind"
-                },
-                "vi": {
-                    "name": "Three Sheets to the Wind"
-                },
-                "zhhans": {
-                    "name": "Three Sheets to the Wind"
-                },
-                "zhhant": {
                     "name": "Three Sheets to the Wind"
                 }
             }
@@ -1820,10 +748,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "human",
-                "scientist"
-            ],
+            "traits": ["human", "scientist"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -1831,37 +756,7 @@
             "power": 4,
             "text": "Each time you play an artifact from your discard pile, gain 1.\nPlay/After Reap: You may play an artifact from your discard pile.\n",
             "locale": {
-                "de": {
-                    "name": "Zavel, „Archäologe“"
-                },
                 "en": {
-                    "name": "Zavel, “Archaeologist”"
-                },
-                "es": {
-                    "name": "Zavel, “Archaeologist”"
-                },
-                "fr": {
-                    "name": "Zavel, « Archéologue »"
-                },
-                "it": {
-                    "name": "Zavel, “Archaeologist”"
-                },
-                "pl": {
-                    "name": "Zavel, “Archaeologist”"
-                },
-                "pt": {
-                    "name": "Zavel, “Archaeologist”"
-                },
-                "th": {
-                    "name": "Zavel, “Archaeologist”"
-                },
-                "vi": {
-                    "name": "Zavel, “Archaeologist”"
-                },
-                "zhhans": {
-                    "name": "Zavel, “Archaeologist”"
-                },
-                "zhhant": {
                     "name": "Zavel, “Archaeologist”"
                 }
             }
@@ -1874,9 +769,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "power"
-            ],
+            "traits": ["power"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -1884,37 +777,7 @@
             "power": null,
             "text": "Your keys cost +1. \nDuring your “draw cards” step, refill your hand to 1 additional card.\n",
             "locale": {
-                "de": {
-                    "name": "Æmbitrage"
-                },
                 "en": {
-                    "name": "Æmbitrage"
-                },
-                "es": {
-                    "name": "Æmbitrage"
-                },
-                "fr": {
-                    "name": "Aombitrage"
-                },
-                "it": {
-                    "name": "Æmbitrage"
-                },
-                "pl": {
-                    "name": "Æmbitrage"
-                },
-                "pt": {
-                    "name": "Æmbitrage"
-                },
-                "th": {
-                    "name": "Æmbitrage"
-                },
-                "vi": {
-                    "name": "Æmbitrage"
-                },
-                "zhhans": {
-                    "name": "Æmbitrage"
-                },
-                "zhhant": {
                     "name": "Æmbitrage"
                 }
             }
@@ -1935,37 +798,7 @@
             "power": null,
             "text": "Play: A friendly creature captures 2. Draw a card.\n",
             "locale": {
-                "de": {
-                    "name": "Autorisierter Einzug"
-                },
                 "en": {
-                    "name": "Authorized Requisitions"
-                },
-                "es": {
-                    "name": "Authorized Requisitions"
-                },
-                "fr": {
-                    "name": "Réquisition Autorisée"
-                },
-                "it": {
-                    "name": "Authorized Requisitions"
-                },
-                "pl": {
-                    "name": "Authorized Requisitions"
-                },
-                "pt": {
-                    "name": "Authorized Requisitions"
-                },
-                "th": {
-                    "name": "Authorized Requisitions"
-                },
-                "vi": {
-                    "name": "Authorized Requisitions"
-                },
-                "zhhans": {
-                    "name": "Authorized Requisitions"
-                },
-                "zhhant": {
                     "name": "Authorized Requisitions"
                 }
             }
@@ -1978,10 +811,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "getrookya",
-                "merchant"
-            ],
+            "traits": ["getrookya", "merchant"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -1989,37 +819,7 @@
             "power": 4,
             "text": "After Fight/After Reap: For each card in your opponent’s hand in excess of 5, they lose 1.\n",
             "locale": {
-                "de": {
-                    "name": "Betreiber des Wandels"
-                },
                 "en": {
-                    "name": "Change Agent"
-                },
-                "es": {
-                    "name": "Change Agent"
-                },
-                "fr": {
-                    "name": "Agent de Change"
-                },
-                "it": {
-                    "name": "Change Agent"
-                },
-                "pl": {
-                    "name": "Change Agent"
-                },
-                "pt": {
-                    "name": "Change Agent"
-                },
-                "th": {
-                    "name": "Change Agent"
-                },
-                "vi": {
-                    "name": "Change Agent"
-                },
-                "zhhans": {
-                    "name": "Change Agent"
-                },
-                "zhhant": {
                     "name": "Change Agent"
                 }
             }
@@ -2040,37 +840,7 @@
             "power": null,
             "text": "This creature gains, “Action: Deal 4 to a creature. If this damage destroys that creature, return Dapper Chapeau to its owner’s hand. Otherwise, attach Dapper Chapeau to that creature.”\n",
             "locale": {
-                "de": {
-                    "name": "Schicker Hut"
-                },
                 "en": {
-                    "name": "Dapper Chapeau"
-                },
-                "es": {
-                    "name": "Dapper Chapeau"
-                },
-                "fr": {
-                    "name": "Chapeau Pimpant"
-                },
-                "it": {
-                    "name": "Dapper Chapeau"
-                },
-                "pl": {
-                    "name": "Dapper Chapeau"
-                },
-                "pt": {
-                    "name": "Dapper Chapeau"
-                },
-                "th": {
-                    "name": "Dapper Chapeau"
-                },
-                "vi": {
-                    "name": "Dapper Chapeau"
-                },
-                "zhhans": {
-                    "name": "Dapper Chapeau"
-                },
-                "zhhant": {
                     "name": "Dapper Chapeau"
                 }
             }
@@ -2091,37 +861,7 @@
             "power": null,
             "text": "Play: Purge up to 2 cards from your hand. For each card purged this way, gain 1.\n",
             "locale": {
-                "de": {
-                    "name": "Drastische Maßnahmen"
-                },
                 "en": {
-                    "name": "Drastic Measures"
-                },
-                "es": {
-                    "name": "Drastic Measures"
-                },
-                "fr": {
-                    "name": "Mesures Drastiques"
-                },
-                "it": {
-                    "name": "Drastic Measures"
-                },
-                "pl": {
-                    "name": "Drastic Measures"
-                },
-                "pt": {
-                    "name": "Drastic Measures"
-                },
-                "th": {
-                    "name": "Drastic Measures"
-                },
-                "vi": {
-                    "name": "Drastic Measures"
-                },
-                "zhhans": {
-                    "name": "Drastic Measures"
-                },
-                "zhhant": {
                     "name": "Drastic Measures"
                 }
             }
@@ -2134,10 +874,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "human",
-                "merchant"
-            ],
+            "traits": ["human", "merchant"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -2145,37 +882,7 @@
             "power": 3,
             "text": "After Reap: Capture 2. You may discard a card. If you do, move 1 from Exeldon Yash to your pool.\n",
             "locale": {
-                "de": {
-                    "name": "Händlerfürst Yash"
-                },
                 "en": {
-                    "name": "Exeldon Yash"
-                },
-                "es": {
-                    "name": "Exeldon Yash"
-                },
-                "fr": {
-                    "name": "Exeldon Vălnŏr"
-                },
-                "it": {
-                    "name": "Exeldon Yash"
-                },
-                "pl": {
-                    "name": "Exeldon Yash"
-                },
-                "pt": {
-                    "name": "Exeldon Yash"
-                },
-                "th": {
-                    "name": "Exeldon Yash"
-                },
-                "vi": {
-                    "name": "Exeldon Yash"
-                },
-                "zhhans": {
-                    "name": "Exeldon Yash"
-                },
-                "zhhant": {
                     "name": "Exeldon Yash"
                 }
             }
@@ -2196,37 +903,7 @@
             "power": null,
             "text": "This creature's text box is considered blank, except for traits.\nPlay: Destroy all other upgrades attached to this creature.\n",
             "locale": {
-                "de": {
-                    "name": "Glücksumkehrer"
-                },
                 "en": {
-                    "name": "Fortune Reverser"
-                },
-                "es": {
-                    "name": "Fortune Reverser"
-                },
-                "fr": {
-                    "name": "Inverseur de Bonne Fortune"
-                },
-                "it": {
-                    "name": "Fortune Reverser"
-                },
-                "pl": {
-                    "name": "Fortune Reverser"
-                },
-                "pt": {
-                    "name": "Fortune Reverser"
-                },
-                "th": {
-                    "name": "Fortune Reverser"
-                },
-                "vi": {
-                    "name": "Fortune Reverser"
-                },
-                "zhhans": {
-                    "name": "Fortune Reverser"
-                },
-                "zhhant": {
                     "name": "Fortune Reverser"
                 }
             }
@@ -2239,10 +916,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "getrookya",
-                "soldier"
-            ],
+            "traits": ["getrookya", "soldier"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -2250,37 +924,7 @@
             "power": 3,
             "text": "Play/After Fight: Take control of an enemy artifact. Give your opponent control of Gegrrŏkŭŭ Sapper.\nScrap: Destroy a friendly artifact. If you do, destroy an enemy artifact.\n",
             "locale": {
-                "de": {
-                    "name": "Gegrrŏkŭŭ-Pionier"
-                },
                 "en": {
-                    "name": "Gegrrŏkŭŭ Sapper"
-                },
-                "es": {
-                    "name": "Gegrrŏkŭŭ Sapper"
-                },
-                "fr": {
-                    "name": "Sapeur Gegrrŏkŭŭ"
-                },
-                "it": {
-                    "name": "Gegrrŏkŭŭ Sapper"
-                },
-                "pl": {
-                    "name": "Gegrrŏkŭŭ Sapper"
-                },
-                "pt": {
-                    "name": "Gegrrŏkŭŭ Sapper"
-                },
-                "th": {
-                    "name": "Gegrrŏkŭŭ Sapper"
-                },
-                "vi": {
-                    "name": "Gegrrŏkŭŭ Sapper"
-                },
-                "zhhans": {
-                    "name": "Gegrrŏkŭŭ Sapper"
-                },
-                "zhhant": {
                     "name": "Gegrrŏkŭŭ Sapper"
                 }
             }
@@ -2293,9 +937,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "human"
-            ],
+            "traits": ["human"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -2303,37 +945,7 @@
             "power": 4,
             "text": "After Fight: Take control of an enemy artifact.\n",
             "locale": {
-                "de": {
-                    "name": "Krisper Ruld"
-                },
                 "en": {
-                    "name": "Krisper Ruld"
-                },
-                "es": {
-                    "name": "Krisper Ruld"
-                },
-                "fr": {
-                    "name": "Krisper Ruld"
-                },
-                "it": {
-                    "name": "Krisper Ruld"
-                },
-                "pl": {
-                    "name": "Krisper Ruld"
-                },
-                "pt": {
-                    "name": "Krisper Ruld"
-                },
-                "th": {
-                    "name": "Krisper Ruld"
-                },
-                "vi": {
-                    "name": "Krisper Ruld"
-                },
-                "zhhans": {
-                    "name": "Krisper Ruld"
-                },
-                "zhhant": {
                     "name": "Krisper Ruld"
                 }
             }
@@ -2346,9 +958,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "human"
-            ],
+            "traits": ["human"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -2356,37 +966,7 @@
             "power": 5,
             "text": "Action: Exhaust an enemy creature. If you do, each player gains 1.\n",
             "locale": {
-                "de": {
-                    "name": "Brieffreund"
-                },
                 "en": {
-                    "name": "Pen Pal"
-                },
-                "es": {
-                    "name": "Pen Pal"
-                },
-                "fr": {
-                    "name": "Correspondant"
-                },
-                "it": {
-                    "name": "Pen Pal"
-                },
-                "pl": {
-                    "name": "Pen Pal"
-                },
-                "pt": {
-                    "name": "Pen Pal"
-                },
-                "th": {
-                    "name": "Pen Pal"
-                },
-                "vi": {
-                    "name": "Pen Pal"
-                },
-                "zhhans": {
-                    "name": "Pen Pal"
-                },
-                "zhhant": {
                     "name": "Pen Pal"
                 }
             }
@@ -2407,37 +987,7 @@
             "power": null,
             "text": "Enhance .\nPlay: Each player reveals a random card from their hand and gains 1 for each  bonus icon on their revealed card.\n",
             "locale": {
-                "de": {
-                    "name": "Ernte des wilden Windes"
-                },
                 "en": {
-                    "name": "Reap the Wild Wind"
-                },
-                "es": {
-                    "name": "Reap the Wild Wind"
-                },
-                "fr": {
-                    "name": "Récolte la Tempête"
-                },
-                "it": {
-                    "name": "Reap the Wild Wind"
-                },
-                "pl": {
-                    "name": "Reap the Wild Wind"
-                },
-                "pt": {
-                    "name": "Reap the Wild Wind"
-                },
-                "th": {
-                    "name": "Reap the Wild Wind"
-                },
-                "vi": {
-                    "name": "Reap the Wild Wind"
-                },
-                "zhhans": {
-                    "name": "Reap the Wild Wind"
-                },
-                "zhhant": {
                     "name": "Reap the Wild Wind"
                 }
             }
@@ -2458,37 +1008,7 @@
             "power": null,
             "text": "Play: Discard the top 10 cards of your deck. If you discard 5 or more cards of the same house this way, steal 2.\n",
             "locale": {
-                "de": {
-                    "name": "Technorachnophobie"
-                },
                 "en": {
-                    "name": "Technorachnophobia"
-                },
-                "es": {
-                    "name": "Technorachnophobia"
-                },
-                "fr": {
-                    "name": "Technoarachnophobie"
-                },
-                "it": {
-                    "name": "Technorachnophobia"
-                },
-                "pl": {
-                    "name": "Technorachnophobia"
-                },
-                "pt": {
-                    "name": "Technorachnophobia"
-                },
-                "th": {
-                    "name": "Technorachnophobia"
-                },
-                "vi": {
-                    "name": "Technorachnophobia"
-                },
-                "zhhans": {
-                    "name": "Technorachnophobia"
-                },
-                "zhhant": {
                     "name": "Technorachnophobia"
                 }
             }
@@ -2500,13 +1020,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_030_6a9967a856dc_en.png",
             "expansion": 928,
             "house": "ekwidon",
-            "keywords": [
-                "poison"
-            ],
-            "traits": [
-                "insect",
-                "cyborg"
-            ],
+            "keywords": ["entrench", "poison"],
+            "traits": ["insect", "cyborg"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -2514,37 +1029,7 @@
             "power": 2,
             "text": "Entrench. Poison.\nAt the start of your turn, if Waspscream is exhausted, take control of an enemy creature. \n",
             "locale": {
-                "de": {
-                    "name": "Wespenschrei"
-                },
                 "en": {
-                    "name": "Waspscream"
-                },
-                "es": {
-                    "name": "Waspscream"
-                },
-                "fr": {
-                    "name": "Guêpe Envoûtante"
-                },
-                "it": {
-                    "name": "Waspscream"
-                },
-                "pl": {
-                    "name": "Waspscream"
-                },
-                "pt": {
-                    "name": "Waspscream"
-                },
-                "th": {
-                    "name": "Waspscream"
-                },
-                "vi": {
-                    "name": "Waspscream"
-                },
-                "zhhans": {
-                    "name": "Waspscream"
-                },
-                "zhhant": {
                     "name": "Waspscream"
                 }
             }
@@ -2557,10 +1042,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "getrookya",
-                "soldier"
-            ],
+            "traits": ["getrookya", "soldier"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2568,37 +1050,7 @@
             "power": 4,
             "text": "After Fight: Heal up to 2 damage from a creature. For each damage healed this way, exalt that creature.\n",
             "locale": {
-                "de": {
-                    "name": "Bleă-Fŏrh"
-                },
                 "en": {
-                    "name": "Bleă-Fŏrh"
-                },
-                "es": {
-                    "name": "Bleă-Fŏrh"
-                },
-                "fr": {
-                    "name": "Tŏmă-Wăky"
-                },
-                "it": {
-                    "name": "Bleă-Fŏrh"
-                },
-                "pl": {
-                    "name": "Bleă-Fŏrh"
-                },
-                "pt": {
-                    "name": "Bleă-Fŏrh"
-                },
-                "th": {
-                    "name": "Bleă-Fŏrh"
-                },
-                "vi": {
-                    "name": "Bleă-Fŏrh"
-                },
-                "zhhans": {
-                    "name": "Bleă-Fŏrh"
-                },
-                "zhhant": {
                     "name": "Bleă-Fŏrh"
                 }
             }
@@ -2610,11 +1062,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_032_ff278f1127e6_en.png",
             "expansion": 928,
             "house": "ekwidon",
-            "keywords": [],
-            "traits": [
-                "getrookya",
-                "thief"
-            ],
+            "keywords": ["entrench"],
+            "traits": ["getrookya", "thief"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2622,37 +1071,7 @@
             "power": 2,
             "text": "Entrench.\nWhile Bypass Burglar is exhausted, each of its neighbors gains, “Action: Steal 1. Deal 1 to this creature.”\n",
             "locale": {
-                "de": {
-                    "name": "Drahtzieher-Einbrecher"
-                },
                 "en": {
-                    "name": "Bypass Burglar"
-                },
-                "es": {
-                    "name": "Bypass Burglar"
-                },
-                "fr": {
-                    "name": "Avide Commanditaire"
-                },
-                "it": {
-                    "name": "Bypass Burglar"
-                },
-                "pl": {
-                    "name": "Bypass Burglar"
-                },
-                "pt": {
-                    "name": "Bypass Burglar"
-                },
-                "th": {
-                    "name": "Bypass Burglar"
-                },
-                "vi": {
-                    "name": "Bypass Burglar"
-                },
-                "zhhans": {
-                    "name": "Bypass Burglar"
-                },
-                "zhhant": {
                     "name": "Bypass Burglar"
                 }
             }
@@ -2665,10 +1084,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "getrookya",
-                "soldier"
-            ],
+            "traits": ["getrookya", "soldier"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2676,37 +1092,7 @@
             "power": 4,
             "text": "After Fight/After Reap: If you are overwhelmed, destroy an enemy creature. Otherwise, destroy an enemy artifact.\n",
             "locale": {
-                "de": {
-                    "name": "Chromatischer Wächter"
-                },
                 "en": {
-                    "name": "Chromatic Guardian"
-                },
-                "es": {
-                    "name": "Chromatic Guardian"
-                },
-                "fr": {
-                    "name": "Gardien Chromatique"
-                },
-                "it": {
-                    "name": "Chromatic Guardian"
-                },
-                "pl": {
-                    "name": "Chromatic Guardian"
-                },
-                "pt": {
-                    "name": "Chromatic Guardian"
-                },
-                "th": {
-                    "name": "Chromatic Guardian"
-                },
-                "vi": {
-                    "name": "Chromatic Guardian"
-                },
-                "zhhans": {
-                    "name": "Chromatic Guardian"
-                },
-                "zhhant": {
                     "name": "Chromatic Guardian"
                 }
             }
@@ -2719,9 +1105,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "getrookya"
-            ],
+            "traits": ["getrookya"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2729,37 +1113,7 @@
             "power": 2,
             "text": "Enhance .\nPlay: You may move each +1 power counter from a creature to another creature.\n",
             "locale": {
-                "de": {
-                    "name": "Cŏnrăd Fisiquĕ"
-                },
                 "en": {
-                    "name": "Cŏnrăd Fisiquĕ"
-                },
-                "es": {
-                    "name": "Cŏnrăd Fisiquĕ"
-                },
-                "fr": {
-                    "name": "Cŏnrăd Fisiquĕ"
-                },
-                "it": {
-                    "name": "Cŏnrăd Fisiquĕ"
-                },
-                "pl": {
-                    "name": "Cŏnrăd Fisiquĕ"
-                },
-                "pt": {
-                    "name": "Cŏnrăd Fisiquĕ"
-                },
-                "th": {
-                    "name": "Cŏnrăd Fisiquĕ"
-                },
-                "vi": {
-                    "name": "Cŏnrăd Fisiquĕ"
-                },
-                "zhhans": {
-                    "name": "Cŏnrăd Fisiquĕ"
-                },
-                "zhhant": {
                     "name": "Cŏnrăd Fisiquĕ"
                 }
             }
@@ -2772,10 +1126,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "getrookya",
-                "merchant"
-            ],
+            "traits": ["getrookya", "merchant"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2783,37 +1134,7 @@
             "power": 6,
             "text": "Action: Steal 1. Deal 1 to Gemcoat Vendor.\n",
             "locale": {
-                "de": {
-                    "name": "Edelstein-Händler"
-                },
                 "en": {
-                    "name": "Gemcoat Vendor"
-                },
-                "es": {
-                    "name": "Gemcoat Vendor"
-                },
-                "fr": {
-                    "name": "Vendeur Sous Cape"
-                },
-                "it": {
-                    "name": "Gemcoat Vendor"
-                },
-                "pl": {
-                    "name": "Gemcoat Vendor"
-                },
-                "pt": {
-                    "name": "Gemcoat Vendor"
-                },
-                "th": {
-                    "name": "Gemcoat Vendor"
-                },
-                "vi": {
-                    "name": "Gemcoat Vendor"
-                },
-                "zhhans": {
-                    "name": "Gemcoat Vendor"
-                },
-                "zhhant": {
                     "name": "Gemcoat Vendor"
                 }
             }
@@ -2826,10 +1147,7 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [
-                "getrookya",
-                "merchant"
-            ],
+            "traits": ["getrookya", "merchant"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2837,37 +1155,7 @@
             "power": 3,
             "text": "After Reap: Deal 3 to a creature. If this damage destroys that creature, its owner gains 1.\n",
             "locale": {
-                "de": {
-                    "name": "Goldener Dolch"
-                },
                 "en": {
-                    "name": "Golden Dagger"
-                },
-                "es": {
-                    "name": "Golden Dagger"
-                },
-                "fr": {
-                    "name": "Dague d'Or"
-                },
-                "it": {
-                    "name": "Golden Dagger"
-                },
-                "pl": {
-                    "name": "Golden Dagger"
-                },
-                "pt": {
-                    "name": "Golden Dagger"
-                },
-                "th": {
-                    "name": "Golden Dagger"
-                },
-                "vi": {
-                    "name": "Golden Dagger"
-                },
-                "zhhans": {
-                    "name": "Golden Dagger"
-                },
-                "zhhant": {
                     "name": "Golden Dagger"
                 }
             }
@@ -2888,37 +1176,7 @@
             "power": null,
             "text": "Play: Put a creature into its owner’s archives.\n",
             "locale": {
-                "de": {
-                    "name": "Hebevorgänge"
-                },
                 "en": {
-                    "name": "Hoist Operations"
-                },
-                "es": {
-                    "name": "Hoist Operations"
-                },
-                "fr": {
-                    "name": "Opérations de Levage"
-                },
-                "it": {
-                    "name": "Hoist Operations"
-                },
-                "pl": {
-                    "name": "Hoist Operations"
-                },
-                "pt": {
-                    "name": "Hoist Operations"
-                },
-                "th": {
-                    "name": "Hoist Operations"
-                },
-                "vi": {
-                    "name": "Hoist Operations"
-                },
-                "zhhans": {
-                    "name": "Hoist Operations"
-                },
-                "zhhant": {
                     "name": "Hoist Operations"
                 }
             }
@@ -2939,37 +1197,7 @@
             "power": null,
             "text": "Play: Exhaust a creature. If you do, ready a creature.\n",
             "locale": {
-                "de": {
-                    "name": "Warmes Bett"
-                },
                 "en": {
-                    "name": "Hot Bunk"
-                },
-                "es": {
-                    "name": "Hot Bunk"
-                },
-                "fr": {
-                    "name": "Changement de Quart"
-                },
-                "it": {
-                    "name": "Hot Bunk"
-                },
-                "pl": {
-                    "name": "Hot Bunk"
-                },
-                "pt": {
-                    "name": "Hot Bunk"
-                },
-                "th": {
-                    "name": "Hot Bunk"
-                },
-                "vi": {
-                    "name": "Hot Bunk"
-                },
-                "zhhans": {
-                    "name": "Hot Bunk"
-                },
-                "zhhant": {
                     "name": "Hot Bunk"
                 }
             }
@@ -2990,37 +1218,7 @@
             "power": null,
             "text": "Play: Your opponent discards a random card from their hand. For each bonus icon on the discarded card, they lose 1.\n",
             "locale": {
-                "de": {
-                    "name": "Nullsteuer"
-                },
                 "en": {
-                    "name": "Nada Tax"
-                },
-                "es": {
-                    "name": "Nada Tax"
-                },
-                "fr": {
-                    "name": "La Taxe Nada"
-                },
-                "it": {
-                    "name": "Nada Tax"
-                },
-                "pl": {
-                    "name": "Nada Tax"
-                },
-                "pt": {
-                    "name": "Nada Tax"
-                },
-                "th": {
-                    "name": "Nada Tax"
-                },
-                "vi": {
-                    "name": "Nada Tax"
-                },
-                "zhhans": {
-                    "name": "Nada Tax"
-                },
-                "zhhant": {
                     "name": "Nada Tax"
                 }
             }
@@ -3041,37 +1239,7 @@
             "power": null,
             "text": "Play: Return a creature to its owner’s hand and archive a card. If you are overwhelmed, repeat the preceding effect.\n",
             "locale": {
-                "de": {
-                    "name": "Jetzt und später"
-                },
                 "en": {
-                    "name": "Now and Later"
-                },
-                "es": {
-                    "name": "Now and Later"
-                },
-                "fr": {
-                    "name": "Maintenant et Après"
-                },
-                "it": {
-                    "name": "Now and Later"
-                },
-                "pl": {
-                    "name": "Now and Later"
-                },
-                "pt": {
-                    "name": "Now and Later"
-                },
-                "th": {
-                    "name": "Now and Later"
-                },
-                "vi": {
-                    "name": "Now and Later"
-                },
-                "zhhans": {
-                    "name": "Now and Later"
-                },
-                "zhhant": {
                     "name": "Now and Later"
                 }
             }
@@ -3092,37 +1260,7 @@
             "power": null,
             "text": "Play: Exhaust a friendly creature. If you do, steal 2.\n",
             "locale": {
-                "de": {
-                    "name": "Akte"
-                },
                 "en": {
-                    "name": "Permanent Record"
-                },
-                "es": {
-                    "name": "Permanent Record"
-                },
-                "fr": {
-                    "name": "Rodomontade"
-                },
-                "it": {
-                    "name": "Permanent Record"
-                },
-                "pl": {
-                    "name": "Permanent Record"
-                },
-                "pt": {
-                    "name": "Permanent Record"
-                },
-                "th": {
-                    "name": "Permanent Record"
-                },
-                "vi": {
-                    "name": "Permanent Record"
-                },
-                "zhhans": {
-                    "name": "Permanent Record"
-                },
-                "zhhant": {
                     "name": "Permanent Record"
                 }
             }
@@ -3134,13 +1272,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_042_9360c260fee2_en.png",
             "expansion": 928,
             "house": "ekwidon",
-            "keywords": [
-                "taunt"
-            ],
-            "traits": [
-                "getrookya",
-                "soldier"
-            ],
+            "keywords": ["taunt"],
+            "traits": ["getrookya", "soldier"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -3148,37 +1281,7 @@
             "power": 4,
             "text": "Taunt.\nAfter Fight: Move 1 from a creature to the common supply. If you do, draw a card.\n",
             "locale": {
-                "de": {
-                    "name": "Văst Stŏik"
-                },
                 "en": {
-                    "name": "Văst Stŏik"
-                },
-                "es": {
-                    "name": "Văst Stŏik"
-                },
-                "fr": {
-                    "name": "Văst Stŏik"
-                },
-                "it": {
-                    "name": "Văst Stŏik"
-                },
-                "pl": {
-                    "name": "Văst Stŏik"
-                },
-                "pt": {
-                    "name": "Văst Stŏik"
-                },
-                "th": {
-                    "name": "Văst Stŏik"
-                },
-                "vi": {
-                    "name": "Văst Stŏik"
-                },
-                "zhhans": {
-                    "name": "Văst Stŏik"
-                },
-                "zhhant": {
                     "name": "Văst Stŏik"
                 }
             }
@@ -3191,9 +1294,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "item"
-            ],
+            "traits": ["item"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -3201,37 +1302,7 @@
             "power": null,
             "text": "Action: Discard a card. If you do, purge a card of the same type as the discarded card from a discard pile.\n",
             "locale": {
-                "de": {
-                    "name": "Auraskop"
-                },
                 "en": {
-                    "name": "Aurascope"
-                },
-                "es": {
-                    "name": "Aurascope"
-                },
-                "fr": {
-                    "name": "Auratoscope"
-                },
-                "it": {
-                    "name": "Aurascope"
-                },
-                "pl": {
-                    "name": "Aurascope"
-                },
-                "pt": {
-                    "name": "Aurascope"
-                },
-                "th": {
-                    "name": "Aurascope"
-                },
-                "vi": {
-                    "name": "Aurascope"
-                },
-                "zhhans": {
-                    "name": "Aurascope"
-                },
-                "zhhant": {
                     "name": "Aurascope"
                 }
             }
@@ -3252,37 +1323,7 @@
             "power": null,
             "text": "Enhance .\nPlay: A friendly creature captures 3. If you are haunted, put Empathic Malice on the bottom of your deck.\n",
             "locale": {
-                "de": {
-                    "name": "Empathische Bosheit"
-                },
                 "en": {
-                    "name": "Empathic Malice"
-                },
-                "es": {
-                    "name": "Empathic Malice"
-                },
-                "fr": {
-                    "name": "Hypocrisie"
-                },
-                "it": {
-                    "name": "Empathic Malice"
-                },
-                "pl": {
-                    "name": "Empathic Malice"
-                },
-                "pt": {
-                    "name": "Empathic Malice"
-                },
-                "th": {
-                    "name": "Empathic Malice"
-                },
-                "vi": {
-                    "name": "Empathic Malice"
-                },
-                "zhhans": {
-                    "name": "Empathic Malice"
-                },
-                "zhhant": {
                     "name": "Empathic Malice"
                 }
             }
@@ -3303,37 +1344,7 @@
             "power": null,
             "text": "Play: Swap each player's deck with their discard pile. Shuffle each player's deck.\n",
             "locale": {
-                "de": {
-                    "name": "Zukunft ist Vergangenheit"
-                },
                 "en": {
-                    "name": "Future is Past"
-                },
-                "es": {
-                    "name": "Future is Past"
-                },
-                "fr": {
-                    "name": "Avenir Révolu"
-                },
-                "it": {
-                    "name": "Future is Past"
-                },
-                "pl": {
-                    "name": "Future is Past"
-                },
-                "pt": {
-                    "name": "Future is Past"
-                },
-                "th": {
-                    "name": "Future is Past"
-                },
-                "vi": {
-                    "name": "Future is Past"
-                },
-                "zhhans": {
-                    "name": "Future is Past"
-                },
-                "zhhant": {
                     "name": "Future is Past"
                 }
             }
@@ -3346,9 +1357,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "location"
-            ],
+            "traits": ["location"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 1,
@@ -3356,37 +1365,7 @@
             "power": null,
             "text": "Action: If you are haunted, archive a card. Otherwise, discard a card. \n",
             "locale": {
-                "de": {
-                    "name": "Geisterstadt"
-                },
                 "en": {
-                    "name": "Ghost Town"
-                },
-                "es": {
-                    "name": "Ghost Town"
-                },
-                "fr": {
-                    "name": "Ville Fantôme"
-                },
-                "it": {
-                    "name": "Ghost Town"
-                },
-                "pl": {
-                    "name": "Ghost Town"
-                },
-                "pt": {
-                    "name": "Ghost Town"
-                },
-                "th": {
-                    "name": "Ghost Town"
-                },
-                "vi": {
-                    "name": "Ghost Town"
-                },
-                "zhhans": {
-                    "name": "Ghost Town"
-                },
-                "zhhant": {
                     "name": "Ghost Town"
                 }
             }
@@ -3399,10 +1378,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter",
-                "robot"
-            ],
+            "traits": ["specter", "robot"],
             "type": "gigantic creature base",
             "rarity": "Special",
             "amber": 0,
@@ -3410,37 +1386,7 @@
             "power": 8,
             "text": "(Play only with the other half of Gigantor.)\nAfter Fight/After Reap: Purge up to 3 cards from a discard pile. For each card purged this way, draw a card.\n",
             "locale": {
-                "de": {
-                    "name": "Gigantor"
-                },
                 "en": {
-                    "name": "Gigantor"
-                },
-                "es": {
-                    "name": "Gigantor"
-                },
-                "fr": {
-                    "name": "Gigantor"
-                },
-                "it": {
-                    "name": "Gigantor"
-                },
-                "pl": {
-                    "name": "Gigantor"
-                },
-                "pt": {
-                    "name": "Gigantor"
-                },
-                "th": {
-                    "name": "Gigantor"
-                },
-                "vi": {
-                    "name": "Gigantor"
-                },
-                "zhhans": {
-                    "name": "Gigantor"
-                },
-                "zhhant": {
                     "name": "Gigantor"
                 }
             }
@@ -3461,37 +1407,7 @@
             "power": null,
             "text": "",
             "locale": {
-                "de": {
-                    "name": "Gigantor"
-                },
                 "en": {
-                    "name": "Gigantor"
-                },
-                "es": {
-                    "name": "Gigantor"
-                },
-                "fr": {
-                    "name": "Gigantor"
-                },
-                "it": {
-                    "name": "Gigantor"
-                },
-                "pl": {
-                    "name": "Gigantor"
-                },
-                "pt": {
-                    "name": "Gigantor"
-                },
-                "th": {
-                    "name": "Gigantor"
-                },
-                "vi": {
-                    "name": "Gigantor"
-                },
-                "zhhans": {
-                    "name": "Gigantor"
-                },
-                "zhhant": {
                     "name": "Gigantor"
                 }
             }
@@ -3504,10 +1420,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "ai",
-                "specter"
-            ],
+            "traits": ["ai", "specter"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3515,37 +1428,7 @@
             "power": 3,
             "text": "Enhance .\nEach friendly Geistoid creature gains versatile.\n",
             "locale": {
-                "de": {
-                    "name": "Holografische Todesfee"
-                },
                 "en": {
-                    "name": "Holographic Banshee"
-                },
-                "es": {
-                    "name": "Holographic Banshee"
-                },
-                "fr": {
-                    "name": "Hurlographique"
-                },
-                "it": {
-                    "name": "Holographic Banshee"
-                },
-                "pl": {
-                    "name": "Holographic Banshee"
-                },
-                "pt": {
-                    "name": "Holographic Banshee"
-                },
-                "th": {
-                    "name": "Holographic Banshee"
-                },
-                "vi": {
-                    "name": "Holographic Banshee"
-                },
-                "zhhans": {
-                    "name": "Holographic Banshee"
-                },
-                "zhhant": {
                     "name": "Holographic Banshee"
                 }
             }
@@ -3558,10 +1441,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter",
-                "robot"
-            ],
+            "traits": ["specter", "robot"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3569,37 +1449,7 @@
             "power": 3,
             "text": "Enhance .\nEach friendly creature with  on it gains, “After Reap: Move 1 from this creature to your pool.”\n",
             "locale": {
-                "de": {
-                    "name": "Jahnspuk"
-                },
                 "en": {
-                    "name": "Jahneerie"
-                },
-                "es": {
-                    "name": "Jahneerie"
-                },
-                "fr": {
-                    "name": "Jane Eerie"
-                },
-                "it": {
-                    "name": "Jahneerie"
-                },
-                "pl": {
-                    "name": "Jahneerie"
-                },
-                "pt": {
-                    "name": "Jahneerie"
-                },
-                "th": {
-                    "name": "Jahneerie"
-                },
-                "vi": {
-                    "name": "Jahneerie"
-                },
-                "zhhans": {
-                    "name": "Jahneerie"
-                },
-                "zhhant": {
                     "name": "Jahneerie"
                 }
             }
@@ -3612,10 +1462,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter",
-                "robot"
-            ],
+            "traits": ["specter", "robot"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3623,37 +1470,7 @@
             "power": 3,
             "text": "After a friendly Geistoid creature enters play, each player discards the top 2 cards of their deck.\nAfter Reap: Play the topmost creature from your discard pile.\n",
             "locale": {
-                "de": {
-                    "name": "Fräulein Unfug"
-                },
                 "en": {
-                    "name": "Miss Chievous"
-                },
-                "es": {
-                    "name": "Miss Chievous"
-                },
-                "fr": {
-                    "name": "Ma' Licieuse"
-                },
-                "it": {
-                    "name": "Miss Chievous"
-                },
-                "pl": {
-                    "name": "Miss Chievous"
-                },
-                "pt": {
-                    "name": "Miss Chievous"
-                },
-                "th": {
-                    "name": "Miss Chievous"
-                },
-                "vi": {
-                    "name": "Miss Chievous"
-                },
-                "zhhans": {
-                    "name": "Miss Chievous"
-                },
-                "zhhant": {
                     "name": "Miss Chievous"
                 }
             }
@@ -3666,9 +1483,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter"
-            ],
+            "traits": ["specter"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3676,37 +1491,7 @@
             "power": 2,
             "text": "Play: Gain 1 for each card in your opponent’s archives. Your opponent discards each card in their archives.\n",
             "locale": {
-                "de": {
-                    "name": "P.K.E.-Absauger"
-                },
                 "en": {
-                    "name": "P.K.E. Syphonator"
-                },
-                "es": {
-                    "name": "P.K.E. Syphonator"
-                },
-                "fr": {
-                    "name": "Sniffeur P.K.E"
-                },
-                "it": {
-                    "name": "P.K.E. Syphonator"
-                },
-                "pl": {
-                    "name": "P.K.E. Syphonator"
-                },
-                "pt": {
-                    "name": "P.K.E. Syphonator"
-                },
-                "th": {
-                    "name": "P.K.E. Syphonator"
-                },
-                "vi": {
-                    "name": "P.K.E. Syphonator"
-                },
-                "zhhans": {
-                    "name": "P.K.E. Syphonator"
-                },
-                "zhhant": {
                     "name": "P.K.E. Syphonator"
                 }
             }
@@ -3727,37 +1512,7 @@
             "power": null,
             "text": "This creature gains, “After Reap: If you are haunted, gain 2.”\n",
             "locale": {
-                "de": {
-                    "name": "Phantastischer Mantel"
-                },
                 "en": {
-                    "name": "Phantasm Cloak"
-                },
-                "es": {
-                    "name": "Phantasm Cloak"
-                },
-                "fr": {
-                    "name": "Cape Fantômatique"
-                },
-                "it": {
-                    "name": "Phantasm Cloak"
-                },
-                "pl": {
-                    "name": "Phantasm Cloak"
-                },
-                "pt": {
-                    "name": "Phantasm Cloak"
-                },
-                "th": {
-                    "name": "Phantasm Cloak"
-                },
-                "vi": {
-                    "name": "Phantasm Cloak"
-                },
-                "zhhans": {
-                    "name": "Phantasm Cloak"
-                },
-                "zhhant": {
                     "name": "Phantasm Cloak"
                 }
             }
@@ -3778,37 +1533,7 @@
             "power": null,
             "text": "Play: Purge a card from a discard pile. If you do, play a creature or artifact from your purged zone as if it were in your hand. Attach Poltergeistoids to it as an upgrade with the text, “This card belongs to house Geistoid.”\n",
             "locale": {
-                "de": {
-                    "name": "Poltergeistoiden"
-                },
                 "en": {
-                    "name": "Poltergeistoids"
-                },
-                "es": {
-                    "name": "Poltergeistoids"
-                },
-                "fr": {
-                    "name": "Polterspectroïdes"
-                },
-                "it": {
-                    "name": "Poltergeistoids"
-                },
-                "pl": {
-                    "name": "Poltergeistoids"
-                },
-                "pt": {
-                    "name": "Poltergeistoids"
-                },
-                "th": {
-                    "name": "Poltergeistoids"
-                },
-                "vi": {
-                    "name": "Poltergeistoids"
-                },
-                "zhhans": {
-                    "name": "Poltergeistoids"
-                },
-                "zhhant": {
                     "name": "Poltergeistoids"
                 }
             }
@@ -3820,12 +1545,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_054_b147e0a64fe2_en.png",
             "expansion": 928,
             "house": "geistoid",
-            "keywords": [
-                "taunt"
-            ],
-            "traits": [
-                "specter"
-            ],
+            "keywords": ["taunt"],
+            "traits": ["specter"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3833,37 +1554,7 @@
             "power": 3,
             "text": "Taunt.\nWhile you are haunted, Protective Playmate gets +6 power. Otherwise, Protective Playmate gains elusive.\n",
             "locale": {
-                "de": {
-                    "name": "Beschützender Kamerad"
-                },
                 "en": {
-                    "name": "Protective Playmate"
-                },
-                "es": {
-                    "name": "Protective Playmate"
-                },
-                "fr": {
-                    "name": "Parangon"
-                },
-                "it": {
-                    "name": "Protective Playmate"
-                },
-                "pl": {
-                    "name": "Protective Playmate"
-                },
-                "pt": {
-                    "name": "Protective Playmate"
-                },
-                "th": {
-                    "name": "Protective Playmate"
-                },
-                "vi": {
-                    "name": "Protective Playmate"
-                },
-                "zhhans": {
-                    "name": "Protective Playmate"
-                },
-                "zhhant": {
                     "name": "Protective Playmate"
                 }
             }
@@ -3884,37 +1575,7 @@
             "power": null,
             "text": "Play: Destroy each creature that is not on a flank. Put a creature from any discard pile into play under your control. Gain 2 chains.\n",
             "locale": {
-                "de": {
-                    "name": "Hülle eines Geistes"
-                },
                 "en": {
-                    "name": "Shell of a Ghost"
-                },
-                "es": {
-                    "name": "Shell of a Ghost"
-                },
-                "fr": {
-                    "name": "Équiper les Morts"
-                },
-                "it": {
-                    "name": "Shell of a Ghost"
-                },
-                "pl": {
-                    "name": "Shell of a Ghost"
-                },
-                "pt": {
-                    "name": "Shell of a Ghost"
-                },
-                "th": {
-                    "name": "Shell of a Ghost"
-                },
-                "vi": {
-                    "name": "Shell of a Ghost"
-                },
-                "zhhans": {
-                    "name": "Shell of a Ghost"
-                },
-                "zhhant": {
                     "name": "Shell of a Ghost"
                 }
             }
@@ -3935,37 +1596,7 @@
             "power": null,
             "text": "Play: Destroy each creature. Each player reveals their hand and discards each creature revealed this way. Each player refills their hand as if it were their “draw cards” step.\n",
             "locale": {
-                "de": {
-                    "name": "Müllhalde"
-                },
                 "en": {
-                    "name": "Trash Heap"
-                },
-                "es": {
-                    "name": "Trash Heap"
-                },
-                "fr": {
-                    "name": "Tas d'Ordures"
-                },
-                "it": {
-                    "name": "Trash Heap"
-                },
-                "pl": {
-                    "name": "Trash Heap"
-                },
-                "pt": {
-                    "name": "Trash Heap"
-                },
-                "th": {
-                    "name": "Trash Heap"
-                },
-                "vi": {
-                    "name": "Trash Heap"
-                },
-                "zhhans": {
-                    "name": "Trash Heap"
-                },
-                "zhhant": {
                     "name": "Trash Heap"
                 }
             }
@@ -3978,10 +1609,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter",
-                "robot"
-            ],
+            "traits": ["specter", "robot"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3989,37 +1617,7 @@
             "power": 4,
             "text": "Varad the Indulgent gets +1 power for each  on it.\nAfter another friendly Geistoid creature fights, Varad the Indulgent captures 1.\n",
             "locale": {
-                "de": {
-                    "name": "Varad der Nachsichtige"
-                },
                 "en": {
-                    "name": "Varad the Indulgent"
-                },
-                "es": {
-                    "name": "Varad the Indulgent"
-                },
-                "fr": {
-                    "name": "Alvad l'Indulgent"
-                },
-                "it": {
-                    "name": "Varad the Indulgent"
-                },
-                "pl": {
-                    "name": "Varad the Indulgent"
-                },
-                "pt": {
-                    "name": "Varad the Indulgent"
-                },
-                "th": {
-                    "name": "Varad the Indulgent"
-                },
-                "vi": {
-                    "name": "Varad the Indulgent"
-                },
-                "zhhans": {
-                    "name": "Varad the Indulgent"
-                },
-                "zhhant": {
                     "name": "Varad the Indulgent"
                 }
             }
@@ -4032,9 +1630,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "power"
-            ],
+            "traits": ["power"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 1,
@@ -4042,37 +1638,7 @@
             "power": null,
             "text": "Omni: Name a card. Until the start of your next turn, cards with that name cannot be played or used. Gain 2 chains.\nScrap: Purge a card from your opponent's discard pile. Your opponent shuffles their discard pile into their deck.\n",
             "locale": {
-                "de": {
-                    "name": "Varghasts Rache"
-                },
                 "en": {
-                    "name": "Varghast’s Vengeance"
-                },
-                "es": {
-                    "name": "Varghast’s Vengeance"
-                },
-                "fr": {
-                    "name": "Vengeance de Varghast"
-                },
-                "it": {
-                    "name": "Varghast’s Vengeance"
-                },
-                "pl": {
-                    "name": "Varghast’s Vengeance"
-                },
-                "pt": {
-                    "name": "Varghast’s Vengeance"
-                },
-                "th": {
-                    "name": "Varghast’s Vengeance"
-                },
-                "vi": {
-                    "name": "Varghast’s Vengeance"
-                },
-                "zhhans": {
-                    "name": "Varghast’s Vengeance"
-                },
-                "zhhant": {
                     "name": "Varghast’s Vengeance"
                 }
             }
@@ -4093,37 +1659,7 @@
             "power": null,
             "text": "Play: Purge a card from your discard pile. If you do, a friendly creature captures 2.\n",
             "locale": {
-                "de": {
-                    "name": "Apoptose"
-                },
                 "en": {
-                    "name": "Apoptosis"
-                },
-                "es": {
-                    "name": "Apoptosis"
-                },
-                "fr": {
-                    "name": "Apoptose"
-                },
-                "it": {
-                    "name": "Apoptosis"
-                },
-                "pl": {
-                    "name": "Apoptosis"
-                },
-                "pt": {
-                    "name": "Apoptosis"
-                },
-                "th": {
-                    "name": "Apoptosis"
-                },
-                "vi": {
-                    "name": "Apoptosis"
-                },
-                "zhhans": {
-                    "name": "Apoptosis"
-                },
-                "zhhant": {
                     "name": "Apoptosis"
                 }
             }
@@ -4136,10 +1672,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter",
-                "robot"
-            ],
+            "traits": ["specter", "robot"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -4147,37 +1680,7 @@
             "power": 2,
             "text": "Destroyed: Deal 6 to each enemy flank creature.\nScrap: Deal 1 to each enemy creature.\n",
             "locale": {
-                "de": {
-                    "name": "Dampfkessel"
-                },
                 "en": {
-                    "name": "Boiler"
-                },
-                "es": {
-                    "name": "Boiler"
-                },
-                "fr": {
-                    "name": "Chaudière"
-                },
-                "it": {
-                    "name": "Boiler"
-                },
-                "pl": {
-                    "name": "Boiler"
-                },
-                "pt": {
-                    "name": "Boiler"
-                },
-                "th": {
-                    "name": "Boiler"
-                },
-                "vi": {
-                    "name": "Boiler"
-                },
-                "zhhans": {
-                    "name": "Boiler"
-                },
-                "zhhant": {
                     "name": "Boiler"
                 }
             }
@@ -4198,37 +1701,7 @@
             "power": null,
             "text": "Play: Choose a friendly creature. Move each  from that creature to your pool. Destroy that creature.\n",
             "locale": {
-                "de": {
-                    "name": "Dämmerungsstrahlen"
-                },
                 "en": {
-                    "name": "Crepuscular Rays"
-                },
-                "es": {
-                    "name": "Crepuscular Rays"
-                },
-                "fr": {
-                    "name": "Rayons Crépusculaires"
-                },
-                "it": {
-                    "name": "Crepuscular Rays"
-                },
-                "pl": {
-                    "name": "Crepuscular Rays"
-                },
-                "pt": {
-                    "name": "Crepuscular Rays"
-                },
-                "th": {
-                    "name": "Crepuscular Rays"
-                },
-                "vi": {
-                    "name": "Crepuscular Rays"
-                },
-                "zhhans": {
-                    "name": "Crepuscular Rays"
-                },
-                "zhhant": {
                     "name": "Crepuscular Rays"
                 }
             }
@@ -4241,10 +1714,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter",
-                "ai"
-            ],
+            "traits": ["specter", "ai"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -4252,37 +1722,7 @@
             "power": 2,
             "text": "Play: Draw 3 cards. Discard 2 cards. Archive a card.\n",
             "locale": {
-                "de": {
-                    "name": "Datamator"
-                },
                 "en": {
-                    "name": "Dammater"
-                },
-                "es": {
-                    "name": "Dammater"
-                },
-                "fr": {
-                    "name": "Dammater"
-                },
-                "it": {
-                    "name": "Dammater"
-                },
-                "pl": {
-                    "name": "Dammater"
-                },
-                "pt": {
-                    "name": "Dammater"
-                },
-                "th": {
-                    "name": "Dammater"
-                },
-                "vi": {
-                    "name": "Dammater"
-                },
-                "zhhans": {
-                    "name": "Dammater"
-                },
-                "zhhant": {
                     "name": "Dammater"
                 }
             }
@@ -4303,37 +1743,7 @@
             "power": null,
             "text": "Play: Shuffle Out of Ideas and the top card of your discard pile into their owner’s deck.\n",
             "locale": {
-                "de": {
-                    "name": "Keine Ideen mehr"
-                },
                 "en": {
-                    "name": "Out of Ideas"
-                },
-                "es": {
-                    "name": "Out of Ideas"
-                },
-                "fr": {
-                    "name": "À Court d'Idées"
-                },
-                "it": {
-                    "name": "Out of Ideas"
-                },
-                "pl": {
-                    "name": "Out of Ideas"
-                },
-                "pt": {
-                    "name": "Out of Ideas"
-                },
-                "th": {
-                    "name": "Out of Ideas"
-                },
-                "vi": {
-                    "name": "Out of Ideas"
-                },
-                "zhhans": {
-                    "name": "Out of Ideas"
-                },
-                "zhhant": {
                     "name": "Out of Ideas"
                 }
             }
@@ -4345,11 +1755,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_064_dc904f55b95a_en.png",
             "expansion": 928,
             "house": "geistoid",
-            "keywords": [],
-            "traits": [
-                "specter",
-                "item"
-            ],
+            "keywords": ["entrench"],
+            "traits": ["specter", "item"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -4357,37 +1764,7 @@
             "power": 3,
             "text": "Entrench.\nWhile Paranormal Palisade is exhausted, it gets +4 armor and gains taunt.\n",
             "locale": {
-                "de": {
-                    "name": "Paranormale Palisade"
-                },
                 "en": {
-                    "name": "Paranormal Palisade"
-                },
-                "es": {
-                    "name": "Paranormal Palisade"
-                },
-                "fr": {
-                    "name": "Palissade Paranormale"
-                },
-                "it": {
-                    "name": "Paranormal Palisade"
-                },
-                "pl": {
-                    "name": "Paranormal Palisade"
-                },
-                "pt": {
-                    "name": "Paranormal Palisade"
-                },
-                "th": {
-                    "name": "Paranormal Palisade"
-                },
-                "vi": {
-                    "name": "Paranormal Palisade"
-                },
-                "zhhans": {
-                    "name": "Paranormal Palisade"
-                },
-                "zhhant": {
                     "name": "Paranormal Palisade"
                 }
             }
@@ -4408,37 +1785,7 @@
             "power": null,
             "text": "Play: Shuffle the top 10 cards of your discard pile into your deck. If you do, destroy each creature.\n",
             "locale": {
-                "de": {
-                    "name": "Asche zu Asche"
-                },
                 "en": {
-                    "name": "Return to Rubble"
-                },
-                "es": {
-                    "name": "Return to Rubble"
-                },
-                "fr": {
-                    "name": "Redevenir Poussière"
-                },
-                "it": {
-                    "name": "Return to Rubble"
-                },
-                "pl": {
-                    "name": "Return to Rubble"
-                },
-                "pt": {
-                    "name": "Return to Rubble"
-                },
-                "th": {
-                    "name": "Return to Rubble"
-                },
-                "vi": {
-                    "name": "Return to Rubble"
-                },
-                "zhhans": {
-                    "name": "Return to Rubble"
-                },
-                "zhhant": {
                     "name": "Return to Rubble"
                 }
             }
@@ -4459,37 +1806,7 @@
             "power": null,
             "text": "Play: If your opponent is haunted, destroy an enemy artifact, Cyborg creature, or Robot creature. If you do, play that card as if it were in your hand. Attach Spontaneous Awakening to it as an upgrade with the text, “This card belongs to house Geistoid.”\n",
             "locale": {
-                "de": {
-                    "name": "Spontanes Erwachen"
-                },
                 "en": {
-                    "name": "Spontaneous Awakening"
-                },
-                "es": {
-                    "name": "Spontaneous Awakening"
-                },
-                "fr": {
-                    "name": "Réveil Spontané"
-                },
-                "it": {
-                    "name": "Spontaneous Awakening"
-                },
-                "pl": {
-                    "name": "Spontaneous Awakening"
-                },
-                "pt": {
-                    "name": "Spontaneous Awakening"
-                },
-                "th": {
-                    "name": "Spontaneous Awakening"
-                },
-                "vi": {
-                    "name": "Spontaneous Awakening"
-                },
-                "zhhans": {
-                    "name": "Spontaneous Awakening"
-                },
-                "zhhant": {
                     "name": "Spontaneous Awakening"
                 }
             }
@@ -4502,10 +1819,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter",
-                "robot"
-            ],
+            "traits": ["specter", "robot"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -4513,37 +1827,7 @@
             "power": 3,
             "text": "After Fight/After Reap: Your opponent shuffles a random card from their hand into their deck.\n",
             "locale": {
-                "de": {
-                    "name": "Techno-Schatten"
-                },
                 "en": {
-                    "name": "Techno-Shade"
-                },
-                "es": {
-                    "name": "Techno-Shade"
-                },
-                "fr": {
-                    "name": "Techn'Ombre"
-                },
-                "it": {
-                    "name": "Techno-Shade"
-                },
-                "pl": {
-                    "name": "Techno-Shade"
-                },
-                "pt": {
-                    "name": "Techno-Shade"
-                },
-                "th": {
-                    "name": "Techno-Shade"
-                },
-                "vi": {
-                    "name": "Techno-Shade"
-                },
-                "zhhans": {
-                    "name": "Techno-Shade"
-                },
-                "zhhant": {
                     "name": "Techno-Shade"
                 }
             }
@@ -4556,10 +1840,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter",
-                "robot"
-            ],
+            "traits": ["specter", "robot"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -4567,37 +1848,7 @@
             "power": 5,
             "text": "Enhance .\nEach friendly creature with  on it gains, “Destroyed: Draw 1 card.”\n",
             "locale": {
-                "de": {
-                    "name": "Gedankenfänger"
-                },
                 "en": {
-                    "name": "Thoughtcatcher"
-                },
-                "es": {
-                    "name": "Thoughtcatcher"
-                },
-                "fr": {
-                    "name": "Attrape-Pensées"
-                },
-                "it": {
-                    "name": "Thoughtcatcher"
-                },
-                "pl": {
-                    "name": "Thoughtcatcher"
-                },
-                "pt": {
-                    "name": "Thoughtcatcher"
-                },
-                "th": {
-                    "name": "Thoughtcatcher"
-                },
-                "vi": {
-                    "name": "Thoughtcatcher"
-                },
-                "zhhans": {
-                    "name": "Thoughtcatcher"
-                },
-                "zhhant": {
                     "name": "Thoughtcatcher"
                 }
             }
@@ -4609,13 +1860,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_069_d555c9c62e62_en.png",
             "expansion": 928,
             "house": "geistoid",
-            "keywords": [
-                "taunt"
-            ],
-            "traits": [
-                "specter",
-                "cyborg"
-            ],
+            "keywords": ["taunt"],
+            "traits": ["specter", "cyborg"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -4623,37 +1869,7 @@
             "power": 6,
             "text": "Taunt.\nDestroyed: If it is not your turn, your opponent discards 5 cards from the top of their deck. Otherwise, discard 5 cards from the top of your deck.\n",
             "locale": {
-                "de": {
-                    "name": "Titanische Erscheinung"
-                },
                 "en": {
-                    "name": "Titan Apparition"
-                },
-                "es": {
-                    "name": "Titan Apparition"
-                },
-                "fr": {
-                    "name": "Titan Revenant"
-                },
-                "it": {
-                    "name": "Titan Apparition"
-                },
-                "pl": {
-                    "name": "Titan Apparition"
-                },
-                "pt": {
-                    "name": "Titan Apparition"
-                },
-                "th": {
-                    "name": "Titan Apparition"
-                },
-                "vi": {
-                    "name": "Titan Apparition"
-                },
-                "zhhans": {
-                    "name": "Titan Apparition"
-                },
-                "zhhant": {
                     "name": "Titan Apparition"
                 }
             }
@@ -4665,13 +1881,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_070_6168d3d312c9_en.png",
             "expansion": 928,
             "house": "geistoid",
-            "keywords": [
-                "taunt"
-            ],
-            "traits": [
-                "specter",
-                "robot"
-            ],
+            "keywords": ["taunt"],
+            "traits": ["specter", "robot"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -4679,37 +1890,7 @@
             "power": 4,
             "text": "Taunt.\nPlay/After Fight: A friendly creature captures 1.\n",
             "locale": {
-                "de": {
-                    "name": "Tributsammler"
-                },
                 "en": {
-                    "name": "Tribute Collector"
-                },
-                "es": {
-                    "name": "Tribute Collector"
-                },
-                "fr": {
-                    "name": "Collecteur de Tributs"
-                },
-                "it": {
-                    "name": "Tribute Collector"
-                },
-                "pl": {
-                    "name": "Tribute Collector"
-                },
-                "pt": {
-                    "name": "Tribute Collector"
-                },
-                "th": {
-                    "name": "Tribute Collector"
-                },
-                "vi": {
-                    "name": "Tribute Collector"
-                },
-                "zhhans": {
-                    "name": "Tribute Collector"
-                },
-                "zhhant": {
                     "name": "Tribute Collector"
                 }
             }
@@ -4730,37 +1911,7 @@
             "power": null,
             "text": "Play: Forge a key at +20 current cost, reduced by 1 for each card in your discard pile (to a minimum of 6). If you do, purge Ecto-Charge.\n",
             "locale": {
-                "de": {
-                    "name": "Ekto-Ladung"
-                },
                 "en": {
-                    "name": "Ecto-Charge"
-                },
-                "es": {
-                    "name": "Ecto-Charge"
-                },
-                "fr": {
-                    "name": "Ecto-Charge"
-                },
-                "it": {
-                    "name": "Ecto-Charge"
-                },
-                "pl": {
-                    "name": "Ecto-Charge"
-                },
-                "pt": {
-                    "name": "Ecto-Charge"
-                },
-                "th": {
-                    "name": "Ecto-Charge"
-                },
-                "vi": {
-                    "name": "Ecto-Charge"
-                },
-                "zhhans": {
-                    "name": "Ecto-Charge"
-                },
-                "zhhant": {
                     "name": "Ecto-Charge"
                 }
             }
@@ -4772,11 +1923,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_072_3ca64451692d_en.png",
             "expansion": 928,
             "house": "geistoid",
-            "keywords": [],
-            "traits": [
-                "specter",
-                "robot"
-            ],
+            "keywords": ["entrench"],
+            "traits": ["specter", "robot"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -4784,37 +1932,7 @@
             "power": 3,
             "text": "Entrench.\nWhile Fading Apparition is exhausted, any  you would gain by reaping may be taken from  among friendly creatures instead of the common supply.\n",
             "locale": {
-                "de": {
-                    "name": "Verblassende Erscheinung"
-                },
                 "en": {
-                    "name": "Fading Apparition"
-                },
-                "es": {
-                    "name": "Fading Apparition"
-                },
-                "fr": {
-                    "name": "Apparition Estompée"
-                },
-                "it": {
-                    "name": "Fading Apparition"
-                },
-                "pl": {
-                    "name": "Fading Apparition"
-                },
-                "pt": {
-                    "name": "Fading Apparition"
-                },
-                "th": {
-                    "name": "Fading Apparition"
-                },
-                "vi": {
-                    "name": "Fading Apparition"
-                },
-                "zhhans": {
-                    "name": "Fading Apparition"
-                },
-                "zhhant": {
                     "name": "Fading Apparition"
                 }
             }
@@ -4827,10 +1945,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter",
-                "robot"
-            ],
+            "traits": ["specter", "robot"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -4838,37 +1953,7 @@
             "power": 2,
             "text": "After Reap: Deal 2 to a creature. If this damage destroys that creature, give a friendly creature two +1 power counters.\n",
             "locale": {
-                "de": {
-                    "name": "Hammer-Schmied"
-                },
                 "en": {
-                    "name": "Hammer Smythe"
-                },
-                "es": {
-                    "name": "Hammer Smythe"
-                },
-                "fr": {
-                    "name": "Plume l'Enclume"
-                },
-                "it": {
-                    "name": "Hammer Smythe"
-                },
-                "pl": {
-                    "name": "Hammer Smythe"
-                },
-                "pt": {
-                    "name": "Hammer Smythe"
-                },
-                "th": {
-                    "name": "Hammer Smythe"
-                },
-                "vi": {
-                    "name": "Hammer Smythe"
-                },
-                "zhhans": {
-                    "name": "Hammer Smythe"
-                },
-                "zhhant": {
                     "name": "Hammer Smythe"
                 }
             }
@@ -4889,37 +1974,7 @@
             "power": null,
             "text": "Enhance . (These icons have already been added to cards in your deck.)\nPlay: If you are haunted, purge a card from a discard pile.\n",
             "locale": {
-                "de": {
-                    "name": "Spukdeck"
-                },
                 "en": {
-                    "name": "Haunting Deck"
-                },
-                "es": {
-                    "name": "Haunting Deck"
-                },
-                "fr": {
-                    "name": "Pont Hanté"
-                },
-                "it": {
-                    "name": "Haunting Deck"
-                },
-                "pl": {
-                    "name": "Haunting Deck"
-                },
-                "pt": {
-                    "name": "Haunting Deck"
-                },
-                "th": {
-                    "name": "Haunting Deck"
-                },
-                "vi": {
-                    "name": "Haunting Deck"
-                },
-                "zhhans": {
-                    "name": "Haunting Deck"
-                },
-                "zhhant": {
                     "name": "Haunting Deck"
                 }
             }
@@ -4940,37 +1995,7 @@
             "power": null,
             "text": "Play: Discard the top 6 cards of your deck. You may put a non-Geistoid card discarded this way into your hand.\n",
             "locale": {
-                "de": {
-                    "name": "Spukmaßnahmen"
-                },
                 "en": {
-                    "name": "Haunting Measures"
-                },
-                "es": {
-                    "name": "Haunting Measures"
-                },
-                "fr": {
-                    "name": "Décantation"
-                },
-                "it": {
-                    "name": "Haunting Measures"
-                },
-                "pl": {
-                    "name": "Haunting Measures"
-                },
-                "pt": {
-                    "name": "Haunting Measures"
-                },
-                "th": {
-                    "name": "Haunting Measures"
-                },
-                "vi": {
-                    "name": "Haunting Measures"
-                },
-                "zhhans": {
-                    "name": "Haunting Measures"
-                },
-                "zhhant": {
                     "name": "Haunting Measures"
                 }
             }
@@ -4983,10 +2008,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter",
-                "robot"
-            ],
+            "traits": ["specter", "robot"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -4994,37 +2016,7 @@
             "power": 3,
             "text": "After Fight: If you are overwhelmed, an enemy creature captures 1 from its own side. Otherwise, capture 1.\n",
             "locale": {
-                "de": {
-                    "name": "Schrott-Jimmy"
-                },
                 "en": {
-                    "name": "Janky Jimmy"
-                },
-                "es": {
-                    "name": "Janky Jimmy"
-                },
-                "fr": {
-                    "name": "Pascal le Bancal"
-                },
-                "it": {
-                    "name": "Janky Jimmy"
-                },
-                "pl": {
-                    "name": "Janky Jimmy"
-                },
-                "pt": {
-                    "name": "Janky Jimmy"
-                },
-                "th": {
-                    "name": "Janky Jimmy"
-                },
-                "vi": {
-                    "name": "Janky Jimmy"
-                },
-                "zhhans": {
-                    "name": "Janky Jimmy"
-                },
-                "zhhant": {
                     "name": "Janky Jimmy"
                 }
             }
@@ -5037,10 +2029,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter",
-                "faerie"
-            ],
+            "traits": ["specter", "faerie"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -5048,37 +2037,7 @@
             "power": 1,
             "text": "Play/Destroyed: Archive the top card of your discard pile.\n",
             "locale": {
-                "de": {
-                    "name": "Memette"
-                },
                 "en": {
-                    "name": "Memette"
-                },
-                "es": {
-                    "name": "Memette"
-                },
-                "fr": {
-                    "name": "Mémotte"
-                },
-                "it": {
-                    "name": "Memette"
-                },
-                "pl": {
-                    "name": "Memette"
-                },
-                "pt": {
-                    "name": "Memette"
-                },
-                "th": {
-                    "name": "Memette"
-                },
-                "vi": {
-                    "name": "Memette"
-                },
-                "zhhans": {
-                    "name": "Memette"
-                },
-                "zhhant": {
                     "name": "Memette"
                 }
             }
@@ -5099,37 +2058,7 @@
             "power": null,
             "text": "Enhance .\nPlay: A friendly creature captures 1. Give control of that creature to your opponent.\n",
             "locale": {
-                "de": {
-                    "name": "Alter Tauschtrick"
-                },
                 "en": {
-                    "name": "Ol’ Switcheroo"
-                },
-                "es": {
-                    "name": "Ol’ Switcheroo"
-                },
-                "fr": {
-                    "name": "Bon Vieux Troc"
-                },
-                "it": {
-                    "name": "Ol’ Switcheroo"
-                },
-                "pl": {
-                    "name": "Ol’ Switcheroo"
-                },
-                "pt": {
-                    "name": "Ol’ Switcheroo"
-                },
-                "th": {
-                    "name": "Ol’ Switcheroo"
-                },
-                "vi": {
-                    "name": "Ol’ Switcheroo"
-                },
-                "zhhans": {
-                    "name": "Ol’ Switcheroo"
-                },
-                "zhhant": {
                     "name": "Ol’ Switcheroo"
                 }
             }
@@ -5142,10 +2071,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter",
-                "cyborg"
-            ],
+            "traits": ["specter", "cyborg"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -5153,37 +2079,7 @@
             "power": 2,
             "text": "Enhance .\nAfter Reap: Discard a card. If you do, give a creature two +1 power counters.\n",
             "locale": {
-                "de": {
-                    "name": "Rezyklops"
-                },
                 "en": {
-                    "name": "Recyclops"
-                },
-                "es": {
-                    "name": "Recyclops"
-                },
-                "fr": {
-                    "name": "Recyclope"
-                },
-                "it": {
-                    "name": "Recyclops"
-                },
-                "pl": {
-                    "name": "Recyclops"
-                },
-                "pt": {
-                    "name": "Recyclops"
-                },
-                "th": {
-                    "name": "Recyclops"
-                },
-                "vi": {
-                    "name": "Recyclops"
-                },
-                "zhhans": {
-                    "name": "Recyclops"
-                },
-                "zhhant": {
                     "name": "Recyclops"
                 }
             }
@@ -5204,37 +2100,7 @@
             "power": null,
             "text": "Play: If you are haunted, deal 5 to a creature. Otherwise, return a creature to its owner’s hand.\n",
             "locale": {
-                "de": {
-                    "name": "Zerlegen und Wiederverwerten"
-                },
                 "en": {
-                    "name": "Reduce, Reuse"
-                },
-                "es": {
-                    "name": "Reduce, Reuse"
-                },
-                "fr": {
-                    "name": "Réduire, Réutiliser"
-                },
-                "it": {
-                    "name": "Reduce, Reuse"
-                },
-                "pl": {
-                    "name": "Reduce, Reuse"
-                },
-                "pt": {
-                    "name": "Reduce, Reuse"
-                },
-                "th": {
-                    "name": "Reduce, Reuse"
-                },
-                "vi": {
-                    "name": "Reduce, Reuse"
-                },
-                "zhhans": {
-                    "name": "Reduce, Reuse"
-                },
-                "zhhant": {
                     "name": "Reduce, Reuse"
                 }
             }
@@ -5246,13 +2112,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_081_b6cde23ea192_en.png",
             "expansion": 928,
             "house": "geistoid",
-            "keywords": [
-                "taunt"
-            ],
-            "traits": [
-                "specter",
-                "robot"
-            ],
+            "keywords": ["taunt"],
+            "traits": ["specter", "robot"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -5260,37 +2121,7 @@
             "power": 4,
             "text": "Taunt. \nIf you are overwhelmed, Spikey Goeff gains hazardous 2.\nScrap: Deal 2 to a creature.\n",
             "locale": {
-                "de": {
-                    "name": "Goeff der Stachelige"
-                },
                 "en": {
-                    "name": "Spikey Goeff"
-                },
-                "es": {
-                    "name": "Spikey Goeff"
-                },
-                "fr": {
-                    "name": "Geoff le Hérissé"
-                },
-                "it": {
-                    "name": "Spikey Goeff"
-                },
-                "pl": {
-                    "name": "Spikey Goeff"
-                },
-                "pt": {
-                    "name": "Spikey Goeff"
-                },
-                "th": {
-                    "name": "Spikey Goeff"
-                },
-                "vi": {
-                    "name": "Spikey Goeff"
-                },
-                "zhhans": {
-                    "name": "Spikey Goeff"
-                },
-                "zhhant": {
                     "name": "Spikey Goeff"
                 }
             }
@@ -5303,10 +2134,7 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [
-                "specter",
-                "robot"
-            ],
+            "traits": ["specter", "robot"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -5314,37 +2142,7 @@
             "power": 4,
             "text": "At the start of your turn, discard a card from your hand.\n",
             "locale": {
-                "de": {
-                    "name": "Geisterkonstrukt"
-                },
                 "en": {
-                    "name": "Wraith Construct"
-                },
-                "es": {
-                    "name": "Wraith Construct"
-                },
-                "fr": {
-                    "name": "Colère Noire"
-                },
-                "it": {
-                    "name": "Wraith Construct"
-                },
-                "pl": {
-                    "name": "Wraith Construct"
-                },
-                "pt": {
-                    "name": "Wraith Construct"
-                },
-                "th": {
-                    "name": "Wraith Construct"
-                },
-                "vi": {
-                    "name": "Wraith Construct"
-                },
-                "zhhans": {
-                    "name": "Wraith Construct"
-                },
-                "zhhant": {
                     "name": "Wraith Construct"
                 }
             }
@@ -5357,10 +2155,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "martian",
-                "soldier"
-            ],
+            "traits": ["martian", "soldier"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -5368,37 +2163,7 @@
             "power": 2,
             "text": "Each non-Mars creature and artifact gains, “After this card is used, destroy it.”\n",
             "locale": {
-                "de": {
-                    "name": "Bartos der Verwüster"
-                },
                 "en": {
-                    "name": "Bartos the Ruiner"
-                },
-                "es": {
-                    "name": "Bartos the Ruiner"
-                },
-                "fr": {
-                    "name": "Bartos le Ravageur"
-                },
-                "it": {
-                    "name": "Bartos the Ruiner"
-                },
-                "pl": {
-                    "name": "Bartos the Ruiner"
-                },
-                "pt": {
-                    "name": "Bartos the Ruiner"
-                },
-                "th": {
-                    "name": "Bartos the Ruiner"
-                },
-                "vi": {
-                    "name": "Bartos the Ruiner"
-                },
-                "zhhans": {
-                    "name": "Bartos the Ruiner"
-                },
-                "zhhant": {
                     "name": "Bartos the Ruiner"
                 }
             }
@@ -5419,37 +2184,7 @@
             "power": null,
             "text": "This creature gains, “After you play a Mars creature, ready this creature and for the remainder of the turn it belongs to house Mars.”",
             "locale": {
-                "de": {
-                    "name": "Hirnstamm-Antenne"
-                },
                 "en": {
-                    "name": "Brain Stem Antenna"
-                },
-                "es": {
-                    "name": "Brain Stem Antenna"
-                },
-                "fr": {
-                    "name": "Antenne Cérébrale"
-                },
-                "it": {
-                    "name": "Brain Stem Antenna"
-                },
-                "pl": {
-                    "name": "Brain Stem Antenna"
-                },
-                "pt": {
-                    "name": "Brain Stem Antenna"
-                },
-                "th": {
-                    "name": "Brain Stem Antenna"
-                },
-                "vi": {
-                    "name": "Brain Stem Antenna"
-                },
-                "zhhans": {
-                    "name": "Brain Stem Antenna"
-                },
-                "zhhant": {
                     "name": "Brain Stem Antenna"
                 }
             }
@@ -5462,10 +2197,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "elder",
-                "recruiter"
-            ],
+            "traits": ["elder", "recruiter"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -5473,37 +2205,7 @@
             "power": 3,
             "text": "Enhance  . (These icons have already been added to cards in your deck.)\nAt the end of your turn, give each other Mars creature two +1 power counters.\n",
             "locale": {
-                "de": {
-                    "name": "Ältester Chargenbetreuer"
-                },
                 "en": {
-                    "name": "Eldest Batchminder"
-                },
-                "es": {
-                    "name": "Eldest Batchminder"
-                },
-                "fr": {
-                    "name": "Doyen des Lots"
-                },
-                "it": {
-                    "name": "Eldest Batchminder"
-                },
-                "pl": {
-                    "name": "Eldest Batchminder"
-                },
-                "pt": {
-                    "name": "Eldest Batchminder"
-                },
-                "th": {
-                    "name": "Eldest Batchminder"
-                },
-                "vi": {
-                    "name": "Eldest Batchminder"
-                },
-                "zhhans": {
-                    "name": "Eldest Batchminder"
-                },
-                "zhhant": {
                     "name": "Eldest Batchminder"
                 }
             }
@@ -5516,11 +2218,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "martian",
-                "leader",
-                "elder"
-            ],
+            "traits": ["martian", "leader", "elder"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -5528,37 +2226,7 @@
             "power": 5,
             "text": "While Emperor Memrox is in the center of your battleline, it gains invulnerable.\nAfter Reap: Archive a card. Gain 1 for each card in your archives.\n",
             "locale": {
-                "de": {
-                    "name": "Imperator Memrox"
-                },
                 "en": {
-                    "name": "Emperor Memrox"
-                },
-                "es": {
-                    "name": "Emperor Memrox"
-                },
-                "fr": {
-                    "name": "Empereur Memrox"
-                },
-                "it": {
-                    "name": "Emperor Memrox"
-                },
-                "pl": {
-                    "name": "Emperor Memrox"
-                },
-                "pt": {
-                    "name": "Emperor Memrox"
-                },
-                "th": {
-                    "name": "Emperor Memrox"
-                },
-                "vi": {
-                    "name": "Emperor Memrox"
-                },
-                "zhhans": {
-                    "name": "Emperor Memrox"
-                },
-                "zhhant": {
                     "name": "Emperor Memrox"
                 }
             }
@@ -5579,37 +2247,7 @@
             "power": null,
             "text": "Play: Destroy a creature and each creature that shares a trait with it. Gain 1 chain.",
             "locale": {
-                "de": {
-                    "name": "Vernichtung"
-                },
                 "en": {
-                    "name": "Extinction"
-                },
-                "es": {
-                    "name": "Extinction"
-                },
-                "fr": {
-                    "name": "Extinction"
-                },
-                "it": {
-                    "name": "Extinction"
-                },
-                "pl": {
-                    "name": "Extinction"
-                },
-                "pt": {
-                    "name": "Extinction"
-                },
-                "th": {
-                    "name": "Extinction"
-                },
-                "vi": {
-                    "name": "Extinction"
-                },
-                "zhhans": {
-                    "name": "Extinction"
-                },
-                "zhhant": {
                     "name": "Extinction"
                 }
             }
@@ -5630,37 +2268,7 @@
             "power": null,
             "text": "Play: For each friendly Mars creature, choose an enemy creature to capture 1 from its own side.",
             "locale": {
-                "de": {
-                    "name": "Hypnotischer Befehl"
-                },
                 "en": {
-                    "name": "Hypnotic Command"
-                },
-                "es": {
-                    "name": "Hypnotic Command"
-                },
-                "fr": {
-                    "name": "Ordre Hypnotique"
-                },
-                "it": {
-                    "name": "Hypnotic Command"
-                },
-                "pl": {
-                    "name": "Hypnotic Command"
-                },
-                "pt": {
-                    "name": "Hypnotic Command"
-                },
-                "th": {
-                    "name": "Hypnotic Command"
-                },
-                "vi": {
-                    "name": "Hypnotic Command"
-                },
-                "zhhans": {
-                    "name": "Hypnotic Command"
-                },
-                "zhhant": {
                     "name": "Hypnotic Command"
                 }
             }
@@ -5681,37 +2289,7 @@
             "power": null,
             "text": "Play: Destroy each friendly creature. For each creature destroyed this way, draw 2 cards.\n",
             "locale": {
-                "de": {
-                    "name": "Marsianische Ausbreitung"
-                },
                 "en": {
-                    "name": "Martian Propagation"
-                },
-                "es": {
-                    "name": "Martian Propagation"
-                },
-                "fr": {
-                    "name": "Propagation Martienne"
-                },
-                "it": {
-                    "name": "Martian Propagation"
-                },
-                "pl": {
-                    "name": "Martian Propagation"
-                },
-                "pt": {
-                    "name": "Martian Propagation"
-                },
-                "th": {
-                    "name": "Martian Propagation"
-                },
-                "vi": {
-                    "name": "Martian Propagation"
-                },
-                "zhhans": {
-                    "name": "Martian Propagation"
-                },
-                "zhhant": {
                     "name": "Martian Propagation"
                 }
             }
@@ -5732,37 +2310,7 @@
             "power": null,
             "text": "Play: Put up to 3 damaged enemy creatures into your archives. If any of these creatures leave your archives, they are put into their owner’s hand instead.",
             "locale": {
-                "de": {
-                    "name": "Massenentführung"
-                },
                 "en": {
-                    "name": "Mass Abduction"
-                },
-                "es": {
-                    "name": "Mass Abduction"
-                },
-                "fr": {
-                    "name": "Enlèvement de Masse"
-                },
-                "it": {
-                    "name": "Mass Abduction"
-                },
-                "pl": {
-                    "name": "Mass Abduction"
-                },
-                "pt": {
-                    "name": "Mass Abduction"
-                },
-                "th": {
-                    "name": "Mass Abduction"
-                },
-                "vi": {
-                    "name": "Mass Abduction"
-                },
-                "zhhans": {
-                    "name": "Mass Abduction"
-                },
-                "zhhant": {
                     "name": "Mass Abduction"
                 }
             }
@@ -5774,13 +2322,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_091_e35c857e4e4a_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": [
-                "deploy"
-            ],
-            "traits": [
-                "beast",
-                "experiment"
-            ],
+            "keywords": ["deploy"],
+            "traits": ["beast", "experiment"],
             "type": "gigantic creature base",
             "rarity": "Special",
             "amber": 0,
@@ -5788,37 +2331,7 @@
             "power": 1,
             "text": "(Play only with the other half of Monster Zero.)\nDeploy.\nEach of Monster Zero's neighbors belongs to house Mars (instead of its other houses).\nPlay: Give Monster Zero a number of +1 power counters equal to the most powerful friendly creature’s power.\n",
             "locale": {
-                "de": {
-                    "name": "Monster Zero"
-                },
                 "en": {
-                    "name": "Monster Zero"
-                },
-                "es": {
-                    "name": "Monster Zero"
-                },
-                "fr": {
-                    "name": "Monstre Zéro"
-                },
-                "it": {
-                    "name": "Monster Zero"
-                },
-                "pl": {
-                    "name": "Monster Zero"
-                },
-                "pt": {
-                    "name": "Monster Zero"
-                },
-                "th": {
-                    "name": "Monster Zero"
-                },
-                "vi": {
-                    "name": "Monster Zero"
-                },
-                "zhhans": {
-                    "name": "Monster Zero"
-                },
-                "zhhant": {
                     "name": "Monster Zero"
                 }
             }
@@ -5839,37 +2352,7 @@
             "power": null,
             "text": "",
             "locale": {
-                "de": {
-                    "name": "Monster Zero"
-                },
                 "en": {
-                    "name": "Monster Zero"
-                },
-                "es": {
-                    "name": "Monster Zero"
-                },
-                "fr": {
-                    "name": "Monstre Zéro"
-                },
-                "it": {
-                    "name": "Monster Zero"
-                },
-                "pl": {
-                    "name": "Monster Zero"
-                },
-                "pt": {
-                    "name": "Monster Zero"
-                },
-                "th": {
-                    "name": "Monster Zero"
-                },
-                "vi": {
-                    "name": "Monster Zero"
-                },
-                "zhhans": {
-                    "name": "Monster Zero"
-                },
-                "zhhant": {
                     "name": "Monster Zero"
                 }
             }
@@ -5882,9 +2365,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "power"
-            ],
+            "traits": ["power"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -5892,37 +2373,7 @@
             "power": null,
             "text": "Enraged creatures cannot be used to fight friendly Mars creatures.\nAction: Enrage each enemy creature.\n",
             "locale": {
-                "de": {
-                    "name": "Psychischer Dunst"
-                },
                 "en": {
-                    "name": "Psychic Haze"
-                },
-                "es": {
-                    "name": "Psychic Haze"
-                },
-                "fr": {
-                    "name": "Brume Psychique"
-                },
-                "it": {
-                    "name": "Psychic Haze"
-                },
-                "pl": {
-                    "name": "Psychic Haze"
-                },
-                "pt": {
-                    "name": "Psychic Haze"
-                },
-                "th": {
-                    "name": "Psychic Haze"
-                },
-                "vi": {
-                    "name": "Psychic Haze"
-                },
-                "zhhans": {
-                    "name": "Psychic Haze"
-                },
-                "zhhant": {
                     "name": "Psychic Haze"
                 }
             }
@@ -5935,9 +2386,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "beast"
-            ],
+            "traits": ["beast"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -5945,37 +2394,7 @@
             "power": 4,
             "text": "You may play a Mars card during each turn in which Mars is not your active house.\n",
             "locale": {
-                "de": {
-                    "name": "Tangrant"
-                },
                 "en": {
-                    "name": "Tangrant"
-                },
-                "es": {
-                    "name": "Tangrant"
-                },
-                "fr": {
-                    "name": "Tangrant"
-                },
-                "it": {
-                    "name": "Tangrant"
-                },
-                "pl": {
-                    "name": "Tangrant"
-                },
-                "pt": {
-                    "name": "Tangrant"
-                },
-                "th": {
-                    "name": "Tangrant"
-                },
-                "vi": {
-                    "name": "Tangrant"
-                },
-                "zhhans": {
-                    "name": "Tangrant"
-                },
-                "zhhant": {
                     "name": "Tangrant"
                 }
             }
@@ -5996,37 +2415,7 @@
             "power": null,
             "text": "Play: For the remainder of the turn, each enemy creature gains, “Destroyed: Fully heal this creature and give control of it to your opponent instead.”\n",
             "locale": {
-                "de": {
-                    "name": "Die Körperfresser"
-                },
                 "en": {
-                    "name": "The Body Snatchers"
-                },
-                "es": {
-                    "name": "The Body Snatchers"
-                },
-                "fr": {
-                    "name": "Usurpation des Corps"
-                },
-                "it": {
-                    "name": "The Body Snatchers"
-                },
-                "pl": {
-                    "name": "The Body Snatchers"
-                },
-                "pt": {
-                    "name": "The Body Snatchers"
-                },
-                "th": {
-                    "name": "The Body Snatchers"
-                },
-                "vi": {
-                    "name": "The Body Snatchers"
-                },
-                "zhhans": {
-                    "name": "The Body Snatchers"
-                },
-                "zhhant": {
                     "name": "The Body Snatchers"
                 }
             }
@@ -6038,13 +2427,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_095_82674306632c_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": [
-                "elusive"
-            ],
-            "traits": [
-                "martian",
-                "politician"
-            ],
+            "keywords": ["elusive"],
+            "traits": ["martian", "politician"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -6052,37 +2436,7 @@
             "power": 2,
             "text": "Elusive.\nAfter Reap: Lose all your . Destroy an enemy non-Mars creature for each  lost this way.\n",
             "locale": {
-                "de": {
-                    "name": "Urxym der „Diplomat“"
-                },
                 "en": {
-                    "name": "Urxym the “Diplomat”"
-                },
-                "es": {
-                    "name": "Urxym the “Diplomat”"
-                },
-                "fr": {
-                    "name": "Urxym le « Diplomate »"
-                },
-                "it": {
-                    "name": "Urxym the “Diplomat”"
-                },
-                "pl": {
-                    "name": "Urxym the “Diplomat”"
-                },
-                "pt": {
-                    "name": "Urxym the “Diplomat”"
-                },
-                "th": {
-                    "name": "Urxym the “Diplomat”"
-                },
-                "vi": {
-                    "name": "Urxym the “Diplomat”"
-                },
-                "zhhans": {
-                    "name": "Urxym the “Diplomat”"
-                },
-                "zhhant": {
                     "name": "Urxym the “Diplomat”"
                 }
             }
@@ -6095,9 +2449,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "power"
-            ],
+            "traits": ["power"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -6105,37 +2457,7 @@
             "power": null,
             "text": "Action: Put a creature on the bottom of its owner’s deck. If you do, give a creature two +1 power counters.\n",
             "locale": {
-                "de": {
-                    "name": "Zzysz’ Verdichter"
-                },
                 "en": {
-                    "name": "Zzyszz’s Compactor"
-                },
-                "es": {
-                    "name": "Zzyszz’s Compactor"
-                },
-                "fr": {
-                    "name": "Compacteur de Zzyszzys"
-                },
-                "it": {
-                    "name": "Zzyszz’s Compactor"
-                },
-                "pl": {
-                    "name": "Zzyszz’s Compactor"
-                },
-                "pt": {
-                    "name": "Zzyszz’s Compactor"
-                },
-                "th": {
-                    "name": "Zzyszz’s Compactor"
-                },
-                "vi": {
-                    "name": "Zzyszz’s Compactor"
-                },
-                "zhhans": {
-                    "name": "Zzyszz’s Compactor"
-                },
-                "zhhant": {
                     "name": "Zzyszz’s Compactor"
                 }
             }
@@ -6148,9 +2470,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "power"
-            ],
+            "traits": ["power"],
             "type": "artifact",
             "rarity": "Uncommon",
             "amber": 0,
@@ -6158,37 +2478,7 @@
             "power": null,
             "text": "Action: Ready and use a friendly creature.\n",
             "locale": {
-                "de": {
-                    "name": "Alle sind Mars"
-                },
                 "en": {
-                    "name": "All Are Mars"
-                },
-                "es": {
-                    "name": "All Are Mars"
-                },
-                "fr": {
-                    "name": "Tous Sont Mars"
-                },
-                "it": {
-                    "name": "All Are Mars"
-                },
-                "pl": {
-                    "name": "All Are Mars"
-                },
-                "pt": {
-                    "name": "All Are Mars"
-                },
-                "th": {
-                    "name": "All Are Mars"
-                },
-                "vi": {
-                    "name": "All Are Mars"
-                },
-                "zhhans": {
-                    "name": "All Are Mars"
-                },
-                "zhhant": {
                     "name": "All Are Mars"
                 }
             }
@@ -6209,37 +2499,7 @@
             "power": null,
             "text": "Play: Destroy an artifact, a creature, and an upgrade.",
             "locale": {
-                "de": {
-                    "name": "Vernichtet sie alle!"
-                },
                 "en": {
-                    "name": "Destroy Them All!"
-                },
-                "es": {
-                    "name": "Destroy Them All!"
-                },
-                "fr": {
-                    "name": "Détruisez-les Tous !"
-                },
-                "it": {
-                    "name": "Destroy Them All!"
-                },
-                "pl": {
-                    "name": "Destroy Them All!"
-                },
-                "pt": {
-                    "name": "Destroy Them All!"
-                },
-                "th": {
-                    "name": "Destroy Them All!"
-                },
-                "vi": {
-                    "name": "Destroy Them All!"
-                },
-                "zhhans": {
-                    "name": "Destroy Them All!"
-                },
-                "zhhant": {
                     "name": "Destroy Them All!"
                 }
             }
@@ -6260,37 +2520,7 @@
             "power": null,
             "text": "Play: Destroy a non-Mars artifact. If you do, you may ready a friendly card. \n",
             "locale": {
-                "de": {
-                    "name": "Mars-Monument"
-                },
                 "en": {
-                    "name": "Edifice for Mars"
-                },
-                "es": {
-                    "name": "Edifice for Mars"
-                },
-                "fr": {
-                    "name": "Édifice à Mars"
-                },
-                "it": {
-                    "name": "Edifice for Mars"
-                },
-                "pl": {
-                    "name": "Edifice for Mars"
-                },
-                "pt": {
-                    "name": "Edifice for Mars"
-                },
-                "th": {
-                    "name": "Edifice for Mars"
-                },
-                "vi": {
-                    "name": "Edifice for Mars"
-                },
-                "zhhans": {
-                    "name": "Edifice for Mars"
-                },
-                "zhhant": {
                     "name": "Edifice for Mars"
                 }
             }
@@ -6303,10 +2533,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "martian",
-                "agent"
-            ],
+            "traits": ["martian", "agent"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -6314,37 +2541,7 @@
             "power": 3,
             "text": "After Fight: Capture 2. If there are 3 or more on Empowered Zark, you may move 3 from it to the common supply and ready each non-Agent Mars creature.\n",
             "locale": {
-                "de": {
-                    "name": "Ermächtigter Zark"
-                },
                 "en": {
-                    "name": "Empowered Zark"
-                },
-                "es": {
-                    "name": "Empowered Zark"
-                },
-                "fr": {
-                    "name": "Zark l’Augmenté"
-                },
-                "it": {
-                    "name": "Empowered Zark"
-                },
-                "pl": {
-                    "name": "Empowered Zark"
-                },
-                "pt": {
-                    "name": "Empowered Zark"
-                },
-                "th": {
-                    "name": "Empowered Zark"
-                },
-                "vi": {
-                    "name": "Empowered Zark"
-                },
-                "zhhans": {
-                    "name": "Empowered Zark"
-                },
-                "zhhant": {
                     "name": "Empowered Zark"
                 }
             }
@@ -6356,10 +2553,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_101_3c5e74d612ea_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": [],
-            "traits": [
-                "beast"
-            ],
+            "keywords": ["entrench"],
+            "traits": ["beast"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -6367,37 +2562,7 @@
             "power": 4,
             "text": "Entrench.\nWhile Golden K1-TT13 is exhausted, each of its neighbors gains, “After Reap: Gain 1.”\n",
             "locale": {
-                "de": {
-                    "name": "Goldenes K4-3TZ3CH3N"
-                },
                 "en": {
-                    "name": "Golden K1-TT13"
-                },
-                "es": {
-                    "name": "Golden K1-TT13"
-                },
-                "fr": {
-                    "name": "CH4-T0N Doré"
-                },
-                "it": {
-                    "name": "Golden K1-TT13"
-                },
-                "pl": {
-                    "name": "Golden K1-TT13"
-                },
-                "pt": {
-                    "name": "Golden K1-TT13"
-                },
-                "th": {
-                    "name": "Golden K1-TT13"
-                },
-                "vi": {
-                    "name": "Golden K1-TT13"
-                },
-                "zhhans": {
-                    "name": "Golden K1-TT13"
-                },
-                "zhhant": {
                     "name": "Golden K1-TT13"
                 }
             }
@@ -6409,12 +2574,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_102_9f799c3a38f5_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": [
-                "elusive"
-            ],
-            "traits": [
-                "martian"
-            ],
+            "keywords": ["elusive"],
+            "traits": ["martian"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -6422,37 +2583,7 @@
             "power": 3,
             "text": "Elusive. Enhance .\nAction: Lose 1. If you do, move all  from a creature to your pool.\n",
             "locale": {
-                "de": {
-                    "name": "Iyxrenu der Kluge"
-                },
                 "en": {
-                    "name": "Iyxrenu the Clever"
-                },
-                "es": {
-                    "name": "Iyxrenu the Clever"
-                },
-                "fr": {
-                    "name": "Iyxrenu le Rusé"
-                },
-                "it": {
-                    "name": "Iyxrenu the Clever"
-                },
-                "pl": {
-                    "name": "Iyxrenu the Clever"
-                },
-                "pt": {
-                    "name": "Iyxrenu the Clever"
-                },
-                "th": {
-                    "name": "Iyxrenu the Clever"
-                },
-                "vi": {
-                    "name": "Iyxrenu the Clever"
-                },
-                "zhhans": {
-                    "name": "Iyxrenu the Clever"
-                },
-                "zhhant": {
                     "name": "Iyxrenu the Clever"
                 }
             }
@@ -6473,37 +2604,7 @@
             "power": null,
             "text": "Play: You may discard any number of cards from your hand. Then, forge a key at +9 current cost, reduced by 1 for each card discarded this way.\n",
             "locale": {
-                "de": {
-                    "name": "Schlüsselentzug"
-                },
                 "en": {
-                    "name": "Key Drain"
-                },
-                "es": {
-                    "name": "Key Drain"
-                },
-                "fr": {
-                    "name": "Clé en Sous-Pression"
-                },
-                "it": {
-                    "name": "Key Drain"
-                },
-                "pl": {
-                    "name": "Key Drain"
-                },
-                "pt": {
-                    "name": "Key Drain"
-                },
-                "th": {
-                    "name": "Key Drain"
-                },
-                "vi": {
-                    "name": "Key Drain"
-                },
-                "zhhans": {
-                    "name": "Key Drain"
-                },
-                "zhhant": {
                     "name": "Key Drain"
                 }
             }
@@ -6516,10 +2617,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "martian",
-                "soldier"
-            ],
+            "traits": ["martian", "soldier"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -6527,37 +2625,7 @@
             "power": 2,
             "text": "For each neighbor Nyzyk Resonator has, your opponent’s keys cost +2.",
             "locale": {
-                "de": {
-                    "name": "Nyzyk-Resonator"
-                },
                 "en": {
-                    "name": "Nyzyk Resonator"
-                },
-                "es": {
-                    "name": "Nyzyk Resonator"
-                },
-                "fr": {
-                    "name": "Résonateur Nyzyk"
-                },
-                "it": {
-                    "name": "Nyzyk Resonator"
-                },
-                "pl": {
-                    "name": "Nyzyk Resonator"
-                },
-                "pt": {
-                    "name": "Nyzyk Resonator"
-                },
-                "th": {
-                    "name": "Nyzyk Resonator"
-                },
-                "vi": {
-                    "name": "Nyzyk Resonator"
-                },
-                "zhhans": {
-                    "name": "Nyzyk Resonator"
-                },
-                "zhhant": {
                     "name": "Nyzyk Resonator"
                 }
             }
@@ -6578,37 +2646,7 @@
             "power": null,
             "text": "Play: Reveal any number of Mars cards from your hand. For each card revealed this way, deal 2 to a creature. (You may choose a different creature each time.)",
             "locale": {
-                "de": {
-                    "name": "Orbitalbombardement"
-                },
                 "en": {
-                    "name": "Orbital Bombardment"
-                },
-                "es": {
-                    "name": "Orbital Bombardment"
-                },
-                "fr": {
-                    "name": "Bombardement Orbital"
-                },
-                "it": {
-                    "name": "Orbital Bombardment"
-                },
-                "pl": {
-                    "name": "Orbital Bombardment"
-                },
-                "pt": {
-                    "name": "Orbital Bombardment"
-                },
-                "th": {
-                    "name": "Orbital Bombardment"
-                },
-                "vi": {
-                    "name": "Orbital Bombardment"
-                },
-                "zhhans": {
-                    "name": "Orbital Bombardment"
-                },
-                "zhhant": {
                     "name": "Orbital Bombardment"
                 }
             }
@@ -6629,37 +2667,7 @@
             "power": null,
             "text": "Play: Deal 2 to a friendly non-Mars creature. If it is not destroyed, it captures 2.\n",
             "locale": {
-                "de": {
-                    "name": "Haiköder"
-                },
                 "en": {
-                    "name": "Shark Bait"
-                },
-                "es": {
-                    "name": "Shark Bait"
-                },
-                "fr": {
-                    "name": "Appât à Requin"
-                },
-                "it": {
-                    "name": "Shark Bait"
-                },
-                "pl": {
-                    "name": "Shark Bait"
-                },
-                "pt": {
-                    "name": "Shark Bait"
-                },
-                "th": {
-                    "name": "Shark Bait"
-                },
-                "vi": {
-                    "name": "Shark Bait"
-                },
-                "zhhans": {
-                    "name": "Shark Bait"
-                },
-                "zhhant": {
                     "name": "Shark Bait"
                 }
             }
@@ -6672,9 +2680,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "beast"
-            ],
+            "traits": ["beast"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -6682,37 +2688,7 @@
             "power": 12,
             "text": "Enhance .\nThe Red Death cannot ready unless you are haunted.\nAfter Fight: Gain 1 and draw a card.\n",
             "locale": {
-                "de": {
-                    "name": "Der Rote Tod"
-                },
                 "en": {
-                    "name": "The Red Death"
-                },
-                "es": {
-                    "name": "The Red Death"
-                },
-                "fr": {
-                    "name": "La Mort Rouge"
-                },
-                "it": {
-                    "name": "The Red Death"
-                },
-                "pl": {
-                    "name": "The Red Death"
-                },
-                "pt": {
-                    "name": "The Red Death"
-                },
-                "th": {
-                    "name": "The Red Death"
-                },
-                "vi": {
-                    "name": "The Red Death"
-                },
-                "zhhans": {
-                    "name": "The Red Death"
-                },
-                "zhhant": {
                     "name": "The Red Death"
                 }
             }
@@ -6724,13 +2700,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_108_a15c49e6356e_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": [
-                "elusive"
-            ],
-            "traits": [
-                "martian",
-                "elder"
-            ],
+            "keywords": ["elusive"],
+            "traits": ["martian", "elder"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -6738,37 +2709,7 @@
             "power": 3,
             "text": "Elusive.\nAfter Reap: The least powerful enemy creature captures 1 from its own side.\n",
             "locale": {
-                "de": {
-                    "name": "lyylyug"
-                },
                 "en": {
-                    "name": "lyylyug"
-                },
-                "es": {
-                    "name": "lyylyug"
-                },
-                "fr": {
-                    "name": "lyylyug"
-                },
-                "it": {
-                    "name": "lyylyug"
-                },
-                "pl": {
-                    "name": "lyylyug"
-                },
-                "pt": {
-                    "name": "lyylyug"
-                },
-                "th": {
-                    "name": "lyylyug"
-                },
-                "vi": {
-                    "name": "lyylyug"
-                },
-                "zhhans": {
-                    "name": "lyylyug"
-                },
-                "zhhant": {
                     "name": "lyylyug"
                 }
             }
@@ -6781,10 +2722,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "martian",
-                "agent"
-            ],
+            "traits": ["martian", "agent"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -6792,37 +2730,7 @@
             "power": 4,
             "text": "After Reap: If you are overwhelmed, give a friendly creature three +1 power counters. Otherwise, give each friendly creature a +1 power counter.\n",
             "locale": {
-                "de": {
-                    "name": "Agent Buuff"
-                },
                 "en": {
-                    "name": "Agent Buuff"
-                },
-                "es": {
-                    "name": "Agent Buuff"
-                },
-                "fr": {
-                    "name": "Agent Buuff"
-                },
-                "it": {
-                    "name": "Agent Buuff"
-                },
-                "pl": {
-                    "name": "Agent Buuff"
-                },
-                "pt": {
-                    "name": "Agent Buuff"
-                },
-                "th": {
-                    "name": "Agent Buuff"
-                },
-                "vi": {
-                    "name": "Agent Buuff"
-                },
-                "zhhans": {
-                    "name": "Agent Buuff"
-                },
-                "zhhant": {
                     "name": "Agent Buuff"
                 }
             }
@@ -6835,9 +2743,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "robot"
-            ],
+            "traits": ["robot"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -6845,37 +2751,7 @@
             "power": 3,
             "text": "After Reap: Destroy a friendly non-Mars creature. If you do, take control of an enemy creature.\n",
             "locale": {
-                "de": {
-                    "name": "Vermittler Vyynx"
-                },
                 "en": {
-                    "name": "Arbiter Vyynx"
-                },
-                "es": {
-                    "name": "Arbiter Vyynx"
-                },
-                "fr": {
-                    "name": "Médiateur Vyynx"
-                },
-                "it": {
-                    "name": "Arbiter Vyynx"
-                },
-                "pl": {
-                    "name": "Arbiter Vyynx"
-                },
-                "pt": {
-                    "name": "Arbiter Vyynx"
-                },
-                "th": {
-                    "name": "Arbiter Vyynx"
-                },
-                "vi": {
-                    "name": "Arbiter Vyynx"
-                },
-                "zhhans": {
-                    "name": "Arbiter Vyynx"
-                },
-                "zhhant": {
                     "name": "Arbiter Vyynx"
                 }
             }
@@ -6888,9 +2764,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "beast"
-            ],
+            "traits": ["beast"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -6898,37 +2772,7 @@
             "power": 2,
             "text": "After Fight: Put the creature Collector Worm fights into your archives. (Both creatures must survive the fight.) If that creature leaves your archives, put it in its owner’s hand instead.\n",
             "locale": {
-                "de": {
-                    "name": "Sammler-Wurm"
-                },
                 "en": {
-                    "name": "Collector Worm"
-                },
-                "es": {
-                    "name": "Collector Worm"
-                },
-                "fr": {
-                    "name": "Ver Collectionneur"
-                },
-                "it": {
-                    "name": "Collector Worm"
-                },
-                "pl": {
-                    "name": "Collector Worm"
-                },
-                "pt": {
-                    "name": "Collector Worm"
-                },
-                "th": {
-                    "name": "Collector Worm"
-                },
-                "vi": {
-                    "name": "Collector Worm"
-                },
-                "zhhans": {
-                    "name": "Collector Worm"
-                },
-                "zhhant": {
                     "name": "Collector Worm"
                 }
             }
@@ -6949,37 +2793,7 @@
             "power": null,
             "text": "Play: Discard the top card of your opponent’s deck. If it is not a Mars card, an enemy creature captures 1 from its own side.\n",
             "locale": {
-                "de": {
-                    "name": "Digitale Manipulation"
-                },
                 "en": {
-                    "name": "Digital Manipulation"
-                },
-                "es": {
-                    "name": "Digital Manipulation"
-                },
-                "fr": {
-                    "name": "Manipulation Numérique"
-                },
-                "it": {
-                    "name": "Digital Manipulation"
-                },
-                "pl": {
-                    "name": "Digital Manipulation"
-                },
-                "pt": {
-                    "name": "Digital Manipulation"
-                },
-                "th": {
-                    "name": "Digital Manipulation"
-                },
-                "vi": {
-                    "name": "Digital Manipulation"
-                },
-                "zhhans": {
-                    "name": "Digital Manipulation"
-                },
-                "zhhant": {
                     "name": "Digital Manipulation"
                 }
             }
@@ -7000,37 +2814,7 @@
             "power": null,
             "text": "Play: Deal 2 to a creature. Reveal a random card from a player’s archives. If you do, deal an additional 3 to the same creature. Discard the revealed card.\n",
             "locale": {
-                "de": {
-                    "name": "Harmonisches Rudel"
-                },
                 "en": {
-                    "name": "Harmonic Pack"
-                },
-                "es": {
-                    "name": "Harmonic Pack"
-                },
-                "fr": {
-                    "name": "Meute Harmonique"
-                },
-                "it": {
-                    "name": "Harmonic Pack"
-                },
-                "pl": {
-                    "name": "Harmonic Pack"
-                },
-                "pt": {
-                    "name": "Harmonic Pack"
-                },
-                "th": {
-                    "name": "Harmonic Pack"
-                },
-                "vi": {
-                    "name": "Harmonic Pack"
-                },
-                "zhhans": {
-                    "name": "Harmonic Pack"
-                },
-                "zhhant": {
                     "name": "Harmonic Pack"
                 }
             }
@@ -7051,37 +2835,7 @@
             "power": null,
             "text": "Play: Put each Mars creature into its owner’s archives. Destroy each creature. Gain 3 chains.\n",
             "locale": {
-                "de": {
-                    "name": "Kabumm!"
-                },
                 "en": {
-                    "name": "Kaboom!"
-                },
-                "es": {
-                    "name": "Kaboom!"
-                },
-                "fr": {
-                    "name": "Bâaoum !"
-                },
-                "it": {
-                    "name": "Kaboom!"
-                },
-                "pl": {
-                    "name": "Kaboom!"
-                },
-                "pt": {
-                    "name": "Kaboom!"
-                },
-                "th": {
-                    "name": "Kaboom!"
-                },
-                "vi": {
-                    "name": "Kaboom!"
-                },
-                "zhhans": {
-                    "name": "Kaboom!"
-                },
-                "zhhant": {
                     "name": "Kaboom!"
                 }
             }
@@ -7094,10 +2848,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "martian",
-                "soldier"
-            ],
+            "traits": ["martian", "soldier"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -7105,37 +2856,7 @@
             "power": 3,
             "text": "Enhance .\nAfter Reap: You may remove each +1 power counter from a creature. If one or more counters are removed this way, archive a card.\n",
             "locale": {
-                "de": {
-                    "name": "Klyyhnug"
-                },
                 "en": {
-                    "name": "Klyyhnug"
-                },
-                "es": {
-                    "name": "Klyyhnug"
-                },
-                "fr": {
-                    "name": "Klyyhnug"
-                },
-                "it": {
-                    "name": "Klyyhnug"
-                },
-                "pl": {
-                    "name": "Klyyhnug"
-                },
-                "pt": {
-                    "name": "Klyyhnug"
-                },
-                "th": {
-                    "name": "Klyyhnug"
-                },
-                "vi": {
-                    "name": "Klyyhnug"
-                },
-                "zhhans": {
-                    "name": "Klyyhnug"
-                },
-                "zhhant": {
                     "name": "Klyyhnug"
                 }
             }
@@ -7147,11 +2868,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_116_dda3661d5b7d_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": [],
-            "traits": [
-                "martian",
-                "elder"
-            ],
+            "keywords": ["entrench"],
+            "traits": ["martian", "elder"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -7159,37 +2877,7 @@
             "power": 3,
             "text": "Entrench.\nWhile Operator Olluyyg is exhausted, your opponent’s keys cost +3.\n",
             "locale": {
-                "de": {
-                    "name": "Operator Olluyyg"
-                },
                 "en": {
-                    "name": "Operator Olluyyg"
-                },
-                "es": {
-                    "name": "Operator Olluyyg"
-                },
-                "fr": {
-                    "name": "Opérateur Olluyyg"
-                },
-                "it": {
-                    "name": "Operator Olluyyg"
-                },
-                "pl": {
-                    "name": "Operator Olluyyg"
-                },
-                "pt": {
-                    "name": "Operator Olluyyg"
-                },
-                "th": {
-                    "name": "Operator Olluyyg"
-                },
-                "vi": {
-                    "name": "Operator Olluyyg"
-                },
-                "zhhans": {
-                    "name": "Operator Olluyyg"
-                },
-                "zhhant": {
                     "name": "Operator Olluyyg"
                 }
             }
@@ -7210,37 +2898,7 @@
             "power": null,
             "text": "Play: You may discard a non-Mars card. If you do, a friendly creature captures 1 for each bonus icon on the discarded card.\n",
             "locale": {
-                "de": {
-                    "name": "Produktiver Müll"
-                },
                 "en": {
-                    "name": "Productive Trash"
-                },
-                "es": {
-                    "name": "Productive Trash"
-                },
-                "fr": {
-                    "name": "Déchets Productifs"
-                },
-                "it": {
-                    "name": "Productive Trash"
-                },
-                "pl": {
-                    "name": "Productive Trash"
-                },
-                "pt": {
-                    "name": "Productive Trash"
-                },
-                "th": {
-                    "name": "Productive Trash"
-                },
-                "vi": {
-                    "name": "Productive Trash"
-                },
-                "zhhans": {
-                    "name": "Productive Trash"
-                },
-                "zhhant": {
                     "name": "Productive Trash"
                 }
             }
@@ -7252,13 +2910,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_118_3a67c38224f0_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": [
-                "deploy"
-            ],
-            "traits": [
-                "martian",
-                "soldier"
-            ],
+            "keywords": ["deploy"],
+            "traits": ["martian", "soldier"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -7266,37 +2919,7 @@
             "power": 3,
             "text": "Deploy.\nPlay: Put a neighboring non-Soldier creature into its owner’s hand. If you do, the most powerful friendly creature captures 2.\n",
             "locale": {
-                "de": {
-                    "name": "Ersatz-Ziel"
-                },
                 "en": {
-                    "name": "Replacement Targ"
-                },
-                "es": {
-                    "name": "Replacement Targ"
-                },
-                "fr": {
-                    "name": "Agent de Remplacement"
-                },
-                "it": {
-                    "name": "Replacement Targ"
-                },
-                "pl": {
-                    "name": "Replacement Targ"
-                },
-                "pt": {
-                    "name": "Replacement Targ"
-                },
-                "th": {
-                    "name": "Replacement Targ"
-                },
-                "vi": {
-                    "name": "Replacement Targ"
-                },
-                "zhhans": {
-                    "name": "Replacement Targ"
-                },
-                "zhhant": {
                     "name": "Replacement Targ"
                 }
             }
@@ -7317,37 +2940,7 @@
             "power": null,
             "text": "Play: Give a creature two +1 power counters. You may remove any number of +1 power counters from a friendly creature. That creature captures 1 for each counter removed this way.\n",
             "locale": {
-                "de": {
-                    "name": "Transmutation"
-                },
                 "en": {
-                    "name": "Transmutation"
-                },
-                "es": {
-                    "name": "Transmutation"
-                },
-                "fr": {
-                    "name": "Transmutation"
-                },
-                "it": {
-                    "name": "Transmutation"
-                },
-                "pl": {
-                    "name": "Transmutation"
-                },
-                "pt": {
-                    "name": "Transmutation"
-                },
-                "th": {
-                    "name": "Transmutation"
-                },
-                "vi": {
-                    "name": "Transmutation"
-                },
-                "zhhans": {
-                    "name": "Transmutation"
-                },
-                "zhhant": {
                     "name": "Transmutation"
                 }
             }
@@ -7360,10 +2953,7 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [
-                "martian",
-                "soldier"
-            ],
+            "traits": ["martian", "soldier"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -7371,37 +2961,7 @@
             "power": 2,
             "text": "After Fight/After Reap: If you are overwhelmed, stun an enemy creature and each of its neighbors. Otherwise, stun a creature. \n",
             "locale": {
-                "de": {
-                    "name": "Ujkyytr der Primus"
-                },
                 "en": {
-                    "name": "Ujkyytr Prime"
-                },
-                "es": {
-                    "name": "Ujkyytr Prime"
-                },
-                "fr": {
-                    "name": "Ujkyytr Premier"
-                },
-                "it": {
-                    "name": "Ujkyytr Prime"
-                },
-                "pl": {
-                    "name": "Ujkyytr Prime"
-                },
-                "pt": {
-                    "name": "Ujkyytr Prime"
-                },
-                "th": {
-                    "name": "Ujkyytr Prime"
-                },
-                "vi": {
-                    "name": "Ujkyytr Prime"
-                },
-                "zhhans": {
-                    "name": "Ujkyytr Prime"
-                },
-                "zhhant": {
                     "name": "Ujkyytr Prime"
                 }
             }
@@ -7414,10 +2974,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon",
-                "leader"
-            ],
+            "traits": ["dragon", "leader"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -7425,37 +2982,7 @@
             "power": 7,
             "text": "While Agorim is in the center of your battleline, friendly creatures get +5 power.\n",
             "locale": {
-                "de": {
-                    "name": "Agorim"
-                },
                 "en": {
-                    "name": "Agorim"
-                },
-                "es": {
-                    "name": "Agorim"
-                },
-                "fr": {
-                    "name": "Agorim"
-                },
-                "it": {
-                    "name": "Agorim"
-                },
-                "pl": {
-                    "name": "Agorim"
-                },
-                "pt": {
-                    "name": "Agorim"
-                },
-                "th": {
-                    "name": "Agorim"
-                },
-                "vi": {
-                    "name": "Agorim"
-                },
-                "zhhans": {
-                    "name": "Agorim"
-                },
-                "zhhant": {
                     "name": "Agorim"
                 }
             }
@@ -7476,37 +3003,7 @@
             "power": null,
             "text": "Play: If you are overwhelmed, draw 3 cards.\n",
             "locale": {
-                "de": {
-                    "name": "Ascheflügel-Protokoll"
-                },
                 "en": {
-                    "name": "Ashwing Protocol"
-                },
-                "es": {
-                    "name": "Ashwing Protocol"
-                },
-                "fr": {
-                    "name": "Protocole Cendraile"
-                },
-                "it": {
-                    "name": "Ashwing Protocol"
-                },
-                "pl": {
-                    "name": "Ashwing Protocol"
-                },
-                "pt": {
-                    "name": "Ashwing Protocol"
-                },
-                "th": {
-                    "name": "Ashwing Protocol"
-                },
-                "vi": {
-                    "name": "Ashwing Protocol"
-                },
-                "zhhans": {
-                    "name": "Ashwing Protocol"
-                },
-                "zhhant": {
                     "name": "Ashwing Protocol"
                 }
             }
@@ -7527,37 +3024,7 @@
             "power": null,
             "text": "Play: Deal 3 to each creature. For each creature destroyed this way, exhaust a creature.\n",
             "locale": {
-                "de": {
-                    "name": "Chloroschlummer-Nebel"
-                },
                 "en": {
-                    "name": "Chlorodoze Vapor"
-                },
-                "es": {
-                    "name": "Chlorodoze Vapor"
-                },
-                "fr": {
-                    "name": "Vapeur Sédative"
-                },
-                "it": {
-                    "name": "Chlorodoze Vapor"
-                },
-                "pl": {
-                    "name": "Chlorodoze Vapor"
-                },
-                "pt": {
-                    "name": "Chlorodoze Vapor"
-                },
-                "th": {
-                    "name": "Chlorodoze Vapor"
-                },
-                "vi": {
-                    "name": "Chlorodoze Vapor"
-                },
-                "zhhans": {
-                    "name": "Chlorodoze Vapor"
-                },
-                "zhhant": {
                     "name": "Chlorodoze Vapor"
                 }
             }
@@ -7570,9 +3037,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "power"
-            ],
+            "traits": ["power"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -7580,37 +3045,7 @@
             "power": null,
             "text": "Keys cost +2.\nAfter your opponent forges a key, gain 2, draw 4 cards, and destroy Cyn Dynasty.\n",
             "locale": {
-                "de": {
-                    "name": "Cyn-Dynastie"
-                },
                 "en": {
-                    "name": "Cyn Dynasty"
-                },
-                "es": {
-                    "name": "Cyn Dynasty"
-                },
-                "fr": {
-                    "name": "Dynastie des Cyn"
-                },
-                "it": {
-                    "name": "Cyn Dynasty"
-                },
-                "pl": {
-                    "name": "Cyn Dynasty"
-                },
-                "pt": {
-                    "name": "Cyn Dynasty"
-                },
-                "th": {
-                    "name": "Cyn Dynasty"
-                },
-                "vi": {
-                    "name": "Cyn Dynasty"
-                },
-                "zhhans": {
-                    "name": "Cyn Dynasty"
-                },
-                "zhhant": {
                     "name": "Cyn Dynasty"
                 }
             }
@@ -7622,10 +3057,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_125_b2d19691951d_en.png",
             "expansion": 928,
             "house": "ouboros",
-            "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "keywords": ["entrench"],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -7633,37 +3066,7 @@
             "power": 5,
             "text": "Entrench.\nAt the start of your turn, if Dray Conis is exhausted, destroy each creature.\n",
             "locale": {
-                "de": {
-                    "name": "Dray Conis"
-                },
                 "en": {
-                    "name": "Dray Conis"
-                },
-                "es": {
-                    "name": "Dray Conis"
-                },
-                "fr": {
-                    "name": "Dray Conis"
-                },
-                "it": {
-                    "name": "Dray Conis"
-                },
-                "pl": {
-                    "name": "Dray Conis"
-                },
-                "pt": {
-                    "name": "Dray Conis"
-                },
-                "th": {
-                    "name": "Dray Conis"
-                },
-                "vi": {
-                    "name": "Dray Conis"
-                },
-                "zhhans": {
-                    "name": "Dray Conis"
-                },
-                "zhhant": {
                     "name": "Dray Conis"
                 }
             }
@@ -7684,37 +3087,7 @@
             "power": null,
             "text": "Play: For each forged key your opponent has, an enemy creature captures 2 from its own side.\n",
             "locale": {
-                "de": {
-                    "name": "Goldene Bürde"
-                },
                 "en": {
-                    "name": "Gilded Burden"
-                },
-                "es": {
-                    "name": "Gilded Burden"
-                },
-                "fr": {
-                    "name": "Fardeau Doré"
-                },
-                "it": {
-                    "name": "Gilded Burden"
-                },
-                "pl": {
-                    "name": "Gilded Burden"
-                },
-                "pt": {
-                    "name": "Gilded Burden"
-                },
-                "th": {
-                    "name": "Gilded Burden"
-                },
-                "vi": {
-                    "name": "Gilded Burden"
-                },
-                "zhhans": {
-                    "name": "Gilded Burden"
-                },
-                "zhhant": {
                     "name": "Gilded Burden"
                 }
             }
@@ -7735,37 +3108,7 @@
             "power": null,
             "text": "This creature gains, “After Fight/After Reap: If you are overwhelmed, gain 1 and deal 3 to an enemy creature.”\n",
             "locale": {
-                "de": {
-                    "name": "Schatzschürfer"
-                },
                 "en": {
-                    "name": "Hoardgouge"
-                },
-                "es": {
-                    "name": "Hoardgouge"
-                },
-                "fr": {
-                    "name": "Creuse-Butin"
-                },
-                "it": {
-                    "name": "Hoardgouge"
-                },
-                "pl": {
-                    "name": "Hoardgouge"
-                },
-                "pt": {
-                    "name": "Hoardgouge"
-                },
-                "th": {
-                    "name": "Hoardgouge"
-                },
-                "vi": {
-                    "name": "Hoardgouge"
-                },
-                "zhhans": {
-                    "name": "Hoardgouge"
-                },
-                "zhhant": {
                     "name": "Hoardgouge"
                 }
             }
@@ -7786,37 +3129,7 @@
             "power": null,
             "text": "",
             "locale": {
-                "de": {
-                    "name": "Kulsha"
-                },
                 "en": {
-                    "name": "Kulsha"
-                },
-                "es": {
-                    "name": "Kulsha"
-                },
-                "fr": {
-                    "name": "Kulsha"
-                },
-                "it": {
-                    "name": "Kulsha"
-                },
-                "pl": {
-                    "name": "Kulsha"
-                },
-                "pt": {
-                    "name": "Kulsha"
-                },
-                "th": {
-                    "name": "Kulsha"
-                },
-                "vi": {
-                    "name": "Kulsha"
-                },
-                "zhhans": {
-                    "name": "Kulsha"
-                },
-                "zhhant": {
                     "name": "Kulsha"
                 }
             }
@@ -7829,9 +3142,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "traits": ["dragon"],
             "type": "gigantic creature base",
             "rarity": "Special",
             "amber": 0,
@@ -7839,37 +3150,7 @@
             "power": 15,
             "text": "(Play only with the other half of Kulsha.)\nYour opponent’s keys cost +2 for each forged key they have. \nAfter Fight/After Reap: Exhaust up to 3 creatures.\n",
             "locale": {
-                "de": {
-                    "name": "Kulsha"
-                },
                 "en": {
-                    "name": "Kulsha"
-                },
-                "es": {
-                    "name": "Kulsha"
-                },
-                "fr": {
-                    "name": "Kulsha"
-                },
-                "it": {
-                    "name": "Kulsha"
-                },
-                "pl": {
-                    "name": "Kulsha"
-                },
-                "pt": {
-                    "name": "Kulsha"
-                },
-                "th": {
-                    "name": "Kulsha"
-                },
-                "vi": {
-                    "name": "Kulsha"
-                },
-                "zhhans": {
-                    "name": "Kulsha"
-                },
-                "zhhant": {
                     "name": "Kulsha"
                 }
             }
@@ -7882,10 +3163,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon",
-                "psion"
-            ],
+            "traits": ["dragon", "psion"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -7893,37 +3171,7 @@
             "power": 6,
             "text": "While fighting, Nizak, The Forgotten gains invulnerable. (It cannot be destroyed or dealt damage.)\nAfter an enemy creature is destroyed fighting Nizak, The Forgotten, return that creature to its owner’s hand.\n",
             "locale": {
-                "de": {
-                    "name": "Nizak der Vergessene"
-                },
                 "en": {
-                    "name": "Nizak, The Forgotten"
-                },
-                "es": {
-                    "name": "Nizak, The Forgotten"
-                },
-                "fr": {
-                    "name": "Nizak, l’Oublié"
-                },
-                "it": {
-                    "name": "Nizak, The Forgotten"
-                },
-                "pl": {
-                    "name": "Nizak, The Forgotten"
-                },
-                "pt": {
-                    "name": "Nizak, The Forgotten"
-                },
-                "th": {
-                    "name": "Nizak, The Forgotten"
-                },
-                "vi": {
-                    "name": "Nizak, The Forgotten"
-                },
-                "zhhans": {
-                    "name": "Nizak, The Forgotten"
-                },
-                "zhhant": {
                     "name": "Nizak, The Forgotten"
                 }
             }
@@ -7944,37 +3192,7 @@
             "power": null,
             "text": "Play: Ready or exhaust a creature. If there are more exhausted friendly creatures than exhausted enemy creatures, gain 2.\n",
             "locale": {
-                "de": {
-                    "name": "Höchste Autorität"
-                },
                 "en": {
-                    "name": "Prime Authority"
-                },
-                "es": {
-                    "name": "Prime Authority"
-                },
-                "fr": {
-                    "name": "Autorité Primaire"
-                },
-                "it": {
-                    "name": "Prime Authority"
-                },
-                "pl": {
-                    "name": "Prime Authority"
-                },
-                "pt": {
-                    "name": "Prime Authority"
-                },
-                "th": {
-                    "name": "Prime Authority"
-                },
-                "vi": {
-                    "name": "Prime Authority"
-                },
-                "zhhans": {
-                    "name": "Prime Authority"
-                },
-                "zhhant": {
                     "name": "Prime Authority"
                 }
             }
@@ -7987,9 +3205,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -7997,37 +3213,7 @@
             "power": 6,
             "text": "While Seda the Sleeper is exhausted and on a flank, it gains invulnerable. \nAfter you ready Seda the Sleeper, you may deal 2 to it. If you do, exhaust it.\nPlay: Capture 6.\n",
             "locale": {
-                "de": {
-                    "name": "Seda der Schläfer"
-                },
                 "en": {
-                    "name": "Seda the Sleeper"
-                },
-                "es": {
-                    "name": "Seda the Sleeper"
-                },
-                "fr": {
-                    "name": "Satya l’Endormi"
-                },
-                "it": {
-                    "name": "Seda the Sleeper"
-                },
-                "pl": {
-                    "name": "Seda the Sleeper"
-                },
-                "pt": {
-                    "name": "Seda the Sleeper"
-                },
-                "th": {
-                    "name": "Seda the Sleeper"
-                },
-                "vi": {
-                    "name": "Seda the Sleeper"
-                },
-                "zhhans": {
-                    "name": "Seda the Sleeper"
-                },
-                "zhhant": {
                     "name": "Seda the Sleeper"
                 }
             }
@@ -8048,37 +3234,7 @@
             "power": null,
             "text": "Enhance .\nPlay: Destroy an Ouboros creature. If you do, gain 2.\n",
             "locale": {
-                "de": {
-                    "name": "Schlafschwund"
-                },
                 "en": {
-                    "name": "Sleepwither"
-                },
-                "es": {
-                    "name": "Sleepwither"
-                },
-                "fr": {
-                    "name": "Sommeil Flétrissant"
-                },
-                "it": {
-                    "name": "Sleepwither"
-                },
-                "pl": {
-                    "name": "Sleepwither"
-                },
-                "pt": {
-                    "name": "Sleepwither"
-                },
-                "th": {
-                    "name": "Sleepwither"
-                },
-                "vi": {
-                    "name": "Sleepwither"
-                },
-                "zhhans": {
-                    "name": "Sleepwither"
-                },
-                "zhhant": {
                     "name": "Sleepwither"
                 }
             }
@@ -8091,9 +3247,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "treasure"
-            ],
+            "traits": ["treasure"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 1,
@@ -8101,37 +3255,7 @@
             "power": null,
             "text": "Action: Destroy Spherular Gem. If you do, gain  equal to the number of forged keys.\n",
             "locale": {
-                "de": {
-                    "name": "Kugelartige Gemme"
-                },
                 "en": {
-                    "name": "Spherular Gem"
-                },
-                "es": {
-                    "name": "Spherular Gem"
-                },
-                "fr": {
-                    "name": "Gemme Sphérulaire"
-                },
-                "it": {
-                    "name": "Spherular Gem"
-                },
-                "pl": {
-                    "name": "Spherular Gem"
-                },
-                "pt": {
-                    "name": "Spherular Gem"
-                },
-                "th": {
-                    "name": "Spherular Gem"
-                },
-                "vi": {
-                    "name": "Spherular Gem"
-                },
-                "zhhans": {
-                    "name": "Spherular Gem"
-                },
-                "zhhant": {
                     "name": "Spherular Gem"
                 }
             }
@@ -8144,9 +3268,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -8154,37 +3276,7 @@
             "power": 6,
             "text": "Tranquil Reiner does not ready during your “ready cards” step.\nAfter Fight/After Reap: Ready an exhausted non-Dragon creature. If you do, gain 3.\n",
             "locale": {
-                "de": {
-                    "name": "Reiner der Friedvolle"
-                },
                 "en": {
-                    "name": "Tranquil Reiner"
-                },
-                "es": {
-                    "name": "Tranquil Reiner"
-                },
-                "fr": {
-                    "name": "Tranquille Émile"
-                },
-                "it": {
-                    "name": "Tranquil Reiner"
-                },
-                "pl": {
-                    "name": "Tranquil Reiner"
-                },
-                "pt": {
-                    "name": "Tranquil Reiner"
-                },
-                "th": {
-                    "name": "Tranquil Reiner"
-                },
-                "vi": {
-                    "name": "Tranquil Reiner"
-                },
-                "zhhans": {
-                    "name": "Tranquil Reiner"
-                },
-                "zhhant": {
                     "name": "Tranquil Reiner"
                 }
             }
@@ -8197,10 +3289,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon",
-                "sage"
-            ],
+            "traits": ["dragon", "sage"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -8208,37 +3297,7 @@
             "power": 6,
             "text": "After Reap: Choose a creature. Until the start of your next turn, that creature gains invulnerable. (It cannot be destroyed or dealt damage.)\n",
             "locale": {
-                "de": {
-                    "name": "Treok der Weise"
-                },
                 "en": {
-                    "name": "Treok, The Wise"
-                },
-                "es": {
-                    "name": "Treok, The Wise"
-                },
-                "fr": {
-                    "name": "Treok, le Judicieux"
-                },
-                "it": {
-                    "name": "Treok, The Wise"
-                },
-                "pl": {
-                    "name": "Treok, The Wise"
-                },
-                "pt": {
-                    "name": "Treok, The Wise"
-                },
-                "th": {
-                    "name": "Treok, The Wise"
-                },
-                "vi": {
-                    "name": "Treok, The Wise"
-                },
-                "zhhans": {
-                    "name": "Treok, The Wise"
-                },
-                "zhhant": {
                     "name": "Treok, The Wise"
                 }
             }
@@ -8251,9 +3310,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -8261,37 +3318,7 @@
             "power": 4,
             "text": "Your keys cost –1 for each forged key your opponent has.\n",
             "locale": {
-                "de": {
-                    "name": "Bollwerkklaue"
-                },
                 "en": {
-                    "name": "Bastionclaw"
-                },
-                "es": {
-                    "name": "Bastionclaw"
-                },
-                "fr": {
-                    "name": "Bastus le Griffu"
-                },
-                "it": {
-                    "name": "Bastionclaw"
-                },
-                "pl": {
-                    "name": "Bastionclaw"
-                },
-                "pt": {
-                    "name": "Bastionclaw"
-                },
-                "th": {
-                    "name": "Bastionclaw"
-                },
-                "vi": {
-                    "name": "Bastionclaw"
-                },
-                "zhhans": {
-                    "name": "Bastionclaw"
-                },
-                "zhhant": {
                     "name": "Bastionclaw"
                 }
             }
@@ -8303,10 +3330,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_137_604de4641871_en.png",
             "expansion": 928,
             "house": "ouboros",
-            "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "keywords": ["entrench"],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -8314,37 +3339,7 @@
             "power": 3,
             "text": "Entrench.\nAt the end of your turn, if Caspart is exhausted, exhaust 2 other creatures.\n",
             "locale": {
-                "de": {
-                    "name": "Caspart"
-                },
                 "en": {
-                    "name": "Caspart"
-                },
-                "es": {
-                    "name": "Caspart"
-                },
-                "fr": {
-                    "name": "Caspard"
-                },
-                "it": {
-                    "name": "Caspart"
-                },
-                "pl": {
-                    "name": "Caspart"
-                },
-                "pt": {
-                    "name": "Caspart"
-                },
-                "th": {
-                    "name": "Caspart"
-                },
-                "vi": {
-                    "name": "Caspart"
-                },
-                "zhhans": {
-                    "name": "Caspart"
-                },
-                "zhhant": {
                     "name": "Caspart"
                 }
             }
@@ -8365,37 +3360,7 @@
             "power": null,
             "text": "Play: Shuffle any number of Dragon creatures from your discard pile into your deck.\n",
             "locale": {
-                "de": {
-                    "name": "DRACHEN!!!"
-                },
                 "en": {
-                    "name": "DRAGONS!!!"
-                },
-                "es": {
-                    "name": "DRAGONS!!!"
-                },
-                "fr": {
-                    "name": "DRAGONS !!!"
-                },
-                "it": {
-                    "name": "DRAGONS!!!"
-                },
-                "pl": {
-                    "name": "DRAGONS!!!"
-                },
-                "pt": {
-                    "name": "DRAGONS!!!"
-                },
-                "th": {
-                    "name": "DRAGONS!!!"
-                },
-                "vi": {
-                    "name": "DRAGONS!!!"
-                },
-                "zhhans": {
-                    "name": "DRAGONS!!!"
-                },
-                "zhhant": {
                     "name": "DRAGONS!!!"
                 }
             }
@@ -8416,37 +3381,7 @@
             "power": null,
             "text": "Play: Exhaust each non-Dragon creature.\n",
             "locale": {
-                "de": {
-                    "name": "Schnarchschwinge"
-                },
                 "en": {
-                    "name": "Doze Wing"
-                },
-                "es": {
-                    "name": "Doze Wing"
-                },
-                "fr": {
-                    "name": "Sous Son Aile"
-                },
-                "it": {
-                    "name": "Doze Wing"
-                },
-                "pl": {
-                    "name": "Doze Wing"
-                },
-                "pt": {
-                    "name": "Doze Wing"
-                },
-                "th": {
-                    "name": "Doze Wing"
-                },
-                "vi": {
-                    "name": "Doze Wing"
-                },
-                "zhhans": {
-                    "name": "Doze Wing"
-                },
-                "zhhant": {
                     "name": "Doze Wing"
                 }
             }
@@ -8467,37 +3402,7 @@
             "power": null,
             "text": "Play: For each color represented among forged keys, steal 1.\n",
             "locale": {
-                "de": {
-                    "name": "Glitzernde Horde"
-                },
                 "en": {
-                    "name": "Glittering Horde"
-                },
-                "es": {
-                    "name": "Glittering Horde"
-                },
-                "fr": {
-                    "name": "Horde Scintillante"
-                },
-                "it": {
-                    "name": "Glittering Horde"
-                },
-                "pl": {
-                    "name": "Glittering Horde"
-                },
-                "pt": {
-                    "name": "Glittering Horde"
-                },
-                "th": {
-                    "name": "Glittering Horde"
-                },
-                "vi": {
-                    "name": "Glittering Horde"
-                },
-                "zhhans": {
-                    "name": "Glittering Horde"
-                },
-                "zhhant": {
                     "name": "Glittering Horde"
                 }
             }
@@ -8510,9 +3415,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -8520,37 +3423,7 @@
             "power": 4,
             "text": "Ignitus gains splash-attack X, where X is the number of exhausted creatures.\n",
             "locale": {
-                "de": {
-                    "name": "Ignitus"
-                },
                 "en": {
-                    "name": "Ignitus"
-                },
-                "es": {
-                    "name": "Ignitus"
-                },
-                "fr": {
-                    "name": "Allumax"
-                },
-                "it": {
-                    "name": "Ignitus"
-                },
-                "pl": {
-                    "name": "Ignitus"
-                },
-                "pt": {
-                    "name": "Ignitus"
-                },
-                "th": {
-                    "name": "Ignitus"
-                },
-                "vi": {
-                    "name": "Ignitus"
-                },
-                "zhhans": {
-                    "name": "Ignitus"
-                },
-                "zhhant": {
                     "name": "Ignitus"
                 }
             }
@@ -8562,10 +3435,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_142_04f306267c69_en.png",
             "expansion": 928,
             "house": "ouboros",
-            "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "keywords": ["entrench"],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -8573,37 +3444,7 @@
             "power": 4,
             "text": "Entrench.\nAt the start of your turn, if Noxious Ionox is exhausted, destroy an enemy creature.\n",
             "locale": {
-                "de": {
-                    "name": "Toxischer Ionos"
-                },
                 "en": {
-                    "name": "Noxious Ionox"
-                },
-                "es": {
-                    "name": "Noxious Ionox"
-                },
-                "fr": {
-                    "name": "Smaragdin le Nocif"
-                },
-                "it": {
-                    "name": "Noxious Ionox"
-                },
-                "pl": {
-                    "name": "Noxious Ionox"
-                },
-                "pt": {
-                    "name": "Noxious Ionox"
-                },
-                "th": {
-                    "name": "Noxious Ionox"
-                },
-                "vi": {
-                    "name": "Noxious Ionox"
-                },
-                "zhhans": {
-                    "name": "Noxious Ionox"
-                },
-                "zhhant": {
                     "name": "Noxious Ionox"
                 }
             }
@@ -8624,37 +3465,7 @@
             "power": null,
             "text": "Play: Forge a key at +8 current cost, reduced by 1 for each  in your opponent’s pool. If you do, purge Parasitic Charge.\n",
             "locale": {
-                "de": {
-                    "name": "Parasitäre Aufladung"
-                },
                 "en": {
-                    "name": "Parasitic Charge"
-                },
-                "es": {
-                    "name": "Parasitic Charge"
-                },
-                "fr": {
-                    "name": "Charge Parasite"
-                },
-                "it": {
-                    "name": "Parasitic Charge"
-                },
-                "pl": {
-                    "name": "Parasitic Charge"
-                },
-                "pt": {
-                    "name": "Parasitic Charge"
-                },
-                "th": {
-                    "name": "Parasitic Charge"
-                },
-                "vi": {
-                    "name": "Parasitic Charge"
-                },
-                "zhhans": {
-                    "name": "Parasitic Charge"
-                },
-                "zhhant": {
                     "name": "Parasitic Charge"
                 }
             }
@@ -8675,37 +3486,7 @@
             "power": null,
             "text": "Play: Until the start of your next turn, creatures cannot ready.\n",
             "locale": {
-                "de": {
-                    "name": "Thermische Erschöpfung"
-                },
                 "en": {
-                    "name": "Thermal Depletion"
-                },
-                "es": {
-                    "name": "Thermal Depletion"
-                },
-                "fr": {
-                    "name": "Réduire en Cendres"
-                },
-                "it": {
-                    "name": "Thermal Depletion"
-                },
-                "pl": {
-                    "name": "Thermal Depletion"
-                },
-                "pt": {
-                    "name": "Thermal Depletion"
-                },
-                "th": {
-                    "name": "Thermal Depletion"
-                },
-                "vi": {
-                    "name": "Thermal Depletion"
-                },
-                "zhhans": {
-                    "name": "Thermal Depletion"
-                },
-                "zhhant": {
                     "name": "Thermal Depletion"
                 }
             }
@@ -8726,37 +3507,7 @@
             "power": null,
             "text": "Play: Shuffle each friendly card in play into your deck. Draw a card for each card shuffled into your deck this way.\n",
             "locale": {
-                "de": {
-                    "name": "Zeitbeben"
-                },
                 "en": {
-                    "name": "Timequake"
-                },
-                "es": {
-                    "name": "Timequake"
-                },
-                "fr": {
-                    "name": "Tremblement de Temps"
-                },
-                "it": {
-                    "name": "Timequake"
-                },
-                "pl": {
-                    "name": "Timequake"
-                },
-                "pt": {
-                    "name": "Timequake"
-                },
-                "th": {
-                    "name": "Timequake"
-                },
-                "vi": {
-                    "name": "Timequake"
-                },
-                "zhhans": {
-                    "name": "Timequake"
-                },
-                "zhhant": {
                     "name": "Timequake"
                 }
             }
@@ -8769,9 +3520,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -8779,37 +3528,7 @@
             "power": 5,
             "text": "After Reap: Use an enemy artifact as if it were yours. Put that artifact on the bottom of its owner’s deck.\n",
             "locale": {
-                "de": {
-                    "name": "Voltash Blitzatem"
-                },
                 "en": {
-                    "name": "Voltash Coilbreath"
-                },
-                "es": {
-                    "name": "Voltash Coilbreath"
-                },
-                "fr": {
-                    "name": "Voltach le Fulgurant"
-                },
-                "it": {
-                    "name": "Voltash Coilbreath"
-                },
-                "pl": {
-                    "name": "Voltash Coilbreath"
-                },
-                "pt": {
-                    "name": "Voltash Coilbreath"
-                },
-                "th": {
-                    "name": "Voltash Coilbreath"
-                },
-                "vi": {
-                    "name": "Voltash Coilbreath"
-                },
-                "zhhans": {
-                    "name": "Voltash Coilbreath"
-                },
-                "zhhant": {
                     "name": "Voltash Coilbreath"
                 }
             }
@@ -8822,9 +3541,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -8832,37 +3549,7 @@
             "power": 5,
             "text": "After Reap: Ready and use a friendly non-Dragon creature.\n",
             "locale": {
-                "de": {
-                    "name": "Zartoo der Flinke"
-                },
                 "en": {
-                    "name": "Zartoo, the Swift"
-                },
-                "es": {
-                    "name": "Zartoo, the Swift"
-                },
-                "fr": {
-                    "name": "Zartou, le Doux"
-                },
-                "it": {
-                    "name": "Zartoo, the Swift"
-                },
-                "pl": {
-                    "name": "Zartoo, the Swift"
-                },
-                "pt": {
-                    "name": "Zartoo, the Swift"
-                },
-                "th": {
-                    "name": "Zartoo, the Swift"
-                },
-                "vi": {
-                    "name": "Zartoo, the Swift"
-                },
-                "zhhans": {
-                    "name": "Zartoo, the Swift"
-                },
-                "zhhant": {
                     "name": "Zartoo, the Swift"
                 }
             }
@@ -8883,37 +3570,7 @@
             "power": null,
             "text": "Play: Choose a friendly exhausted creature. Ready and use that creature.\n",
             "locale": {
-                "de": {
-                    "name": "Arkane Erleichterung"
-                },
                 "en": {
-                    "name": "Arcane Relief"
-                },
-                "es": {
-                    "name": "Arcane Relief"
-                },
-                "fr": {
-                    "name": "Relève Arcanique"
-                },
-                "it": {
-                    "name": "Arcane Relief"
-                },
-                "pl": {
-                    "name": "Arcane Relief"
-                },
-                "pt": {
-                    "name": "Arcane Relief"
-                },
-                "th": {
-                    "name": "Arcane Relief"
-                },
-                "vi": {
-                    "name": "Arcane Relief"
-                },
-                "zhhans": {
-                    "name": "Arcane Relief"
-                },
-                "zhhant": {
                     "name": "Arcane Relief"
                 }
             }
@@ -8934,37 +3591,7 @@
             "power": null,
             "text": "Play: If you are overwhelmed, choose a friendly creature. For each creature your opponent controls in excess of you, the chosen creature captures 1.\n",
             "locale": {
-                "de": {
-                    "name": "Klauenmantelschlag"
-                },
                 "en": {
-                    "name": "Clawcloak Swipe"
-                },
-                "es": {
-                    "name": "Clawcloak Swipe"
-                },
-                "fr": {
-                    "name": "Revers de Fortune"
-                },
-                "it": {
-                    "name": "Clawcloak Swipe"
-                },
-                "pl": {
-                    "name": "Clawcloak Swipe"
-                },
-                "pt": {
-                    "name": "Clawcloak Swipe"
-                },
-                "th": {
-                    "name": "Clawcloak Swipe"
-                },
-                "vi": {
-                    "name": "Clawcloak Swipe"
-                },
-                "zhhans": {
-                    "name": "Clawcloak Swipe"
-                },
-                "zhhant": {
                     "name": "Clawcloak Swipe"
                 }
             }
@@ -8977,9 +3604,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -8987,37 +3612,7 @@
             "power": 6,
             "text": "After a player readies a creature, deal 1 to it.\n",
             "locale": {
-                "de": {
-                    "name": "Kosmokrax"
-                },
                 "en": {
-                    "name": "Cosmicrux"
-                },
-                "es": {
-                    "name": "Cosmicrux"
-                },
-                "fr": {
-                    "name": "Cosmicrux"
-                },
-                "it": {
-                    "name": "Cosmicrux"
-                },
-                "pl": {
-                    "name": "Cosmicrux"
-                },
-                "pt": {
-                    "name": "Cosmicrux"
-                },
-                "th": {
-                    "name": "Cosmicrux"
-                },
-                "vi": {
-                    "name": "Cosmicrux"
-                },
-                "zhhans": {
-                    "name": "Cosmicrux"
-                },
-                "zhhant": {
                     "name": "Cosmicrux"
                 }
             }
@@ -9030,9 +3625,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -9040,37 +3633,7 @@
             "power": 4,
             "text": "After Fight: Gain 1 for each ready friendly creature of the active house.\n",
             "locale": {
-                "de": {
-                    "name": "Deltas der Kühne"
-                },
                 "en": {
-                    "name": "Daring Delt"
-                },
-                "es": {
-                    "name": "Daring Delt"
-                },
-                "fr": {
-                    "name": "Delth l’Audacieuse"
-                },
-                "it": {
-                    "name": "Daring Delt"
-                },
-                "pl": {
-                    "name": "Daring Delt"
-                },
-                "pt": {
-                    "name": "Daring Delt"
-                },
-                "th": {
-                    "name": "Daring Delt"
-                },
-                "vi": {
-                    "name": "Daring Delt"
-                },
-                "zhhans": {
-                    "name": "Daring Delt"
-                },
-                "zhhant": {
                     "name": "Daring Delt"
                 }
             }
@@ -9091,37 +3654,7 @@
             "power": null,
             "text": "Play: Each friendly exhausted creature captures 1.\n",
             "locale": {
-                "de": {
-                    "name": "Beute horten"
-                },
                 "en": {
-                    "name": "Hoarding the Goods"
-                },
-                "es": {
-                    "name": "Hoarding the Goods"
-                },
-                "fr": {
-                    "name": "Accaparer les Biens"
-                },
-                "it": {
-                    "name": "Hoarding the Goods"
-                },
-                "pl": {
-                    "name": "Hoarding the Goods"
-                },
-                "pt": {
-                    "name": "Hoarding the Goods"
-                },
-                "th": {
-                    "name": "Hoarding the Goods"
-                },
-                "vi": {
-                    "name": "Hoarding the Goods"
-                },
-                "zhhans": {
-                    "name": "Hoarding the Goods"
-                },
-                "zhhant": {
                     "name": "Hoarding the Goods"
                 }
             }
@@ -9142,37 +3675,7 @@
             "power": null,
             "text": "Play: If you are overwhelmed, exhaust each creature. Otherwise, exhaust a creature.\n",
             "locale": {
-                "de": {
-                    "name": "Leylinien"
-                },
                 "en": {
-                    "name": "Ley Lines"
-                },
-                "es": {
-                    "name": "Ley Lines"
-                },
-                "fr": {
-                    "name": "Lignes Telluriques"
-                },
-                "it": {
-                    "name": "Ley Lines"
-                },
-                "pl": {
-                    "name": "Ley Lines"
-                },
-                "pt": {
-                    "name": "Ley Lines"
-                },
-                "th": {
-                    "name": "Ley Lines"
-                },
-                "vi": {
-                    "name": "Ley Lines"
-                },
-                "zhhans": {
-                    "name": "Ley Lines"
-                },
-                "zhhant": {
                     "name": "Ley Lines"
                 }
             }
@@ -9185,9 +3688,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -9195,37 +3696,7 @@
             "power": 2,
             "text": "Play: If your opponent has more forged keys than you, steal 2. Otherwise, capture 2.\n",
             "locale": {
-                "de": {
-                    "name": "Pip der Langfinger"
-                },
                 "en": {
-                    "name": "Pip the Pilferer"
-                },
-                "es": {
-                    "name": "Pip the Pilferer"
-                },
-                "fr": {
-                    "name": "Pip le Chapardeur"
-                },
-                "it": {
-                    "name": "Pip the Pilferer"
-                },
-                "pl": {
-                    "name": "Pip the Pilferer"
-                },
-                "pt": {
-                    "name": "Pip the Pilferer"
-                },
-                "th": {
-                    "name": "Pip the Pilferer"
-                },
-                "vi": {
-                    "name": "Pip the Pilferer"
-                },
-                "zhhans": {
-                    "name": "Pip the Pilferer"
-                },
-                "zhhant": {
                     "name": "Pip the Pilferer"
                 }
             }
@@ -9238,9 +3709,7 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -9248,37 +3717,7 @@
             "power": 2,
             "text": "Enhance .\nAfter Fight/After Reap: If you are overwhelmed, capture 1 for each +1 power counter on friendly creatures. Otherwise, capture 1.\n",
             "locale": {
-                "de": {
-                    "name": "Ria Schwarmgier"
-                },
                 "en": {
-                    "name": "Ria Bevy Gress"
-                },
-                "es": {
-                    "name": "Ria Bevy Gress"
-                },
-                "fr": {
-                    "name": "Ria Bevy Gress"
-                },
-                "it": {
-                    "name": "Ria Bevy Gress"
-                },
-                "pl": {
-                    "name": "Ria Bevy Gress"
-                },
-                "pt": {
-                    "name": "Ria Bevy Gress"
-                },
-                "th": {
-                    "name": "Ria Bevy Gress"
-                },
-                "vi": {
-                    "name": "Ria Bevy Gress"
-                },
-                "zhhans": {
-                    "name": "Ria Bevy Gress"
-                },
-                "zhhant": {
                     "name": "Ria Bevy Gress"
                 }
             }
@@ -9290,13 +3729,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_156_4035d48321a1_en.png",
             "expansion": 928,
             "house": "ouboros",
-            "keywords": [
-                "treachery",
-                "versatile"
-            ],
-            "traits": [
-                "dragon"
-            ],
+            "keywords": ["treachery", "versatile"],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -9304,37 +3738,7 @@
             "power": 4,
             "text": "Treachery. Versatile.\nAfter a friendly creature is used, deal 1 to each friendly creature.\n",
             "locale": {
-                "de": {
-                    "name": "Schattenfinstergroll"
-                },
                 "en": {
-                    "name": "Shadow Gloomcoil"
-                },
-                "es": {
-                    "name": "Shadow Gloomcoil"
-                },
-                "fr": {
-                    "name": "Aigrefin des Ombres"
-                },
-                "it": {
-                    "name": "Shadow Gloomcoil"
-                },
-                "pl": {
-                    "name": "Shadow Gloomcoil"
-                },
-                "pt": {
-                    "name": "Shadow Gloomcoil"
-                },
-                "th": {
-                    "name": "Shadow Gloomcoil"
-                },
-                "vi": {
-                    "name": "Shadow Gloomcoil"
-                },
-                "zhhans": {
-                    "name": "Shadow Gloomcoil"
-                },
-                "zhhant": {
                     "name": "Shadow Gloomcoil"
                 }
             }
@@ -9346,10 +3750,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_157_8a60e0c7e031_en.png",
             "expansion": 928,
             "house": "ouboros",
-            "keywords": [],
-            "traits": [
-                "dragon"
-            ],
+            "keywords": ["entrench"],
+            "traits": ["dragon"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -9357,37 +3759,7 @@
             "power": 3,
             "text": "Entrench.\nAt the end of your turn, if Snapper Dyn is exhausted, deal 1 to an enemy creature for each  in your opponent’s pool.\n",
             "locale": {
-                "de": {
-                    "name": "Schnapper Dyn"
-                },
                 "en": {
-                    "name": "Snapper Dyn"
-                },
-                "es": {
-                    "name": "Snapper Dyn"
-                },
-                "fr": {
-                    "name": "Dyn le Happeur"
-                },
-                "it": {
-                    "name": "Snapper Dyn"
-                },
-                "pl": {
-                    "name": "Snapper Dyn"
-                },
-                "pt": {
-                    "name": "Snapper Dyn"
-                },
-                "th": {
-                    "name": "Snapper Dyn"
-                },
-                "vi": {
-                    "name": "Snapper Dyn"
-                },
-                "zhhans": {
-                    "name": "Snapper Dyn"
-                },
-                "zhhant": {
                     "name": "Snapper Dyn"
                 }
             }
@@ -9399,11 +3771,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_158_2834e0b3e8e7_en.png",
             "expansion": 928,
             "house": "ouboros",
-            "keywords": [],
-            "traits": [
-                "dragon",
-                "cyborg"
-            ],
+            "keywords": ["entrench"],
+            "traits": ["dragon", "cyborg"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -9411,37 +3780,7 @@
             "power": 3,
             "text": "Entrench.\nAfter an enemy creature reaps, if Sparkscheme is exhausted, draw a card.\n",
             "locale": {
-                "de": {
-                    "name": "Funkenplan"
-                },
                 "en": {
-                    "name": "Sparkscheme"
-                },
-                "es": {
-                    "name": "Sparkscheme"
-                },
-                "fr": {
-                    "name": "Châtaigne"
-                },
-                "it": {
-                    "name": "Sparkscheme"
-                },
-                "pl": {
-                    "name": "Sparkscheme"
-                },
-                "pt": {
-                    "name": "Sparkscheme"
-                },
-                "th": {
-                    "name": "Sparkscheme"
-                },
-                "vi": {
-                    "name": "Sparkscheme"
-                },
-                "zhhans": {
-                    "name": "Sparkscheme"
-                },
-                "zhhant": {
                     "name": "Sparkscheme"
                 }
             }
@@ -9462,37 +3801,7 @@
             "power": null,
             "text": "Play: Deal 3 to a creature. If this damage destroys that creature, draw a card.\n",
             "locale": {
-                "de": {
-                    "name": "Wunden der Vorhut"
-                },
                 "en": {
-                    "name": "Vanguard Wounds"
-                },
-                "es": {
-                    "name": "Vanguard Wounds"
-                },
-                "fr": {
-                    "name": "Blessures Préventives"
-                },
-                "it": {
-                    "name": "Vanguard Wounds"
-                },
-                "pl": {
-                    "name": "Vanguard Wounds"
-                },
-                "pt": {
-                    "name": "Vanguard Wounds"
-                },
-                "th": {
-                    "name": "Vanguard Wounds"
-                },
-                "vi": {
-                    "name": "Vanguard Wounds"
-                },
-                "zhhans": {
-                    "name": "Vanguard Wounds"
-                },
-                "zhhant": {
                     "name": "Vanguard Wounds"
                 }
             }
@@ -9505,9 +3814,7 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [
-                "robot"
-            ],
+            "traits": ["robot"],
             "type": "gigantic creature base",
             "rarity": "Special",
             "amber": 0,
@@ -9515,37 +3822,7 @@
             "power": 7,
             "text": "(Play only with the other half of Boosted B4-RRY.)\nPlay/After Fight/After Reap: Choose one:\nTake control of an enemy artifact. While under your control, it belongs to house Shadows (instead of its original house).\nPlay a random card from your opponent’s archives as if it were yours.\n",
             "locale": {
-                "de": {
-                    "name": "Verstärkter B4-RRY"
-                },
                 "en": {
-                    "name": "Boosted B4-RRY"
-                },
-                "es": {
-                    "name": "Boosted B4-RRY"
-                },
-                "fr": {
-                    "name": "T0-N10 les Bons Pistons"
-                },
-                "it": {
-                    "name": "Boosted B4-RRY"
-                },
-                "pl": {
-                    "name": "Boosted B4-RRY"
-                },
-                "pt": {
-                    "name": "Boosted B4-RRY"
-                },
-                "th": {
-                    "name": "Boosted B4-RRY"
-                },
-                "vi": {
-                    "name": "Boosted B4-RRY"
-                },
-                "zhhans": {
-                    "name": "Boosted B4-RRY"
-                },
-                "zhhant": {
                     "name": "Boosted B4-RRY"
                 }
             }
@@ -9566,37 +3843,7 @@
             "power": null,
             "text": "",
             "locale": {
-                "de": {
-                    "name": "Verstärkter B4-RRY"
-                },
                 "en": {
-                    "name": "Boosted B4-RRY"
-                },
-                "es": {
-                    "name": "Boosted B4-RRY"
-                },
-                "fr": {
-                    "name": "T0-N10 les Bons Pistons"
-                },
-                "it": {
-                    "name": "Boosted B4-RRY"
-                },
-                "pl": {
-                    "name": "Boosted B4-RRY"
-                },
-                "pt": {
-                    "name": "Boosted B4-RRY"
-                },
-                "th": {
-                    "name": "Boosted B4-RRY"
-                },
-                "vi": {
-                    "name": "Boosted B4-RRY"
-                },
-                "zhhans": {
-                    "name": "Boosted B4-RRY"
-                },
-                "zhhant": {
                     "name": "Boosted B4-RRY"
                 }
             }
@@ -9608,13 +3855,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_161_b2748bc619b2_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": [
-                "elusive"
-            ],
-            "traits": [
-                "elf",
-                "thief"
-            ],
+            "keywords": ["elusive"],
+            "traits": ["elf", "thief"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -9622,37 +3864,7 @@
             "power": 2,
             "text": "Elusive. (The first time this creature is attacked each turn, no damage is dealt.)\nAfter Reap: Destroy a flank creature.",
             "locale": {
-                "de": {
-                    "name": "Scharfauge"
-                },
                 "en": {
-                    "name": "Bulleteye"
-                },
-                "es": {
-                    "name": "Bulleteye"
-                },
-                "fr": {
-                    "name": "Ciblette"
-                },
-                "it": {
-                    "name": "Bulleteye"
-                },
-                "pl": {
-                    "name": "Bulleteye"
-                },
-                "pt": {
-                    "name": "Bulleteye"
-                },
-                "th": {
-                    "name": "Bulleteye"
-                },
-                "vi": {
-                    "name": "Bulleteye"
-                },
-                "zhhans": {
-                    "name": "Bulleteye"
-                },
-                "zhhant": {
                     "name": "Bulleteye"
                 }
             }
@@ -9665,9 +3877,7 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [
-                "item"
-            ],
+            "traits": ["item"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -9675,37 +3885,7 @@
             "power": null,
             "text": "Enhance .\nEach friendly Shadows creature gains hazardous 2.\n",
             "locale": {
-                "de": {
-                    "name": "Cheval-de-Frise"
-                },
                 "en": {
-                    "name": "Cheval de Frise"
-                },
-                "es": {
-                    "name": "Cheval de Frise"
-                },
-                "fr": {
-                    "name": "Cheval de Frise"
-                },
-                "it": {
-                    "name": "Cheval de Frise"
-                },
-                "pl": {
-                    "name": "Cheval de Frise"
-                },
-                "pt": {
-                    "name": "Cheval de Frise"
-                },
-                "th": {
-                    "name": "Cheval de Frise"
-                },
-                "vi": {
-                    "name": "Cheval de Frise"
-                },
-                "zhhans": {
-                    "name": "Cheval de Frise"
-                },
-                "zhhant": {
                     "name": "Cheval de Frise"
                 }
             }
@@ -9726,37 +3906,7 @@
             "power": null,
             "text": "Play: Exalt each damaged enemy creature.",
             "locale": {
-                "de": {
-                    "name": "Leichte Opfer"
-                },
                 "en": {
-                    "name": "Easy Marks"
-                },
-                "es": {
-                    "name": "Easy Marks"
-                },
-                "fr": {
-                    "name": "Marques Faciles"
-                },
-                "it": {
-                    "name": "Easy Marks"
-                },
-                "pl": {
-                    "name": "Easy Marks"
-                },
-                "pt": {
-                    "name": "Easy Marks"
-                },
-                "th": {
-                    "name": "Easy Marks"
-                },
-                "vi": {
-                    "name": "Easy Marks"
-                },
-                "zhhans": {
-                    "name": "Easy Marks"
-                },
-                "zhhant": {
                     "name": "Easy Marks"
                 }
             }
@@ -9777,37 +3927,7 @@
             "power": null,
             "text": "Play: Destroy a damaged creature. If you do, steal 1.\n",
             "locale": {
-                "de": {
-                    "name": "Todesstoß"
-                },
                 "en": {
-                    "name": "Finishing Blow"
-                },
-                "es": {
-                    "name": "Finishing Blow"
-                },
-                "fr": {
-                    "name": "Coup de Grâce"
-                },
-                "it": {
-                    "name": "Finishing Blow"
-                },
-                "pl": {
-                    "name": "Finishing Blow"
-                },
-                "pt": {
-                    "name": "Finishing Blow"
-                },
-                "th": {
-                    "name": "Finishing Blow"
-                },
-                "vi": {
-                    "name": "Finishing Blow"
-                },
-                "zhhans": {
-                    "name": "Finishing Blow"
-                },
-                "zhhant": {
                     "name": "Finishing Blow"
                 }
             }
@@ -9819,13 +3939,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_165_a52b46ee6548_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": [
-                "elusive"
-            ],
-            "traits": [
-                "elf",
-                "politician"
-            ],
+            "keywords": ["elusive"],
+            "traits": ["elf", "politician"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -9833,37 +3948,7 @@
             "power": 2,
             "text": "Elusive.\nYou may spend up to 3 from your opponent’s pool when forging keys.\n",
             "locale": {
-                "de": {
-                    "name": "Ehrenwerter Abagnale"
-                },
                 "en": {
-                    "name": "Honorable Abagnale"
-                },
-                "es": {
-                    "name": "Honorable Abagnale"
-                },
-                "fr": {
-                    "name": "Abagnale l’Honorable"
-                },
-                "it": {
-                    "name": "Honorable Abagnale"
-                },
-                "pl": {
-                    "name": "Honorable Abagnale"
-                },
-                "pt": {
-                    "name": "Honorable Abagnale"
-                },
-                "th": {
-                    "name": "Honorable Abagnale"
-                },
-                "vi": {
-                    "name": "Honorable Abagnale"
-                },
-                "zhhans": {
-                    "name": "Honorable Abagnale"
-                },
-                "zhhant": {
                     "name": "Honorable Abagnale"
                 }
             }
@@ -9884,37 +3969,7 @@
             "power": null,
             "text": "Play: Pay your opponent up to 6. For each  paid this way, draw a card.\n",
             "locale": {
-                "de": {
-                    "name": "Der Rest ist für dich"
-                },
                 "en": {
-                    "name": "Keep the Change"
-                },
-                "es": {
-                    "name": "Keep the Change"
-                },
-                "fr": {
-                    "name": "Garde la Monnaie"
-                },
-                "it": {
-                    "name": "Keep the Change"
-                },
-                "pl": {
-                    "name": "Keep the Change"
-                },
-                "pt": {
-                    "name": "Keep the Change"
-                },
-                "th": {
-                    "name": "Keep the Change"
-                },
-                "vi": {
-                    "name": "Keep the Change"
-                },
-                "zhhans": {
-                    "name": "Keep the Change"
-                },
-                "zhhant": {
                     "name": "Keep the Change"
                 }
             }
@@ -9926,13 +3981,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_167_03b2dc801255_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": [
-                "elusive"
-            ],
-            "traits": [
-                "elf",
-                "thief"
-            ],
+            "keywords": ["elusive"],
+            "traits": ["elf", "thief"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -9940,37 +3990,7 @@
             "power": 4,
             "text": "Elusive.\nAt the end of your opponent's turn, if they drew 2 or more cards during their “draw cards” step, steal 2.\n",
             "locale": {
-                "de": {
-                    "name": "Luis Compère"
-                },
                 "en": {
-                    "name": "Luis Compère"
-                },
-                "es": {
-                    "name": "Luis Compère"
-                },
-                "fr": {
-                    "name": "Compère Louis"
-                },
-                "it": {
-                    "name": "Luis Compère"
-                },
-                "pl": {
-                    "name": "Luis Compère"
-                },
-                "pt": {
-                    "name": "Luis Compère"
-                },
-                "th": {
-                    "name": "Luis Compère"
-                },
-                "vi": {
-                    "name": "Luis Compère"
-                },
-                "zhhans": {
-                    "name": "Luis Compère"
-                },
-                "zhhant": {
                     "name": "Luis Compère"
                 }
             }
@@ -9991,37 +4011,7 @@
             "power": null,
             "text": "This creature cannot be used and gains, “At the start of your turn, you may pay your opponent 2. If you do, destroy Ransom.”\n",
             "locale": {
-                "de": {
-                    "name": "Lösegeld"
-                },
                 "en": {
-                    "name": "Ransom"
-                },
-                "es": {
-                    "name": "Ransom"
-                },
-                "fr": {
-                    "name": "Rançon"
-                },
-                "it": {
-                    "name": "Ransom"
-                },
-                "pl": {
-                    "name": "Ransom"
-                },
-                "pt": {
-                    "name": "Ransom"
-                },
-                "th": {
-                    "name": "Ransom"
-                },
-                "vi": {
-                    "name": "Ransom"
-                },
-                "zhhans": {
-                    "name": "Ransom"
-                },
-                "zhhant": {
                     "name": "Ransom"
                 }
             }
@@ -10042,37 +4032,7 @@
             "power": null,
             "text": "Play: Pay your opponent 1. If you do, take control of an enemy creature or artifact.\n",
             "locale": {
-                "de": {
-                    "name": "Gas geben und greifen"
-                },
                 "en": {
-                    "name": "Rein and Cycle"
-                },
-                "es": {
-                    "name": "Rein and Cycle"
-                },
-                "fr": {
-                    "name": "Gagner au Change"
-                },
-                "it": {
-                    "name": "Rein and Cycle"
-                },
-                "pl": {
-                    "name": "Rein and Cycle"
-                },
-                "pt": {
-                    "name": "Rein and Cycle"
-                },
-                "th": {
-                    "name": "Rein and Cycle"
-                },
-                "vi": {
-                    "name": "Rein and Cycle"
-                },
-                "zhhans": {
-                    "name": "Rein and Cycle"
-                },
-                "zhhant": {
                     "name": "Rein and Cycle"
                 }
             }
@@ -10093,37 +4053,7 @@
             "power": null,
             "text": "Play: Each player discards the top 5 cards of their deck. For each Shadows card discarded, its owner gains 1.\n",
             "locale": {
-                "de": {
-                    "name": "Manipulierte Lotterie"
-                },
                 "en": {
-                    "name": "Rigged Lottery"
-                },
-                "es": {
-                    "name": "Rigged Lottery"
-                },
-                "fr": {
-                    "name": "Loterie Truquée"
-                },
-                "it": {
-                    "name": "Rigged Lottery"
-                },
-                "pl": {
-                    "name": "Rigged Lottery"
-                },
-                "pt": {
-                    "name": "Rigged Lottery"
-                },
-                "th": {
-                    "name": "Rigged Lottery"
-                },
-                "vi": {
-                    "name": "Rigged Lottery"
-                },
-                "zhhans": {
-                    "name": "Rigged Lottery"
-                },
-                "zhhant": {
                     "name": "Rigged Lottery"
                 }
             }
@@ -10144,37 +4074,7 @@
             "power": null,
             "text": "Play: Steal 1. Then, steal 1 for each copy of Routine Job in your discard pile.",
             "locale": {
-                "de": {
-                    "name": "Routinearbeit"
-                },
                 "en": {
-                    "name": "Routine Job"
-                },
-                "es": {
-                    "name": "Routine Job"
-                },
-                "fr": {
-                    "name": "Travail de Routine"
-                },
-                "it": {
-                    "name": "Routine Job"
-                },
-                "pl": {
-                    "name": "Routine Job"
-                },
-                "pt": {
-                    "name": "Routine Job"
-                },
-                "th": {
-                    "name": "Routine Job"
-                },
-                "vi": {
-                    "name": "Routine Job"
-                },
-                "zhhans": {
-                    "name": "Routine Job"
-                },
-                "zhhant": {
                     "name": "Routine Job"
                 }
             }
@@ -10187,10 +4087,7 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [
-                "elf",
-                "thief"
-            ],
+            "traits": ["elf", "thief"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -10198,37 +4095,7 @@
             "power": 3,
             "text": "After Fight/After Reap: Move 1 from a friendly card to your pool.",
             "locale": {
-                "de": {
-                    "name": "Selwyn die Hehlerin"
-                },
                 "en": {
-                    "name": "Selwyn the Fence"
-                },
-                "es": {
-                    "name": "Selwyn the Fence"
-                },
-                "fr": {
-                    "name": "Selwyn la Receleuse"
-                },
-                "it": {
-                    "name": "Selwyn the Fence"
-                },
-                "pl": {
-                    "name": "Selwyn the Fence"
-                },
-                "pt": {
-                    "name": "Selwyn the Fence"
-                },
-                "th": {
-                    "name": "Selwyn the Fence"
-                },
-                "vi": {
-                    "name": "Selwyn the Fence"
-                },
-                "zhhans": {
-                    "name": "Selwyn the Fence"
-                },
-                "zhhant": {
                     "name": "Selwyn the Fence"
                 }
             }
@@ -10241,10 +4108,7 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [
-                "elf",
-                "thief"
-            ],
+            "traits": ["elf", "thief"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -10252,37 +4116,7 @@
             "power": 2,
             "text": "Play: Take control of an enemy artifact. While under your control, if it does not belong to one of your three houses, it belongs to house Shadows.",
             "locale": {
-                "de": {
-                    "name": "Schlangenstehler"
-                },
                 "en": {
-                    "name": "Sneklifter"
-                },
-                "es": {
-                    "name": "Sneklifter"
-                },
-                "fr": {
-                    "name": "Crotale la Détale"
-                },
-                "it": {
-                    "name": "Sneklifter"
-                },
-                "pl": {
-                    "name": "Sneklifter"
-                },
-                "pt": {
-                    "name": "Sneklifter"
-                },
-                "th": {
-                    "name": "Sneklifter"
-                },
-                "vi": {
-                    "name": "Sneklifter"
-                },
-                "zhhans": {
-                    "name": "Sneklifter"
-                },
-                "zhhant": {
                     "name": "Sneklifter"
                 }
             }
@@ -10295,9 +4129,7 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [
-                "power"
-            ],
+            "traits": ["power"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 1,
@@ -10305,37 +4137,7 @@
             "power": null,
             "text": "After a player gains  by reaping, a creature they do not control captures that .\n",
             "locale": {
-                "de": {
-                    "name": "Weitverbreitete Korruption"
-                },
                 "en": {
-                    "name": "Widespread Corruption"
-                },
-                "es": {
-                    "name": "Widespread Corruption"
-                },
-                "fr": {
-                    "name": "Corruption Généralisée"
-                },
-                "it": {
-                    "name": "Widespread Corruption"
-                },
-                "pl": {
-                    "name": "Widespread Corruption"
-                },
-                "pt": {
-                    "name": "Widespread Corruption"
-                },
-                "th": {
-                    "name": "Widespread Corruption"
-                },
-                "vi": {
-                    "name": "Widespread Corruption"
-                },
-                "zhhans": {
-                    "name": "Widespread Corruption"
-                },
-                "zhhant": {
                     "name": "Widespread Corruption"
                 }
             }
@@ -10356,37 +4158,7 @@
             "power": null,
             "text": "Play: Each player shuffles their archives and discard pile into their deck. Discard the top 5 cards of your opponent’s deck. Play the top card of their deck as if it were yours.\n",
             "locale": {
-                "de": {
-                    "name": "Blankoscheck"
-                },
                 "en": {
-                    "name": "Blank Check"
-                },
-                "es": {
-                    "name": "Blank Check"
-                },
-                "fr": {
-                    "name": "Chèque en Blanc"
-                },
-                "it": {
-                    "name": "Blank Check"
-                },
-                "pl": {
-                    "name": "Blank Check"
-                },
-                "pt": {
-                    "name": "Blank Check"
-                },
-                "th": {
-                    "name": "Blank Check"
-                },
-                "vi": {
-                    "name": "Blank Check"
-                },
-                "zhhans": {
-                    "name": "Blank Check"
-                },
-                "zhhant": {
                     "name": "Blank Check"
                 }
             }
@@ -10407,37 +4179,7 @@
             "power": null,
             "text": "Play: Enrage an enemy creature. Move all  from that creature to your pool.\n",
             "locale": {
-                "de": {
-                    "name": "Dreister Diebstahl"
-                },
                 "en": {
-                    "name": "Blatant Thievery"
-                },
-                "es": {
-                    "name": "Blatant Thievery"
-                },
-                "fr": {
-                    "name": "Flagrant Délit"
-                },
-                "it": {
-                    "name": "Blatant Thievery"
-                },
-                "pl": {
-                    "name": "Blatant Thievery"
-                },
-                "pt": {
-                    "name": "Blatant Thievery"
-                },
-                "th": {
-                    "name": "Blatant Thievery"
-                },
-                "vi": {
-                    "name": "Blatant Thievery"
-                },
-                "zhhans": {
-                    "name": "Blatant Thievery"
-                },
-                "zhhant": {
                     "name": "Blatant Thievery"
                 }
             }
@@ -10450,10 +4192,7 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [
-                "elf",
-                "thief"
-            ],
+            "traits": ["elf", "thief"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -10461,37 +4200,7 @@
             "power": 3,
             "text": "After you play Subtle Chain, ready Chain Gang. \nAction: Steal 1. Shuffle a Subtle Chain from your discard pile into your deck.\n",
             "locale": {
-                "de": {
-                    "name": "Ketten-Bande"
-                },
                 "en": {
-                    "name": "Chain Gang"
-                },
-                "es": {
-                    "name": "Chain Gang"
-                },
-                "fr": {
-                    "name": "Récidivistes en Chaîne"
-                },
-                "it": {
-                    "name": "Chain Gang"
-                },
-                "pl": {
-                    "name": "Chain Gang"
-                },
-                "pt": {
-                    "name": "Chain Gang"
-                },
-                "th": {
-                    "name": "Chain Gang"
-                },
-                "vi": {
-                    "name": "Chain Gang"
-                },
-                "zhhans": {
-                    "name": "Chain Gang"
-                },
-                "zhhant": {
                     "name": "Chain Gang"
                 }
             }
@@ -10512,37 +4221,7 @@
             "power": null,
             "text": "Play: If your opponent has more  than you, they lose half of their  (rounding down the loss).\n",
             "locale": {
-                "de": {
-                    "name": "Falschgeld-Affäre"
-                },
                 "en": {
-                    "name": "Counterfeit Controversy"
-                },
-                "es": {
-                    "name": "Counterfeit Controversy"
-                },
-                "fr": {
-                    "name": "Contrefaçon Controversée"
-                },
-                "it": {
-                    "name": "Counterfeit Controversy"
-                },
-                "pl": {
-                    "name": "Counterfeit Controversy"
-                },
-                "pt": {
-                    "name": "Counterfeit Controversy"
-                },
-                "th": {
-                    "name": "Counterfeit Controversy"
-                },
-                "vi": {
-                    "name": "Counterfeit Controversy"
-                },
-                "zhhans": {
-                    "name": "Counterfeit Controversy"
-                },
-                "zhhant": {
                     "name": "Counterfeit Controversy"
                 }
             }
@@ -10563,37 +4242,7 @@
             "power": null,
             "text": "Enhance .\nPlay: Move all  from one creature to another creature.\n",
             "locale": {
-                "de": {
-                    "name": "Beute loswerden"
-                },
                 "en": {
-                    "name": "Ditch the Loot"
-                },
-                "es": {
-                    "name": "Ditch the Loot"
-                },
-                "fr": {
-                    "name": "Bazarder le Butin"
-                },
-                "it": {
-                    "name": "Ditch the Loot"
-                },
-                "pl": {
-                    "name": "Ditch the Loot"
-                },
-                "pt": {
-                    "name": "Ditch the Loot"
-                },
-                "th": {
-                    "name": "Ditch the Loot"
-                },
-                "vi": {
-                    "name": "Ditch the Loot"
-                },
-                "zhhans": {
-                    "name": "Ditch the Loot"
-                },
-                "zhhant": {
                     "name": "Ditch the Loot"
                 }
             }
@@ -10606,10 +4255,7 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [
-                "elf",
-                "politician"
-            ],
+            "traits": ["elf", "politician"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -10617,37 +4263,7 @@
             "power": 2,
             "text": "Each enemy creature gains, “After Fight/After Reap: Exhaust each friendly creature that shares a house with this creature.”\n",
             "locale": {
-                "de": {
-                    "name": "Ox Sarbane"
-                },
                 "en": {
-                    "name": "Ox Sarbane"
-                },
-                "es": {
-                    "name": "Ox Sarbane"
-                },
-                "fr": {
-                    "name": "Ox Sarbane"
-                },
-                "it": {
-                    "name": "Ox Sarbane"
-                },
-                "pl": {
-                    "name": "Ox Sarbane"
-                },
-                "pt": {
-                    "name": "Ox Sarbane"
-                },
-                "th": {
-                    "name": "Ox Sarbane"
-                },
-                "vi": {
-                    "name": "Ox Sarbane"
-                },
-                "zhhans": {
-                    "name": "Ox Sarbane"
-                },
-                "zhhant": {
                     "name": "Ox Sarbane"
                 }
             }
@@ -10668,37 +4284,7 @@
             "power": null,
             "text": "Play: If you have more  than your opponent, they discard a random card from their hand and you draw a card.",
             "locale": {
-                "de": {
-                    "name": "Verwirrende Klügelei"
-                },
                 "en": {
-                    "name": "Perplexing Sophistry"
-                },
-                "es": {
-                    "name": "Perplexing Sophistry"
-                },
-                "fr": {
-                    "name": "Sophisme Troublant"
-                },
-                "it": {
-                    "name": "Perplexing Sophistry"
-                },
-                "pl": {
-                    "name": "Perplexing Sophistry"
-                },
-                "pt": {
-                    "name": "Perplexing Sophistry"
-                },
-                "th": {
-                    "name": "Perplexing Sophistry"
-                },
-                "vi": {
-                    "name": "Perplexing Sophistry"
-                },
-                "zhhans": {
-                    "name": "Perplexing Sophistry"
-                },
-                "zhhant": {
                     "name": "Perplexing Sophistry"
                 }
             }
@@ -10710,13 +4296,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_182_89d39b7724d5_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": [
-                "elusive"
-            ],
-            "traits": [
-                "elf",
-                "thief"
-            ],
+            "keywords": ["elusive"],
+            "traits": ["elf", "thief"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -10724,37 +4305,7 @@
             "power": 1,
             "text": "Elusive. (The first time this creature is attacked each turn, no damage is dealt.)\nAction: Steal 2. Until the start of your next turn, Reckless Rizzo loses elusive.",
             "locale": {
-                "de": {
-                    "name": "Waghalsige Rizzo"
-                },
                 "en": {
-                    "name": "Reckless Rizzo"
-                },
-                "es": {
-                    "name": "Reckless Rizzo"
-                },
-                "fr": {
-                    "name": "Rizzo Sans Repos"
-                },
-                "it": {
-                    "name": "Reckless Rizzo"
-                },
-                "pl": {
-                    "name": "Reckless Rizzo"
-                },
-                "pt": {
-                    "name": "Reckless Rizzo"
-                },
-                "th": {
-                    "name": "Reckless Rizzo"
-                },
-                "vi": {
-                    "name": "Reckless Rizzo"
-                },
-                "zhhans": {
-                    "name": "Reckless Rizzo"
-                },
-                "zhhant": {
                     "name": "Reckless Rizzo"
                 }
             }
@@ -10775,37 +4326,7 @@
             "power": null,
             "text": "Play: Your opponent discards a random card from their hand. \n",
             "locale": {
-                "de": {
-                    "name": "Subtile Kette"
-                },
                 "en": {
-                    "name": "Subtle Chain"
-                },
-                "es": {
-                    "name": "Subtle Chain"
-                },
-                "fr": {
-                    "name": "Chaîne Subtile"
-                },
-                "it": {
-                    "name": "Subtle Chain"
-                },
-                "pl": {
-                    "name": "Subtle Chain"
-                },
-                "pt": {
-                    "name": "Subtle Chain"
-                },
-                "th": {
-                    "name": "Subtle Chain"
-                },
-                "vi": {
-                    "name": "Subtle Chain"
-                },
-                "zhhans": {
-                    "name": "Subtle Chain"
-                },
-                "zhhant": {
                     "name": "Subtle Chain"
                 }
             }
@@ -10817,13 +4338,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_184_35b3374fb0e1_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": [
-                "elusive"
-            ],
-            "traits": [
-                "elf",
-                "cyborg"
-            ],
+            "keywords": ["elusive", "entrench"],
+            "traits": ["elf", "cyborg"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -10831,37 +4347,7 @@
             "power": 2,
             "text": "Elusive. Entrench.\nWhile The Watch is exhausted, your  cannot be stolen.\n",
             "locale": {
-                "de": {
-                    "name": "Die Wache"
-                },
                 "en": {
-                    "name": "The Watch"
-                },
-                "es": {
-                    "name": "The Watch"
-                },
-                "fr": {
-                    "name": "Le Veilleur"
-                },
-                "it": {
-                    "name": "The Watch"
-                },
-                "pl": {
-                    "name": "The Watch"
-                },
-                "pt": {
-                    "name": "The Watch"
-                },
-                "th": {
-                    "name": "The Watch"
-                },
-                "vi": {
-                    "name": "The Watch"
-                },
-                "zhhans": {
-                    "name": "The Watch"
-                },
-                "zhhant": {
                     "name": "The Watch"
                 }
             }
@@ -10882,37 +4368,7 @@
             "power": null,
             "text": "Play: Steal all but 6 of your\nopponent’s .\n",
             "locale": {
-                "de": {
-                    "name": "Zu viel zu bewachen"
-                },
                 "en": {
-                    "name": "Too Much to Protect"
-                },
-                "es": {
-                    "name": "Too Much to Protect"
-                },
-                "fr": {
-                    "name": "Trop à Protéger"
-                },
-                "it": {
-                    "name": "Too Much to Protect"
-                },
-                "pl": {
-                    "name": "Too Much to Protect"
-                },
-                "pt": {
-                    "name": "Too Much to Protect"
-                },
-                "th": {
-                    "name": "Too Much to Protect"
-                },
-                "vi": {
-                    "name": "Too Much to Protect"
-                },
-                "zhhans": {
-                    "name": "Too Much to Protect"
-                },
-                "zhhant": {
                     "name": "Too Much to Protect"
                 }
             }
@@ -10925,10 +4381,7 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [
-                "elf",
-                "thief"
-            ],
+            "traits": ["elf", "thief"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -10936,37 +4389,7 @@
             "power": 3,
             "text": "After your opponent plays a creature, deal 2 to it.\n",
             "locale": {
-                "de": {
-                    "name": "Vaelra Flüsterfang"
-                },
                 "en": {
-                    "name": "Vaelra Whisperfang"
-                },
-                "es": {
-                    "name": "Vaelra Whisperfang"
-                },
-                "fr": {
-                    "name": "Vaelra Quenottes"
-                },
-                "it": {
-                    "name": "Vaelra Whisperfang"
-                },
-                "pl": {
-                    "name": "Vaelra Whisperfang"
-                },
-                "pt": {
-                    "name": "Vaelra Whisperfang"
-                },
-                "th": {
-                    "name": "Vaelra Whisperfang"
-                },
-                "vi": {
-                    "name": "Vaelra Whisperfang"
-                },
-                "zhhans": {
-                    "name": "Vaelra Whisperfang"
-                },
-                "zhhant": {
                     "name": "Vaelra Whisperfang"
                 }
             }
@@ -10979,10 +4402,7 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [
-                "human",
-                "scientist"
-            ],
+            "traits": ["human", "scientist"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -10990,37 +4410,7 @@
             "power": 3,
             "text": "After Reap: Purge a card from your discard pile. If you do, until the start of your next turn, your opponent cannot play cards of the purged card’s type.\n",
             "locale": {
-                "de": {
-                    "name": "Victor Flux"
-                },
                 "en": {
-                    "name": "Victor Flux"
-                },
-                "es": {
-                    "name": "Victor Flux"
-                },
-                "fr": {
-                    "name": "Victor Flux"
-                },
-                "it": {
-                    "name": "Victor Flux"
-                },
-                "pl": {
-                    "name": "Victor Flux"
-                },
-                "pt": {
-                    "name": "Victor Flux"
-                },
-                "th": {
-                    "name": "Victor Flux"
-                },
-                "vi": {
-                    "name": "Victor Flux"
-                },
-                "zhhans": {
-                    "name": "Victor Flux"
-                },
-                "zhhant": {
                     "name": "Victor Flux"
                 }
             }
@@ -11032,12 +4422,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_188_842763412b46_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": [
-                "skirmish"
-            ],
-            "traits": [
-                "beast"
-            ],
+            "keywords": ["skirmish"],
+            "traits": ["beast"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -11045,37 +4431,7 @@
             "power": 2,
             "text": "Skirmish.\nAfter Fight: Exhaust an enemy creature.\n",
             "locale": {
-                "de": {
-                    "name": "Achromatischer Basilisk"
-                },
                 "en": {
-                    "name": "Achromatic Basilisk"
-                },
-                "es": {
-                    "name": "Achromatic Basilisk"
-                },
-                "fr": {
-                    "name": "Basilic Achromatique"
-                },
-                "it": {
-                    "name": "Achromatic Basilisk"
-                },
-                "pl": {
-                    "name": "Achromatic Basilisk"
-                },
-                "pt": {
-                    "name": "Achromatic Basilisk"
-                },
-                "th": {
-                    "name": "Achromatic Basilisk"
-                },
-                "vi": {
-                    "name": "Achromatic Basilisk"
-                },
-                "zhhans": {
-                    "name": "Achromatic Basilisk"
-                },
-                "zhhant": {
                     "name": "Achromatic Basilisk"
                 }
             }
@@ -11096,37 +4452,7 @@
             "power": null,
             "text": "Play: If you are overwhelmed, exhaust an enemy creature. Steal 1 for each exhausted enemy creature.\n",
             "locale": {
-                "de": {
-                    "name": "Kalt erwischt"
-                },
                 "en": {
-                    "name": "Caught You Napping"
-                },
-                "es": {
-                    "name": "Caught You Napping"
-                },
-                "fr": {
-                    "name": "Choppé à Roupiller"
-                },
-                "it": {
-                    "name": "Caught You Napping"
-                },
-                "pl": {
-                    "name": "Caught You Napping"
-                },
-                "pt": {
-                    "name": "Caught You Napping"
-                },
-                "th": {
-                    "name": "Caught You Napping"
-                },
-                "vi": {
-                    "name": "Caught You Napping"
-                },
-                "zhhans": {
-                    "name": "Caught You Napping"
-                },
-                "zhhant": {
                     "name": "Caught You Napping"
                 }
             }
@@ -11139,10 +4465,7 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [
-                "elf",
-                "soldier"
-            ],
+            "traits": ["elf", "soldier"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -11150,37 +4473,7 @@
             "power": 1,
             "text": "Enhance .\nDestroyed: Deal 2 to each enemy flank creature.\n",
             "locale": {
-                "de": {
-                    "name": "Knall E. More"
-                },
                 "en": {
-                    "name": "Clay More"
-                },
-                "es": {
-                    "name": "Clay More"
-                },
-                "fr": {
-                    "name": "Bonne Mine"
-                },
-                "it": {
-                    "name": "Clay More"
-                },
-                "pl": {
-                    "name": "Clay More"
-                },
-                "pt": {
-                    "name": "Clay More"
-                },
-                "th": {
-                    "name": "Clay More"
-                },
-                "vi": {
-                    "name": "Clay More"
-                },
-                "zhhans": {
-                    "name": "Clay More"
-                },
-                "zhhant": {
                     "name": "Clay More"
                 }
             }
@@ -11193,10 +4486,7 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [
-                "elf",
-                "thief"
-            ],
+            "traits": ["elf", "thief"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -11204,37 +4494,7 @@
             "power": 2,
             "text": "Enhance .\nPlay: For each +1 power counter on each creature, deal 1 to a creature.\n",
             "locale": {
-                "de": {
-                    "name": "Colt Slevin"
-                },
                 "en": {
-                    "name": "Colt Sleven"
-                },
-                "es": {
-                    "name": "Colt Sleven"
-                },
-                "fr": {
-                    "name": "Colt Sleven"
-                },
-                "it": {
-                    "name": "Colt Sleven"
-                },
-                "pl": {
-                    "name": "Colt Sleven"
-                },
-                "pt": {
-                    "name": "Colt Sleven"
-                },
-                "th": {
-                    "name": "Colt Sleven"
-                },
-                "vi": {
-                    "name": "Colt Sleven"
-                },
-                "zhhans": {
-                    "name": "Colt Sleven"
-                },
-                "zhhant": {
                     "name": "Colt Sleven"
                 }
             }
@@ -11246,12 +4506,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_192_67159b61a030_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": [
-                "taunt"
-            ],
-            "traits": [
-                "elf"
-            ],
+            "keywords": ["taunt"],
+            "traits": ["elf"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -11259,37 +4515,7 @@
             "power": 2,
             "text": "Taunt.\nDestroyed: Steal 1.\n",
             "locale": {
-                "de": {
-                    "name": "Sündenbock"
-                },
                 "en": {
-                    "name": "Fallguy"
-                },
-                "es": {
-                    "name": "Fallguy"
-                },
-                "fr": {
-                    "name": "Bouc Émissaire"
-                },
-                "it": {
-                    "name": "Fallguy"
-                },
-                "pl": {
-                    "name": "Fallguy"
-                },
-                "pt": {
-                    "name": "Fallguy"
-                },
-                "th": {
-                    "name": "Fallguy"
-                },
-                "vi": {
-                    "name": "Fallguy"
-                },
-                "zhhans": {
-                    "name": "Fallguy"
-                },
-                "zhhant": {
                     "name": "Fallguy"
                 }
             }
@@ -11301,13 +4527,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_193_b8611631dec2_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": [
-                "elusive"
-            ],
-            "traits": [
-                "elf",
-                "thief"
-            ],
+            "keywords": ["elusive", "entrench"],
+            "traits": ["elf", "thief"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -11315,37 +4536,7 @@
             "power": 2,
             "text": "Elusive. Entrench.\nWhile Grammy Taps is exhausted, each of its neighbors gains elusive.\n",
             "locale": {
-                "de": {
-                    "name": "Omi Taps"
-                },
                 "en": {
-                    "name": "Grammy Taps"
-                },
-                "es": {
-                    "name": "Grammy Taps"
-                },
-                "fr": {
-                    "name": "Mamy Blue"
-                },
-                "it": {
-                    "name": "Grammy Taps"
-                },
-                "pl": {
-                    "name": "Grammy Taps"
-                },
-                "pt": {
-                    "name": "Grammy Taps"
-                },
-                "th": {
-                    "name": "Grammy Taps"
-                },
-                "vi": {
-                    "name": "Grammy Taps"
-                },
-                "zhhans": {
-                    "name": "Grammy Taps"
-                },
-                "zhhant": {
                     "name": "Grammy Taps"
                 }
             }
@@ -11366,37 +4557,7 @@
             "power": null,
             "text": "Play: Destroy a friendly creature. If you do, deal 6 to a creature.\n",
             "locale": {
-                "de": {
-                    "name": "Ein Leben für ein Leben"
-                },
                 "en": {
-                    "name": "Life for a Life"
-                },
-                "es": {
-                    "name": "Life for a Life"
-                },
-                "fr": {
-                    "name": "Une Vie contre une Vie"
-                },
-                "it": {
-                    "name": "Life for a Life"
-                },
-                "pl": {
-                    "name": "Life for a Life"
-                },
-                "pt": {
-                    "name": "Life for a Life"
-                },
-                "th": {
-                    "name": "Life for a Life"
-                },
-                "vi": {
-                    "name": "Life for a Life"
-                },
-                "zhhans": {
-                    "name": "Life for a Life"
-                },
-                "zhhant": {
                     "name": "Life for a Life"
                 }
             }
@@ -11409,10 +4570,7 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [
-                "elf",
-                "thief"
-            ],
+            "traits": ["elf", "thief"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -11420,37 +4578,7 @@
             "power": 2,
             "text": "After Reap: If you are overwhelmed, steal 2. Otherwise, steal 1.\n",
             "locale": {
-                "de": {
-                    "name": "Albtraum-Straßenkind"
-                },
                 "en": {
-                    "name": "Nightmare Urchin"
-                },
-                "es": {
-                    "name": "Nightmare Urchin"
-                },
-                "fr": {
-                    "name": "Orphelin Endiablé"
-                },
-                "it": {
-                    "name": "Nightmare Urchin"
-                },
-                "pl": {
-                    "name": "Nightmare Urchin"
-                },
-                "pt": {
-                    "name": "Nightmare Urchin"
-                },
-                "th": {
-                    "name": "Nightmare Urchin"
-                },
-                "vi": {
-                    "name": "Nightmare Urchin"
-                },
-                "zhhans": {
-                    "name": "Nightmare Urchin"
-                },
-                "zhhant": {
                     "name": "Nightmare Urchin"
                 }
             }
@@ -11463,10 +4591,7 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [
-                "elf",
-                "thief"
-            ],
+            "traits": ["elf", "thief"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -11474,37 +4599,7 @@
             "power": 2,
             "text": "Play: If your opponent has more  than you, steal 2.\n",
             "locale": {
-                "de": {
-                    "name": "Buchhalter Malloy"
-                },
                 "en": {
-                    "name": "Pincher Malloy"
-                },
-                "es": {
-                    "name": "Pincher Malloy"
-                },
-                "fr": {
-                    "name": "Malo le Faussaire"
-                },
-                "it": {
-                    "name": "Pincher Malloy"
-                },
-                "pl": {
-                    "name": "Pincher Malloy"
-                },
-                "pt": {
-                    "name": "Pincher Malloy"
-                },
-                "th": {
-                    "name": "Pincher Malloy"
-                },
-                "vi": {
-                    "name": "Pincher Malloy"
-                },
-                "zhhans": {
-                    "name": "Pincher Malloy"
-                },
-                "zhhant": {
                     "name": "Pincher Malloy"
                 }
             }
@@ -11525,37 +4620,7 @@
             "power": null,
             "text": "Play: Deal 2 to a creature, with 1 splash. If this damage destroys 2 or more creatures, steal 1.\n",
             "locale": {
-                "de": {
-                    "name": "Pyrotechnischer Blitz"
-                },
                 "en": {
-                    "name": "Pyrotechnic Flash"
-                },
-                "es": {
-                    "name": "Pyrotechnic Flash"
-                },
-                "fr": {
-                    "name": "Éclair Pyrotechnique"
-                },
-                "it": {
-                    "name": "Pyrotechnic Flash"
-                },
-                "pl": {
-                    "name": "Pyrotechnic Flash"
-                },
-                "pt": {
-                    "name": "Pyrotechnic Flash"
-                },
-                "th": {
-                    "name": "Pyrotechnic Flash"
-                },
-                "vi": {
-                    "name": "Pyrotechnic Flash"
-                },
-                "zhhans": {
-                    "name": "Pyrotechnic Flash"
-                },
-                "zhhant": {
                     "name": "Pyrotechnic Flash"
                 }
             }
@@ -11576,37 +4641,7 @@
             "power": null,
             "text": "Play: Exhaust the least powerful enemy creature and each of its neighbors.\n",
             "locale": {
-                "de": {
-                    "name": "Mach mal Pause"
-                },
                 "en": {
-                    "name": "Take a Break"
-                },
-                "es": {
-                    "name": "Take a Break"
-                },
-                "fr": {
-                    "name": "Prends une Pause"
-                },
-                "it": {
-                    "name": "Take a Break"
-                },
-                "pl": {
-                    "name": "Take a Break"
-                },
-                "pt": {
-                    "name": "Take a Break"
-                },
-                "th": {
-                    "name": "Take a Break"
-                },
-                "vi": {
-                    "name": "Take a Break"
-                },
-                "zhhans": {
-                    "name": "Take a Break"
-                },
-                "zhhant": {
                     "name": "Take a Break"
                 }
             }
@@ -11627,37 +4662,7 @@
             "power": null,
             "text": "Play: Deal 1 to up to three creatures. Gain 1 for each creature destroyed this way.",
             "locale": {
-                "de": {
-                    "name": "Wurfsterne"
-                },
                 "en": {
-                    "name": "Throwing Stars"
-                },
-                "es": {
-                    "name": "Throwing Stars"
-                },
-                "fr": {
-                    "name": "Étoiles de Lancer"
-                },
-                "it": {
-                    "name": "Throwing Stars"
-                },
-                "pl": {
-                    "name": "Throwing Stars"
-                },
-                "pt": {
-                    "name": "Throwing Stars"
-                },
-                "th": {
-                    "name": "Throwing Stars"
-                },
-                "vi": {
-                    "name": "Throwing Stars"
-                },
-                "zhhans": {
-                    "name": "Throwing Stars"
-                },
-                "zhhant": {
                     "name": "Throwing Stars"
                 }
             }
@@ -11669,13 +4674,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_200_54d9e0fd8302_en.png",
             "expansion": 928,
             "house": "skyborn",
-            "keywords": [
-                "deploy"
-            ],
-            "traits": [
-                "alien",
-                "halyard"
-            ],
+            "keywords": ["deploy"],
+            "traits": ["alien", "halyard"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -11683,37 +4683,7 @@
             "power": 3,
             "text": "Deploy.\nPlay: Exhaust each non-flank creature.\n",
             "locale": {
-                "de": {
-                    "name": "Aviatrix Virtuosa"
-                },
                 "en": {
-                    "name": "Aviatrix Virtuosa"
-                },
-                "es": {
-                    "name": "Aviatrix Virtuosa"
-                },
-                "fr": {
-                    "name": "Aviatrix Virtuosa"
-                },
-                "it": {
-                    "name": "Aviatrix Virtuosa"
-                },
-                "pl": {
-                    "name": "Aviatrix Virtuosa"
-                },
-                "pt": {
-                    "name": "Aviatrix Virtuosa"
-                },
-                "th": {
-                    "name": "Aviatrix Virtuosa"
-                },
-                "vi": {
-                    "name": "Aviatrix Virtuosa"
-                },
-                "zhhans": {
-                    "name": "Aviatrix Virtuosa"
-                },
-                "zhhant": {
                     "name": "Aviatrix Virtuosa"
                 }
             }
@@ -11726,9 +4696,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "location"
-            ],
+            "traits": ["location"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -11736,37 +4704,7 @@
             "power": null,
             "text": "Your opponent’s keys cost +1 for each Skyborn creature on a flank.\n",
             "locale": {
-                "de": {
-                    "name": "Wolkenbruch-Befehl"
-                },
                 "en": {
-                    "name": "Cloudburst Command"
-                },
-                "es": {
-                    "name": "Cloudburst Command"
-                },
-                "fr": {
-                    "name": "Régie Cumulo-Blastus"
-                },
-                "it": {
-                    "name": "Cloudburst Command"
-                },
-                "pl": {
-                    "name": "Cloudburst Command"
-                },
-                "pt": {
-                    "name": "Cloudburst Command"
-                },
-                "th": {
-                    "name": "Cloudburst Command"
-                },
-                "vi": {
-                    "name": "Cloudburst Command"
-                },
-                "zhhans": {
-                    "name": "Cloudburst Command"
-                },
-                "zhhant": {
                     "name": "Cloudburst Command"
                 }
             }
@@ -11779,9 +4717,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "raptrix"
-            ],
+            "traits": ["raptrix"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -11789,37 +4725,7 @@
             "power": 4,
             "text": "Each enemy creature loses each of its destroyed abilities.\n",
             "locale": {
-                "de": {
-                    "name": "Flipp Stahl­hart"
-                },
                 "en": {
-                    "name": "Flip Stallard"
-                },
-                "es": {
-                    "name": "Flip Stallard"
-                },
-                "fr": {
-                    "name": "Flip Stallard"
-                },
-                "it": {
-                    "name": "Flip Stallard"
-                },
-                "pl": {
-                    "name": "Flip Stallard"
-                },
-                "pt": {
-                    "name": "Flip Stallard"
-                },
-                "th": {
-                    "name": "Flip Stallard"
-                },
-                "vi": {
-                    "name": "Flip Stallard"
-                },
-                "zhhans": {
-                    "name": "Flip Stallard"
-                },
-                "zhhant": {
                     "name": "Flip Stallard"
                 }
             }
@@ -11840,37 +4746,7 @@
             "power": null,
             "text": "Play: Deal 1 to each creature for each forged key.\n",
             "locale": {
-                "de": {
-                    "name": "Geschmiedeter Blitz"
-                },
                 "en": {
-                    "name": "Forged Bolt"
-                },
-                "es": {
-                    "name": "Forged Bolt"
-                },
-                "fr": {
-                    "name": "Forgedroyer"
-                },
-                "it": {
-                    "name": "Forged Bolt"
-                },
-                "pl": {
-                    "name": "Forged Bolt"
-                },
-                "pt": {
-                    "name": "Forged Bolt"
-                },
-                "th": {
-                    "name": "Forged Bolt"
-                },
-                "vi": {
-                    "name": "Forged Bolt"
-                },
-                "zhhans": {
-                    "name": "Forged Bolt"
-                },
-                "zhhant": {
                     "name": "Forged Bolt"
                 }
             }
@@ -11883,10 +4759,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "dinosaur",
-                "stormkin"
-            ],
+            "traits": ["dinosaur", "stormkin"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -11894,37 +4767,7 @@
             "power": 6,
             "text": "After Fight/After Reap: You may exalt Han Peregrine. If you do, fully heal a damaged creature and move it to either flank of its controller's battleline.\n",
             "locale": {
-                "de": {
-                    "name": "Han der Wanderer"
-                },
                 "en": {
-                    "name": "Han Peregrine"
-                },
-                "es": {
-                    "name": "Han Peregrine"
-                },
-                "fr": {
-                    "name": "Han Peregrine"
-                },
-                "it": {
-                    "name": "Han Peregrine"
-                },
-                "pl": {
-                    "name": "Han Peregrine"
-                },
-                "pt": {
-                    "name": "Han Peregrine"
-                },
-                "th": {
-                    "name": "Han Peregrine"
-                },
-                "vi": {
-                    "name": "Han Peregrine"
-                },
-                "zhhans": {
-                    "name": "Han Peregrine"
-                },
-                "zhhant": {
                     "name": "Han Peregrine"
                 }
             }
@@ -11945,37 +4788,7 @@
             "power": null,
             "text": "Play: Put each friendly Skyborn creature into its owner’s archives.\n",
             "locale": {
-                "de": {
-                    "name": "Ein langer Weg nach Hause"
-                },
                 "en": {
-                    "name": "Long Way Home"
-                },
-                "es": {
-                    "name": "Long Way Home"
-                },
-                "fr": {
-                    "name": "Long Détour"
-                },
-                "it": {
-                    "name": "Long Way Home"
-                },
-                "pl": {
-                    "name": "Long Way Home"
-                },
-                "pt": {
-                    "name": "Long Way Home"
-                },
-                "th": {
-                    "name": "Long Way Home"
-                },
-                "vi": {
-                    "name": "Long Way Home"
-                },
-                "zhhans": {
-                    "name": "Long Way Home"
-                },
-                "zhhant": {
                     "name": "Long Way Home"
                 }
             }
@@ -11987,14 +4800,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_206_7927e522d310_en.png",
             "expansion": 928,
             "house": "skyborn",
-            "keywords": [
-                "treachery",
-                "versatile"
-            ],
-            "traits": [
-                "beast",
-                "cyborg"
-            ],
+            "keywords": ["treachery", "versatile"],
+            "traits": ["beast", "cyborg"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -12002,37 +4809,7 @@
             "power": 5,
             "text": "Treachery. Versatile.\nYou cannot forge keys.\nAt the end of your turn, deal 2 to Malforge.\n",
             "locale": {
-                "de": {
-                    "name": "Fehlschmiede"
-                },
                 "en": {
-                    "name": "Malforge"
-                },
-                "es": {
-                    "name": "Malforge"
-                },
-                "fr": {
-                    "name": "Malforge"
-                },
-                "it": {
-                    "name": "Malforge"
-                },
-                "pl": {
-                    "name": "Malforge"
-                },
-                "pt": {
-                    "name": "Malforge"
-                },
-                "th": {
-                    "name": "Malforge"
-                },
-                "vi": {
-                    "name": "Malforge"
-                },
-                "zhhans": {
-                    "name": "Malforge"
-                },
-                "zhhant": {
                     "name": "Malforge"
                 }
             }
@@ -12053,37 +4830,7 @@
             "power": null,
             "text": "Play: Gain control of an enemy flank creature.\n",
             "locale": {
-                "de": {
-                    "name": "Maqui-Expedition"
-                },
                 "en": {
-                    "name": "Maqui Expedition"
-                },
-                "es": {
-                    "name": "Maqui Expedition"
-                },
-                "fr": {
-                    "name": "Expédition Maquis"
-                },
-                "it": {
-                    "name": "Maqui Expedition"
-                },
-                "pl": {
-                    "name": "Maqui Expedition"
-                },
-                "pt": {
-                    "name": "Maqui Expedition"
-                },
-                "th": {
-                    "name": "Maqui Expedition"
-                },
-                "vi": {
-                    "name": "Maqui Expedition"
-                },
-                "zhhans": {
-                    "name": "Maqui Expedition"
-                },
-                "zhhant": {
                     "name": "Maqui Expedition"
                 }
             }
@@ -12096,9 +4843,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "item"
-            ],
+            "traits": ["item"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -12106,37 +4851,7 @@
             "power": null,
             "text": "Enhance  . (These icons have already been added to cards in your deck.)\nAction: Ready and fight with a friendly Skyborn creature. If your blue key is forged, repeat the preceding effect.\n",
             "locale": {
-                "de": {
-                    "name": "Rasierer-Gambit"
-                },
                 "en": {
-                    "name": "Razor’s Gambit"
-                },
-                "es": {
-                    "name": "Razor’s Gambit"
-                },
-                "fr": {
-                    "name": "Stratagème du Rasoir"
-                },
-                "it": {
-                    "name": "Razor’s Gambit"
-                },
-                "pl": {
-                    "name": "Razor’s Gambit"
-                },
-                "pt": {
-                    "name": "Razor’s Gambit"
-                },
-                "th": {
-                    "name": "Razor’s Gambit"
-                },
-                "vi": {
-                    "name": "Razor’s Gambit"
-                },
-                "zhhans": {
-                    "name": "Razor’s Gambit"
-                },
-                "zhhant": {
                     "name": "Razor’s Gambit"
                 }
             }
@@ -12157,37 +4872,7 @@
             "power": null,
             "text": "Play: Discard a card. Resolve its bonus icons as if you had played it. If a yellow key is forged, repeat the preceding effect.\n",
             "locale": {
-                "de": {
-                    "name": "Fröhliches Überbordwerfen"
-                },
                 "en": {
-                    "name": "Recreational Jettison"
-                },
-                "es": {
-                    "name": "Recreational Jettison"
-                },
-                "fr": {
-                    "name": "Délestage Récréatif"
-                },
-                "it": {
-                    "name": "Recreational Jettison"
-                },
-                "pl": {
-                    "name": "Recreational Jettison"
-                },
-                "pt": {
-                    "name": "Recreational Jettison"
-                },
-                "th": {
-                    "name": "Recreational Jettison"
-                },
-                "vi": {
-                    "name": "Recreational Jettison"
-                },
-                "zhhans": {
-                    "name": "Recreational Jettison"
-                },
-                "zhhant": {
                     "name": "Recreational Jettison"
                 }
             }
@@ -12208,37 +4893,7 @@
             "power": null,
             "text": "Each time a card would be discarded from a player's hand, reveal the card and put it facedown under this creature instead.\n",
             "locale": {
-                "de": {
-                    "name": "Hochwertiger Klebstoff"
-                },
                 "en": {
-                    "name": "Refined Adhesive"
-                },
-                "es": {
-                    "name": "Refined Adhesive"
-                },
-                "fr": {
-                    "name": "Adhésif Raffiné"
-                },
-                "it": {
-                    "name": "Refined Adhesive"
-                },
-                "pl": {
-                    "name": "Refined Adhesive"
-                },
-                "pt": {
-                    "name": "Refined Adhesive"
-                },
-                "th": {
-                    "name": "Refined Adhesive"
-                },
-                "vi": {
-                    "name": "Refined Adhesive"
-                },
-                "zhhans": {
-                    "name": "Refined Adhesive"
-                },
-                "zhhant": {
                     "name": "Refined Adhesive"
                 }
             }
@@ -12259,37 +4914,7 @@
             "power": null,
             "text": "Play: Take control of the enemy creature in the center of your opponent’s battleline.\n",
             "locale": {
-                "de": {
-                    "name": "Willkommenskultur"
-                },
                 "en": {
-                    "name": "Universal Welcome"
-                },
-                "es": {
-                    "name": "Universal Welcome"
-                },
-                "fr": {
-                    "name": "Accueil Universel"
-                },
-                "it": {
-                    "name": "Universal Welcome"
-                },
-                "pl": {
-                    "name": "Universal Welcome"
-                },
-                "pt": {
-                    "name": "Universal Welcome"
-                },
-                "th": {
-                    "name": "Universal Welcome"
-                },
-                "vi": {
-                    "name": "Universal Welcome"
-                },
-                "zhhans": {
-                    "name": "Universal Welcome"
-                },
-                "zhhant": {
                     "name": "Universal Welcome"
                 }
             }
@@ -12302,10 +4927,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "adagion",
-                "artisan"
-            ],
+            "traits": ["adagion", "artisan"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -12313,37 +4935,7 @@
             "power": 2,
             "text": "While your yellow key is forged, each enemy creature enters play stunned. \nPlay: If your yellow key is forged, stun each enemy creature.\n",
             "locale": {
-                "de": {
-                    "name": "Vicomte von Aerys"
-                },
                 "en": {
-                    "name": "Viscount of Aerys"
-                },
-                "es": {
-                    "name": "Viscount of Aerys"
-                },
-                "fr": {
-                    "name": "Vicomte d’Aerys"
-                },
-                "it": {
-                    "name": "Viscount of Aerys"
-                },
-                "pl": {
-                    "name": "Viscount of Aerys"
-                },
-                "pt": {
-                    "name": "Viscount of Aerys"
-                },
-                "th": {
-                    "name": "Viscount of Aerys"
-                },
-                "vi": {
-                    "name": "Viscount of Aerys"
-                },
-                "zhhans": {
-                    "name": "Viscount of Aerys"
-                },
-                "zhhant": {
                     "name": "Viscount of Aerys"
                 }
             }
@@ -12364,37 +4956,7 @@
             "power": null,
             "text": "",
             "locale": {
-                "de": {
-                    "name": "Zomok"
-                },
                 "en": {
-                    "name": "Zomok"
-                },
-                "es": {
-                    "name": "Zomok"
-                },
-                "fr": {
-                    "name": "Zomok"
-                },
-                "it": {
-                    "name": "Zomok"
-                },
-                "pl": {
-                    "name": "Zomok"
-                },
-                "pt": {
-                    "name": "Zomok"
-                },
-                "th": {
-                    "name": "Zomok"
-                },
-                "vi": {
-                    "name": "Zomok"
-                },
-                "zhhans": {
-                    "name": "Zomok"
-                },
-                "zhhant": {
                     "name": "Zomok"
                 }
             }
@@ -12407,10 +4969,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "beast",
-                "cyborg"
-            ],
+            "traits": ["beast", "cyborg"],
             "type": "gigantic creature base",
             "rarity": "Special",
             "amber": 0,
@@ -12418,37 +4977,7 @@
             "power": 16,
             "text": "(Play only with the other half of Zomok.)\nWhile Zomok is attacking, ignore taunt, elusive, poison, hazardous, and invulnerable.\nAfter Fight: Deal 2 to a creature for each forged key.\n",
             "locale": {
-                "de": {
-                    "name": "Zomok"
-                },
                 "en": {
-                    "name": "Zomok"
-                },
-                "es": {
-                    "name": "Zomok"
-                },
-                "fr": {
-                    "name": "Zomok"
-                },
-                "it": {
-                    "name": "Zomok"
-                },
-                "pl": {
-                    "name": "Zomok"
-                },
-                "pt": {
-                    "name": "Zomok"
-                },
-                "th": {
-                    "name": "Zomok"
-                },
-                "vi": {
-                    "name": "Zomok"
-                },
-                "zhhans": {
-                    "name": "Zomok"
-                },
-                "zhhant": {
                     "name": "Zomok"
                 }
             }
@@ -12461,10 +4990,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "getrookya",
-                "pilot"
-            ],
+            "traits": ["getrookya", "pilot"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 1,
@@ -12472,37 +4998,7 @@
             "power": 2,
             "text": "After Fight/After Reap: Shuffle Æmber Airhart into its owner’s deck.\n",
             "locale": {
-                "de": {
-                    "name": "Æmber-Flughart"
-                },
                 "en": {
-                    "name": "Æmber Airhart"
-                },
-                "es": {
-                    "name": "Æmber Airhart"
-                },
-                "fr": {
-                    "name": "Amelia Aombrehart"
-                },
-                "it": {
-                    "name": "Æmber Airhart"
-                },
-                "pl": {
-                    "name": "Æmber Airhart"
-                },
-                "pt": {
-                    "name": "Æmber Airhart"
-                },
-                "th": {
-                    "name": "Æmber Airhart"
-                },
-                "vi": {
-                    "name": "Æmber Airhart"
-                },
-                "zhhans": {
-                    "name": "Æmber Airhart"
-                },
-                "zhhant": {
                     "name": "Æmber Airhart"
                 }
             }
@@ -12514,11 +5010,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_215_27bb4ff395af_en.png",
             "expansion": 928,
             "house": "skyborn",
-            "keywords": [],
-            "traits": [
-                "halyard",
-                "cyborg"
-            ],
+            "keywords": ["entrench"],
+            "traits": ["halyard", "cyborg"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -12526,37 +5019,7 @@
             "power": 3,
             "text": "Entrench.\nAt the start of your turn, if Cabochon is exhausted, gain 1 for each friendly Skyborn flank creature.\n",
             "locale": {
-                "de": {
-                    "name": "Cabochon"
-                },
                 "en": {
-                    "name": "Cabochon"
-                },
-                "es": {
-                    "name": "Cabochon"
-                },
-                "fr": {
-                    "name": "Cabochon"
-                },
-                "it": {
-                    "name": "Cabochon"
-                },
-                "pl": {
-                    "name": "Cabochon"
-                },
-                "pt": {
-                    "name": "Cabochon"
-                },
-                "th": {
-                    "name": "Cabochon"
-                },
-                "vi": {
-                    "name": "Cabochon"
-                },
-                "zhhans": {
-                    "name": "Cabochon"
-                },
-                "zhhant": {
                     "name": "Cabochon"
                 }
             }
@@ -12577,37 +5040,7 @@
             "power": null,
             "text": "Play: Move a creature to a flank of its controller’s battleline. Steal 1.\n",
             "locale": {
-                "de": {
-                    "name": "Rand der Welt"
-                },
                 "en": {
-                    "name": "Edge of the World"
-                },
-                "es": {
-                    "name": "Edge of the World"
-                },
-                "fr": {
-                    "name": "Bout du Monde"
-                },
-                "it": {
-                    "name": "Edge of the World"
-                },
-                "pl": {
-                    "name": "Edge of the World"
-                },
-                "pt": {
-                    "name": "Edge of the World"
-                },
-                "th": {
-                    "name": "Edge of the World"
-                },
-                "vi": {
-                    "name": "Edge of the World"
-                },
-                "zhhans": {
-                    "name": "Edge of the World"
-                },
-                "zhhant": {
                     "name": "Edge of the World"
                 }
             }
@@ -12628,37 +5061,7 @@
             "power": null,
             "text": "Play: Steal 1 for each ready Skyborn creature in play.\n",
             "locale": {
-                "de": {
-                    "name": "Glutbeutel"
-                },
                 "en": {
-                    "name": "Embered Purse"
-                },
-                "es": {
-                    "name": "Embered Purse"
-                },
-                "fr": {
-                    "name": "Bourse Embrasée"
-                },
-                "it": {
-                    "name": "Embered Purse"
-                },
-                "pl": {
-                    "name": "Embered Purse"
-                },
-                "pt": {
-                    "name": "Embered Purse"
-                },
-                "th": {
-                    "name": "Embered Purse"
-                },
-                "vi": {
-                    "name": "Embered Purse"
-                },
-                "zhhans": {
-                    "name": "Embered Purse"
-                },
-                "zhhant": {
                     "name": "Embered Purse"
                 }
             }
@@ -12679,37 +5082,7 @@
             "power": null,
             "text": "Play: Each friendly flank creature captures 1. If a yellow key is forged, repeat the preceding effect.\n",
             "locale": {
-                "de": {
-                    "name": "Vergoldet sie!"
-                },
                 "en": {
-                    "name": "Gilt ’Em Good"
-                },
-                "es": {
-                    "name": "Gilt ’Em Good"
-                },
-                "fr": {
-                    "name": "Couverts d'Or"
-                },
-                "it": {
-                    "name": "Gilt ’Em Good"
-                },
-                "pl": {
-                    "name": "Gilt ’Em Good"
-                },
-                "pt": {
-                    "name": "Gilt ’Em Good"
-                },
-                "th": {
-                    "name": "Gilt ’Em Good"
-                },
-                "vi": {
-                    "name": "Gilt ’Em Good"
-                },
-                "zhhans": {
-                    "name": "Gilt ’Em Good"
-                },
-                "zhhant": {
                     "name": "Gilt ’Em Good"
                 }
             }
@@ -12730,37 +5103,7 @@
             "power": null,
             "text": "Play: Take control of an enemy flank creature and give it three +1 power counters. While under your control, it belongs to house Skyborn. (Instead of its original house.)\n",
             "locale": {
-                "de": {
-                    "name": "Hannibals Mal"
-                },
                 "en": {
-                    "name": "Hannibal’s Mark"
-                },
-                "es": {
-                    "name": "Hannibal’s Mark"
-                },
-                "fr": {
-                    "name": "Marque d’Hannibal"
-                },
-                "it": {
-                    "name": "Hannibal’s Mark"
-                },
-                "pl": {
-                    "name": "Hannibal’s Mark"
-                },
-                "pt": {
-                    "name": "Hannibal’s Mark"
-                },
-                "th": {
-                    "name": "Hannibal’s Mark"
-                },
-                "vi": {
-                    "name": "Hannibal’s Mark"
-                },
-                "zhhans": {
-                    "name": "Hannibal’s Mark"
-                },
-                "zhhant": {
                     "name": "Hannibal’s Mark"
                 }
             }
@@ -12773,9 +5116,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "j'reen"
-            ],
+            "traits": ["j'reen"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -12783,37 +5124,7 @@
             "power": 3,
             "text": "After Reap: If Navigator Ketarr is on a flank, draw 2 cards and archive a card.\n",
             "locale": {
-                "de": {
-                    "name": "Navigator Ketarr"
-                },
                 "en": {
-                    "name": "Navigator Ketarr"
-                },
-                "es": {
-                    "name": "Navigator Ketarr"
-                },
-                "fr": {
-                    "name": "Navigateur Ketarr"
-                },
-                "it": {
-                    "name": "Navigator Ketarr"
-                },
-                "pl": {
-                    "name": "Navigator Ketarr"
-                },
-                "pt": {
-                    "name": "Navigator Ketarr"
-                },
-                "th": {
-                    "name": "Navigator Ketarr"
-                },
-                "vi": {
-                    "name": "Navigator Ketarr"
-                },
-                "zhhans": {
-                    "name": "Navigator Ketarr"
-                },
-                "zhhant": {
                     "name": "Navigator Ketarr"
                 }
             }
@@ -12825,12 +5136,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_221_e01ccd3b42f8_en.png",
             "expansion": 928,
             "house": "skyborn",
-            "keywords": [
-                "taunt"
-            ],
-            "traits": [
-                "stormkin"
-            ],
+            "keywords": ["taunt"],
+            "traits": ["stormkin"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -12838,37 +5145,7 @@
             "power": 6,
             "text": "Taunt.\nAfter Fight: You may move Pirate Champion to a flank.\n",
             "locale": {
-                "de": {
-                    "name": "Piratenmeister"
-                },
                 "en": {
-                    "name": "Pirate Champion"
-                },
-                "es": {
-                    "name": "Pirate Champion"
-                },
-                "fr": {
-                    "name": "Champion Pirate"
-                },
-                "it": {
-                    "name": "Pirate Champion"
-                },
-                "pl": {
-                    "name": "Pirate Champion"
-                },
-                "pt": {
-                    "name": "Pirate Champion"
-                },
-                "th": {
-                    "name": "Pirate Champion"
-                },
-                "vi": {
-                    "name": "Pirate Champion"
-                },
-                "zhhans": {
-                    "name": "Pirate Champion"
-                },
-                "zhhant": {
                     "name": "Pirate Champion"
                 }
             }
@@ -12889,37 +5166,7 @@
             "power": null,
             "text": "Play: Move a friendly Skyborn creature to a flank and ready it. If a red key is forged, repeat the preceding effect.\n",
             "locale": {
-                "de": {
-                    "name": "Abendrot"
-                },
                 "en": {
-                    "name": "Red Skies"
-                },
-                "es": {
-                    "name": "Red Skies"
-                },
-                "fr": {
-                    "name": "Ciels Rouges"
-                },
-                "it": {
-                    "name": "Red Skies"
-                },
-                "pl": {
-                    "name": "Red Skies"
-                },
-                "pt": {
-                    "name": "Red Skies"
-                },
-                "th": {
-                    "name": "Red Skies"
-                },
-                "vi": {
-                    "name": "Red Skies"
-                },
-                "zhhans": {
-                    "name": "Red Skies"
-                },
-                "zhhant": {
                     "name": "Red Skies"
                 }
             }
@@ -12940,37 +5187,7 @@
             "power": null,
             "text": "Play: Gain 1 for each house represented among friendly flank creatures.\n",
             "locale": {
-                "de": {
-                    "name": "Silberstreifen"
-                },
                 "en": {
-                    "name": "Silver Linings"
-                },
-                "es": {
-                    "name": "Silver Linings"
-                },
-                "fr": {
-                    "name": "Lueur d’Espoir"
-                },
-                "it": {
-                    "name": "Silver Linings"
-                },
-                "pl": {
-                    "name": "Silver Linings"
-                },
-                "pt": {
-                    "name": "Silver Linings"
-                },
-                "th": {
-                    "name": "Silver Linings"
-                },
-                "vi": {
-                    "name": "Silver Linings"
-                },
-                "zhhans": {
-                    "name": "Silver Linings"
-                },
-                "zhhant": {
                     "name": "Silver Linings"
                 }
             }
@@ -12983,10 +5200,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "human",
-                "knight"
-            ],
+            "traits": ["human", "knight"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -12994,37 +5208,7 @@
             "power": 5,
             "text": "If your red key is forged, Sir Lorcas gains skirmish. \nIf your yellow key is forged, Sir Lorcas gains elusive. \nIf your blue key is forged, Sir Lorcas gains taunt.\n",
             "locale": {
-                "de": {
-                    "name": "Sir Lorcas"
-                },
                 "en": {
-                    "name": "Sir Lorcas"
-                },
-                "es": {
-                    "name": "Sir Lorcas"
-                },
-                "fr": {
-                    "name": "Sire Lorcas"
-                },
-                "it": {
-                    "name": "Sir Lorcas"
-                },
-                "pl": {
-                    "name": "Sir Lorcas"
-                },
-                "pt": {
-                    "name": "Sir Lorcas"
-                },
-                "th": {
-                    "name": "Sir Lorcas"
-                },
-                "vi": {
-                    "name": "Sir Lorcas"
-                },
-                "zhhans": {
-                    "name": "Sir Lorcas"
-                },
-                "zhhant": {
                     "name": "Sir Lorcas"
                 }
             }
@@ -13037,10 +5221,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "robot",
-                "halyard"
-            ],
+            "traits": ["robot", "halyard"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -13048,37 +5229,7 @@
             "power": 4,
             "text": "After Reap: If a blue key is forged, draw 2 cards. Otherwise, draw a card.\n",
             "locale": {
-                "de": {
-                    "name": "Tur-bo-prop"
-                },
                 "en": {
-                    "name": "Tur-bo-prop"
-                },
-                "es": {
-                    "name": "Tur-bo-prop"
-                },
-                "fr": {
-                    "name": "Tur-bo-prop"
-                },
-                "it": {
-                    "name": "Tur-bo-prop"
-                },
-                "pl": {
-                    "name": "Tur-bo-prop"
-                },
-                "pt": {
-                    "name": "Tur-bo-prop"
-                },
-                "th": {
-                    "name": "Tur-bo-prop"
-                },
-                "vi": {
-                    "name": "Tur-bo-prop"
-                },
-                "zhhans": {
-                    "name": "Tur-bo-prop"
-                },
-                "zhhant": {
                     "name": "Tur-bo-prop"
                 }
             }
@@ -13091,10 +5242,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "human",
-                "halyard"
-            ],
+            "traits": ["human", "halyard"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -13102,37 +5250,7 @@
             "power": 3,
             "text": "After your opponent discards a card from their hand, gain 1.\n",
             "locale": {
-                "de": {
-                    "name": "Ty Lourd"
-                },
                 "en": {
-                    "name": "Ty Lourd"
-                },
-                "es": {
-                    "name": "Ty Lourd"
-                },
-                "fr": {
-                    "name": "Ty Lourd"
-                },
-                "it": {
-                    "name": "Ty Lourd"
-                },
-                "pl": {
-                    "name": "Ty Lourd"
-                },
-                "pt": {
-                    "name": "Ty Lourd"
-                },
-                "th": {
-                    "name": "Ty Lourd"
-                },
-                "vi": {
-                    "name": "Ty Lourd"
-                },
-                "zhhans": {
-                    "name": "Ty Lourd"
-                },
-                "zhhant": {
                     "name": "Ty Lourd"
                 }
             }
@@ -13153,37 +5271,7 @@
             "power": null,
             "text": "Play: Steal 2 if any flank creature shares a house with another flank creature. Otherwise, steal 1.\n",
             "locale": {
-                "de": {
-                    "name": "Gegen alle Flaggen"
-                },
                 "en": {
-                    "name": "Against All Flags"
-                },
-                "es": {
-                    "name": "Against All Flags"
-                },
-                "fr": {
-                    "name": "À l’Abordage !"
-                },
-                "it": {
-                    "name": "Against All Flags"
-                },
-                "pl": {
-                    "name": "Against All Flags"
-                },
-                "pt": {
-                    "name": "Against All Flags"
-                },
-                "th": {
-                    "name": "Against All Flags"
-                },
-                "vi": {
-                    "name": "Against All Flags"
-                },
-                "zhhans": {
-                    "name": "Against All Flags"
-                },
-                "zhhant": {
                     "name": "Against All Flags"
                 }
             }
@@ -13204,37 +5292,7 @@
             "power": null,
             "text": "Play: Move a creature to a flank of its controller’s battleline and exhaust it.\n",
             "locale": {
-                "de": {
-                    "name": "Fassrolle"
-                },
                 "en": {
-                    "name": "Barrel Roll"
-                },
-                "es": {
-                    "name": "Barrel Roll"
-                },
-                "fr": {
-                    "name": "Tonneau"
-                },
-                "it": {
-                    "name": "Barrel Roll"
-                },
-                "pl": {
-                    "name": "Barrel Roll"
-                },
-                "pt": {
-                    "name": "Barrel Roll"
-                },
-                "th": {
-                    "name": "Barrel Roll"
-                },
-                "vi": {
-                    "name": "Barrel Roll"
-                },
-                "zhhans": {
-                    "name": "Barrel Roll"
-                },
-                "zhhant": {
                     "name": "Barrel Roll"
                 }
             }
@@ -13247,9 +5305,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "beast"
-            ],
+            "traits": ["beast"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -13257,37 +5313,7 @@
             "power": 2,
             "text": "Enhance .\nAfter Fight/After Reap: Put a +1 power counter on each friendly flank creature.\n",
             "locale": {
-                "de": {
-                    "name": "Blutschwinge"
-                },
                 "en": {
-                    "name": "Bloodwing"
-                },
-                "es": {
-                    "name": "Bloodwing"
-                },
-                "fr": {
-                    "name": "Piruche"
-                },
-                "it": {
-                    "name": "Bloodwing"
-                },
-                "pl": {
-                    "name": "Bloodwing"
-                },
-                "pt": {
-                    "name": "Bloodwing"
-                },
-                "th": {
-                    "name": "Bloodwing"
-                },
-                "vi": {
-                    "name": "Bloodwing"
-                },
-                "zhhans": {
-                    "name": "Bloodwing"
-                },
-                "zhhant": {
                     "name": "Bloodwing"
                 }
             }
@@ -13308,37 +5334,7 @@
             "power": null,
             "text": "Play: If you are overwhelmed, put an enemy creature on the bottom of its owner’s deck. Otherwise, move an enemy creature to a flank of its controller’s battleline and exhaust it.\n",
             "locale": {
-                "de": {
-                    "name": "Eiskalte Fesseln"
-                },
                 "en": {
-                    "name": "Cold Ropes"
-                },
-                "es": {
-                    "name": "Cold Ropes"
-                },
-                "fr": {
-                    "name": "Coup de Froid"
-                },
-                "it": {
-                    "name": "Cold Ropes"
-                },
-                "pl": {
-                    "name": "Cold Ropes"
-                },
-                "pt": {
-                    "name": "Cold Ropes"
-                },
-                "th": {
-                    "name": "Cold Ropes"
-                },
-                "vi": {
-                    "name": "Cold Ropes"
-                },
-                "zhhans": {
-                    "name": "Cold Ropes"
-                },
-                "zhhant": {
                     "name": "Cold Ropes"
                 }
             }
@@ -13351,10 +5347,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "human",
-                "cyborg"
-            ],
+            "traits": ["human", "cyborg"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -13362,37 +5355,7 @@
             "power": 4,
             "text": "After Fight: Steal 1. If a blue key is forged, ward Deep Blue Bryn.\n",
             "locale": {
-                "de": {
-                    "name": "Tief Blauer Bryn"
-                },
                 "en": {
-                    "name": "Deep Blue Bryn"
-                },
-                "es": {
-                    "name": "Deep Blue Bryn"
-                },
-                "fr": {
-                    "name": "Bryn Barbacier"
-                },
-                "it": {
-                    "name": "Deep Blue Bryn"
-                },
-                "pl": {
-                    "name": "Deep Blue Bryn"
-                },
-                "pt": {
-                    "name": "Deep Blue Bryn"
-                },
-                "th": {
-                    "name": "Deep Blue Bryn"
-                },
-                "vi": {
-                    "name": "Deep Blue Bryn"
-                },
-                "zhhans": {
-                    "name": "Deep Blue Bryn"
-                },
-                "zhhant": {
                     "name": "Deep Blue Bryn"
                 }
             }
@@ -13405,10 +5368,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "cyborg",
-                "stormkin"
-            ],
+            "traits": ["cyborg", "stormkin"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -13416,37 +5376,7 @@
             "power": 4,
             "text": "After Reap: If Jeen Peary is on a flank, steal 1.\n",
             "locale": {
-                "de": {
-                    "name": "Jeen Peary"
-                },
                 "en": {
-                    "name": "Jeen Peary"
-                },
-                "es": {
-                    "name": "Jeen Peary"
-                },
-                "fr": {
-                    "name": "Jeanne Peary"
-                },
-                "it": {
-                    "name": "Jeen Peary"
-                },
-                "pl": {
-                    "name": "Jeen Peary"
-                },
-                "pt": {
-                    "name": "Jeen Peary"
-                },
-                "th": {
-                    "name": "Jeen Peary"
-                },
-                "vi": {
-                    "name": "Jeen Peary"
-                },
-                "zhhans": {
-                    "name": "Jeen Peary"
-                },
-                "zhhant": {
                     "name": "Jeen Peary"
                 }
             }
@@ -13467,37 +5397,7 @@
             "power": null,
             "text": "Play: Ready and use a friendly flank creature. If you are overwhelmed, repeat the preceding effect.\n",
             "locale": {
-                "de": {
-                    "name": "Starthilfe"
-                },
                 "en": {
-                    "name": "Jump Start"
-                },
-                "es": {
-                    "name": "Jump Start"
-                },
-                "fr": {
-                    "name": "Catapultage"
-                },
-                "it": {
-                    "name": "Jump Start"
-                },
-                "pl": {
-                    "name": "Jump Start"
-                },
-                "pt": {
-                    "name": "Jump Start"
-                },
-                "th": {
-                    "name": "Jump Start"
-                },
-                "vi": {
-                    "name": "Jump Start"
-                },
-                "zhhans": {
-                    "name": "Jump Start"
-                },
-                "zhhant": {
                     "name": "Jump Start"
                 }
             }
@@ -13510,10 +5410,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "human",
-                "stormkin"
-            ],
+            "traits": ["human", "stormkin"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -13521,37 +5418,7 @@
             "power": 5,
             "text": "After Fight: If you are overwhelmed, steal 2. Otherwise capture 1.\n",
             "locale": {
-                "de": {
-                    "name": "Leutnant Chars"
-                },
                 "en": {
-                    "name": "Leftenant Chars"
-                },
-                "es": {
-                    "name": "Leftenant Chars"
-                },
-                "fr": {
-                    "name": "Lieutenant Charles"
-                },
-                "it": {
-                    "name": "Leftenant Chars"
-                },
-                "pl": {
-                    "name": "Leftenant Chars"
-                },
-                "pt": {
-                    "name": "Leftenant Chars"
-                },
-                "th": {
-                    "name": "Leftenant Chars"
-                },
-                "vi": {
-                    "name": "Leftenant Chars"
-                },
-                "zhhans": {
-                    "name": "Leftenant Chars"
-                },
-                "zhhant": {
                     "name": "Leftenant Chars"
                 }
             }
@@ -13572,37 +5439,7 @@
             "power": null,
             "text": "Play: Destroy an enemy flank creature.\n",
             "locale": {
-                "de": {
-                    "name": "Die Propeller abstauben"
-                },
                 "en": {
-                    "name": "Prop Dusting"
-                },
-                "es": {
-                    "name": "Prop Dusting"
-                },
-                "fr": {
-                    "name": "Dépoussiérer les Hélices"
-                },
-                "it": {
-                    "name": "Prop Dusting"
-                },
-                "pl": {
-                    "name": "Prop Dusting"
-                },
-                "pt": {
-                    "name": "Prop Dusting"
-                },
-                "th": {
-                    "name": "Prop Dusting"
-                },
-                "vi": {
-                    "name": "Prop Dusting"
-                },
-                "zhhans": {
-                    "name": "Prop Dusting"
-                },
-                "zhhant": {
                     "name": "Prop Dusting"
                 }
             }
@@ -13614,11 +5451,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_236_f8c0933a3ed9_en.png",
             "expansion": 928,
             "house": "skyborn",
-            "keywords": [],
-            "traits": [
-                "dinosaur",
-                "halyard"
-            ],
+            "keywords": ["entrench"],
+            "traits": ["dinosaur", "halyard"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -13626,37 +5460,7 @@
             "power": 3,
             "text": "Entrench.\nWhile Remmi Hound is exhausted, each friendly flank creature gets +4 power.\n\n",
             "locale": {
-                "de": {
-                    "name": "Remmi-Hund"
-                },
                 "en": {
-                    "name": "Remmi Hound"
-                },
-                "es": {
-                    "name": "Remmi Hound"
-                },
-                "fr": {
-                    "name": "Rémi le Limier"
-                },
-                "it": {
-                    "name": "Remmi Hound"
-                },
-                "pl": {
-                    "name": "Remmi Hound"
-                },
-                "pt": {
-                    "name": "Remmi Hound"
-                },
-                "th": {
-                    "name": "Remmi Hound"
-                },
-                "vi": {
-                    "name": "Remmi Hound"
-                },
-                "zhhans": {
-                    "name": "Remmi Hound"
-                },
-                "zhhant": {
                     "name": "Remmi Hound"
                 }
             }
@@ -13669,10 +5473,7 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [
-                "human",
-                "stormkin"
-            ],
+            "traits": ["human", "stormkin"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -13680,37 +5481,7 @@
             "power": 3,
             "text": "After Fight: If a red key is forged, deal 4 to each enemy flank creature. Otherwise, deal 1 to each enemy flank creature.\n",
             "locale": {
-                "de": {
-                    "name": "Ruby Rackham"
-                },
                 "en": {
-                    "name": "Ruby Rackham"
-                },
-                "es": {
-                    "name": "Ruby Rackham"
-                },
-                "fr": {
-                    "name": "Rackham la Rouge"
-                },
-                "it": {
-                    "name": "Ruby Rackham"
-                },
-                "pl": {
-                    "name": "Ruby Rackham"
-                },
-                "pt": {
-                    "name": "Ruby Rackham"
-                },
-                "th": {
-                    "name": "Ruby Rackham"
-                },
-                "vi": {
-                    "name": "Ruby Rackham"
-                },
-                "zhhans": {
-                    "name": "Ruby Rackham"
-                },
-                "zhhant": {
                     "name": "Ruby Rackham"
                 }
             }
@@ -13722,12 +5493,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_238_80fde38668eb_en.png",
             "expansion": 928,
             "house": "skyborn",
-            "keywords": [
-                "elusive"
-            ],
-            "traits": [
-                "stormkin"
-            ],
+            "keywords": ["elusive"],
+            "traits": ["stormkin"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -13735,37 +5502,7 @@
             "power": 2,
             "text": "Elusive.\nAfter Reap: If your red key is forged, destroy an enemy creature. If your yellow key is forged, destroy an enemy artifact. If your blue key is forged, destroy an enemy upgrade.\n",
             "locale": {
-                "de": {
-                    "name": "Schleichende Saboteure"
-                },
                 "en": {
-                    "name": "Skulking Saboteurs"
-                },
-                "es": {
-                    "name": "Skulking Saboteurs"
-                },
-                "fr": {
-                    "name": "Saboteurs Inventifs"
-                },
-                "it": {
-                    "name": "Skulking Saboteurs"
-                },
-                "pl": {
-                    "name": "Skulking Saboteurs"
-                },
-                "pt": {
-                    "name": "Skulking Saboteurs"
-                },
-                "th": {
-                    "name": "Skulking Saboteurs"
-                },
-                "vi": {
-                    "name": "Skulking Saboteurs"
-                },
-                "zhhans": {
-                    "name": "Skulking Saboteurs"
-                },
-                "zhhant": {
                     "name": "Skulking Saboteurs"
                 }
             }
@@ -13778,9 +5515,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "location"
-            ],
+            "traits": ["location"],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 1,
@@ -13788,37 +5523,7 @@
             "power": null,
             "text": "After a creature fights, it doesn’t ready during the “ready cards” step this turn.\n",
             "locale": {
-                "de": {
-                    "name": "Brackwasserküste"
-                },
                 "en": {
-                    "name": "Brackish Shoreline"
-                },
-                "es": {
-                    "name": "Brackish Shoreline"
-                },
-                "fr": {
-                    "name": "Rivage Saumâtre"
-                },
-                "it": {
-                    "name": "Brackish Shoreline"
-                },
-                "pl": {
-                    "name": "Brackish Shoreline"
-                },
-                "pt": {
-                    "name": "Brackish Shoreline"
-                },
-                "th": {
-                    "name": "Brackish Shoreline"
-                },
-                "vi": {
-                    "name": "Brackish Shoreline"
-                },
-                "zhhans": {
-                    "name": "Brackish Shoreline"
-                },
-                "zhhant": {
                     "name": "Brackish Shoreline"
                 }
             }
@@ -13839,37 +5544,7 @@
             "power": null,
             "text": "Play: Choose one:\nDestroy an artifact.\nDestroy an upgrade.\nDestroy a creature with armor.\n",
             "locale": {
-                "de": {
-                    "name": "Rosten"
-                },
                 "en": {
-                    "name": "Corrode"
-                },
-                "es": {
-                    "name": "Corrode"
-                },
-                "fr": {
-                    "name": "Corroder"
-                },
-                "it": {
-                    "name": "Corrode"
-                },
-                "pl": {
-                    "name": "Corrode"
-                },
-                "pt": {
-                    "name": "Corrode"
-                },
-                "th": {
-                    "name": "Corrode"
-                },
-                "vi": {
-                    "name": "Corrode"
-                },
-                "zhhans": {
-                    "name": "Corrode"
-                },
-                "zhhant": {
                     "name": "Corrode"
                 }
             }
@@ -13890,37 +5565,7 @@
             "power": null,
             "text": "Play: Exhaust a creature and each of its neighbors. Stun 2 exhausted creatures.\n",
             "locale": {
-                "de": {
-                    "name": "Benommen und verwirrt"
-                },
                 "en": {
-                    "name": "Dazed and Confused"
-                },
-                "es": {
-                    "name": "Dazed and Confused"
-                },
-                "fr": {
-                    "name": "Confus et Perdus"
-                },
-                "it": {
-                    "name": "Dazed and Confused"
-                },
-                "pl": {
-                    "name": "Dazed and Confused"
-                },
-                "pt": {
-                    "name": "Dazed and Confused"
-                },
-                "th": {
-                    "name": "Dazed and Confused"
-                },
-                "vi": {
-                    "name": "Dazed and Confused"
-                },
-                "zhhans": {
-                    "name": "Dazed and Confused"
-                },
-                "zhhant": {
                     "name": "Dazed and Confused"
                 }
             }
@@ -13933,9 +5578,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "aquan"
-            ],
+            "traits": ["aquan"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -13943,37 +5586,7 @@
             "power": 5,
             "text": "After you play an Aquan creature, exhaust an enemy creature.\n",
             "locale": {
-                "de": {
-                    "name": "Tiefenpriester Glebe"
-                },
                 "en": {
-                    "name": "Deep Priest Glebe"
-                },
-                "es": {
-                    "name": "Deep Priest Glebe"
-                },
-                "fr": {
-                    "name": "Prêtre des Profondeurs Glebe"
-                },
-                "it": {
-                    "name": "Deep Priest Glebe"
-                },
-                "pl": {
-                    "name": "Deep Priest Glebe"
-                },
-                "pt": {
-                    "name": "Deep Priest Glebe"
-                },
-                "th": {
-                    "name": "Deep Priest Glebe"
-                },
-                "vi": {
-                    "name": "Deep Priest Glebe"
-                },
-                "zhhans": {
-                    "name": "Deep Priest Glebe"
-                },
-                "zhhant": {
                     "name": "Deep Priest Glebe"
                 }
             }
@@ -13994,37 +5607,7 @@
             "power": null,
             "text": "Play: For the remainder of the turn, after you play another card, exhaust a creature.\n",
             "locale": {
-                "de": {
-                    "name": "Blitzeis"
-                },
                 "en": {
-                    "name": "Flash Freeze"
-                },
-                "es": {
-                    "name": "Flash Freeze"
-                },
-                "fr": {
-                    "name": "Gel Éclair"
-                },
-                "it": {
-                    "name": "Flash Freeze"
-                },
-                "pl": {
-                    "name": "Flash Freeze"
-                },
-                "pt": {
-                    "name": "Flash Freeze"
-                },
-                "th": {
-                    "name": "Flash Freeze"
-                },
-                "vi": {
-                    "name": "Flash Freeze"
-                },
-                "zhhans": {
-                    "name": "Flash Freeze"
-                },
-                "zhhant": {
                     "name": "Flash Freeze"
                 }
             }
@@ -14045,37 +5628,7 @@
             "power": null,
             "text": "",
             "locale": {
-                "de": {
-                    "name": "Hydrogan"
-                },
                 "en": {
-                    "name": "Hydrogan"
-                },
-                "es": {
-                    "name": "Hydrogan"
-                },
-                "fr": {
-                    "name": "Hydrogand"
-                },
-                "it": {
-                    "name": "Hydrogan"
-                },
-                "pl": {
-                    "name": "Hydrogan"
-                },
-                "pt": {
-                    "name": "Hydrogan"
-                },
-                "th": {
-                    "name": "Hydrogan"
-                },
-                "vi": {
-                    "name": "Hydrogan"
-                },
-                "zhhans": {
-                    "name": "Hydrogan"
-                },
-                "zhhant": {
                     "name": "Hydrogan"
                 }
             }
@@ -14088,10 +5641,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "beast",
-                "leviathan"
-            ],
+            "traits": ["beast", "leviathan"],
             "type": "gigantic creature base",
             "rarity": "Special",
             "amber": 0,
@@ -14099,37 +5649,7 @@
             "power": 10,
             "text": "(Play only with the other half of Hydrogan.)\nPlay: Put each other creature faceup under Hydrogan.\nAfter Fight/After Reap: Put a creature from under Hydrogan into play under your control.\nDestroyed: Purge each card under Hydrogan.\n",
             "locale": {
-                "de": {
-                    "name": "Hydrogan"
-                },
                 "en": {
-                    "name": "Hydrogan"
-                },
-                "es": {
-                    "name": "Hydrogan"
-                },
-                "fr": {
-                    "name": "Hydrogand"
-                },
-                "it": {
-                    "name": "Hydrogan"
-                },
-                "pl": {
-                    "name": "Hydrogan"
-                },
-                "pt": {
-                    "name": "Hydrogan"
-                },
-                "th": {
-                    "name": "Hydrogan"
-                },
-                "vi": {
-                    "name": "Hydrogan"
-                },
-                "zhhans": {
-                    "name": "Hydrogan"
-                },
-                "zhhant": {
                     "name": "Hydrogan"
                 }
             }
@@ -14150,37 +5670,7 @@
             "power": null,
             "text": "Play: Look at your opponent’s hand. Play a card from that hand as if it were yours.\n",
             "locale": {
-                "de": {
-                    "name": "Lateralverschiebung"
-                },
                 "en": {
-                    "name": "Lateral Shift"
-                },
-                "es": {
-                    "name": "Lateral Shift"
-                },
-                "fr": {
-                    "name": "Décalage Latéral"
-                },
-                "it": {
-                    "name": "Lateral Shift"
-                },
-                "pl": {
-                    "name": "Lateral Shift"
-                },
-                "pt": {
-                    "name": "Lateral Shift"
-                },
-                "th": {
-                    "name": "Lateral Shift"
-                },
-                "vi": {
-                    "name": "Lateral Shift"
-                },
-                "zhhans": {
-                    "name": "Lateral Shift"
-                },
-                "zhhant": {
                     "name": "Lateral Shift"
                 }
             }
@@ -14201,37 +5691,7 @@
             "power": null,
             "text": "Play: Reveal a random unrevealed card from your opponent’s hand. Then, you may either repeat this effect or your opponent discards the last revealed card.",
             "locale": {
-                "de": {
-                    "name": "Plünderung"
-                },
                 "en": {
-                    "name": "Plunder"
-                },
-                "es": {
-                    "name": "Plunder"
-                },
-                "fr": {
-                    "name": "Pillage"
-                },
-                "it": {
-                    "name": "Plunder"
-                },
-                "pl": {
-                    "name": "Plunder"
-                },
-                "pt": {
-                    "name": "Plunder"
-                },
-                "th": {
-                    "name": "Plunder"
-                },
-                "vi": {
-                    "name": "Plunder"
-                },
-                "zhhans": {
-                    "name": "Plunder"
-                },
-                "zhhant": {
                     "name": "Plunder"
                 }
             }
@@ -14252,37 +5712,7 @@
             "power": null,
             "text": "Play: Exhaust a creature. Draw a card for each exhausted creature. Destroy each exhausted creature.\n",
             "locale": {
-                "de": {
-                    "name": "Sand ins Auge"
-                },
                 "en": {
-                    "name": "Sand In Your Eye"
-                },
-                "es": {
-                    "name": "Sand In Your Eye"
-                },
-                "fr": {
-                    "name": "Du Sable dans l'Œil"
-                },
-                "it": {
-                    "name": "Sand In Your Eye"
-                },
-                "pl": {
-                    "name": "Sand In Your Eye"
-                },
-                "pt": {
-                    "name": "Sand In Your Eye"
-                },
-                "th": {
-                    "name": "Sand In Your Eye"
-                },
-                "vi": {
-                    "name": "Sand In Your Eye"
-                },
-                "zhhans": {
-                    "name": "Sand In Your Eye"
-                },
-                "zhhant": {
                     "name": "Sand In Your Eye"
                 }
             }
@@ -14295,9 +5725,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "aquan"
-            ],
+            "traits": ["aquan"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -14305,37 +5733,7 @@
             "power": 5,
             "text": "At the start of your opponent’s turn, that player discards the top card of their deck and exhausts each creature of that card’s house.\n",
             "locale": {
-                "de": {
-                    "name": "Sibyl Waimare"
-                },
                 "en": {
-                    "name": "Sibyl Waimare"
-                },
-                "es": {
-                    "name": "Sibyl Waimare"
-                },
-                "fr": {
-                    "name": "Sybille Waimare"
-                },
-                "it": {
-                    "name": "Sibyl Waimare"
-                },
-                "pl": {
-                    "name": "Sibyl Waimare"
-                },
-                "pt": {
-                    "name": "Sibyl Waimare"
-                },
-                "th": {
-                    "name": "Sibyl Waimare"
-                },
-                "vi": {
-                    "name": "Sibyl Waimare"
-                },
-                "zhhans": {
-                    "name": "Sibyl Waimare"
-                },
-                "zhhant": {
                     "name": "Sibyl Waimare"
                 }
             }
@@ -14356,37 +5754,7 @@
             "power": null,
             "text": "Enhance .\nThis creature gains, “At the start of your turn, if this creature is exhausted, purge another creature that shares a house with it.”\n",
             "locale": {
-                "de": {
-                    "name": "Sternenmal"
-                },
                 "en": {
-                    "name": "Starpatch"
-                },
-                "es": {
-                    "name": "Starpatch"
-                },
-                "fr": {
-                    "name": "Souffre-Chef"
-                },
-                "it": {
-                    "name": "Starpatch"
-                },
-                "pl": {
-                    "name": "Starpatch"
-                },
-                "pt": {
-                    "name": "Starpatch"
-                },
-                "th": {
-                    "name": "Starpatch"
-                },
-                "vi": {
-                    "name": "Starpatch"
-                },
-                "zhhans": {
-                    "name": "Starpatch"
-                },
-                "zhhant": {
                     "name": "Starpatch"
                 }
             }
@@ -14407,37 +5775,7 @@
             "power": null,
             "text": "Play: Discard the top 10 cards of your opponent’s deck.",
             "locale": {
-                "de": {
-                    "name": "Thalassophobie"
-                },
                 "en": {
-                    "name": "Thalassophobia"
-                },
-                "es": {
-                    "name": "Thalassophobia"
-                },
-                "fr": {
-                    "name": "Thalassophobie"
-                },
-                "it": {
-                    "name": "Thalassophobia"
-                },
-                "pl": {
-                    "name": "Thalassophobia"
-                },
-                "pt": {
-                    "name": "Thalassophobia"
-                },
-                "th": {
-                    "name": "Thalassophobia"
-                },
-                "vi": {
-                    "name": "Thalassophobia"
-                },
-                "zhhans": {
-                    "name": "Thalassophobia"
-                },
-                "zhhant": {
                     "name": "Thalassophobia"
                 }
             }
@@ -14450,9 +5788,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "aquan"
-            ],
+            "traits": ["aquan"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -14460,37 +5796,7 @@
             "power": 9,
             "text": "Instead of readying creatures they control during their “ready cards” step, your opponent deals 1 to The Chosen One for each exhausted creature they control.",
             "locale": {
-                "de": {
-                    "name": "Der Auserwählte"
-                },
                 "en": {
-                    "name": "The Chosen One"
-                },
-                "es": {
-                    "name": "The Chosen One"
-                },
-                "fr": {
-                    "name": "L’Élu"
-                },
-                "it": {
-                    "name": "The Chosen One"
-                },
-                "pl": {
-                    "name": "The Chosen One"
-                },
-                "pt": {
-                    "name": "The Chosen One"
-                },
-                "th": {
-                    "name": "The Chosen One"
-                },
-                "vi": {
-                    "name": "The Chosen One"
-                },
-                "zhhans": {
-                    "name": "The Chosen One"
-                },
-                "zhhant": {
                     "name": "The Chosen One"
                 }
             }
@@ -14503,9 +5809,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "beast"
-            ],
+            "traits": ["beast"],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -14513,37 +5817,7 @@
             "power": 30,
             "text": "Thing from the Deep cannot be played unless Open the Seal is in your discard pile.\nAfter Fight: Steal 2.\n",
             "locale": {
-                "de": {
-                    "name": "Das Ding aus der Tiefe"
-                },
                 "en": {
-                    "name": "Thing from the Deep"
-                },
-                "es": {
-                    "name": "Thing from the Deep"
-                },
-                "fr": {
-                    "name": "Chose des Profondeurs"
-                },
-                "it": {
-                    "name": "Thing from the Deep"
-                },
-                "pl": {
-                    "name": "Thing from the Deep"
-                },
-                "pt": {
-                    "name": "Thing from the Deep"
-                },
-                "th": {
-                    "name": "Thing from the Deep"
-                },
-                "vi": {
-                    "name": "Thing from the Deep"
-                },
-                "zhhans": {
-                    "name": "Thing from the Deep"
-                },
-                "zhhant": {
                     "name": "Thing from the Deep"
                 }
             }
@@ -14564,37 +5838,7 @@
             "power": null,
             "text": "This creature gains, “While this creature is exhausted, your keys cost +6.”\n",
             "locale": {
-                "de": {
-                    "name": "Schwachstelle"
-                },
                 "en": {
-                    "name": "Weak Link"
-                },
-                "es": {
-                    "name": "Weak Link"
-                },
-                "fr": {
-                    "name": "Maillon Faible"
-                },
-                "it": {
-                    "name": "Weak Link"
-                },
-                "pl": {
-                    "name": "Weak Link"
-                },
-                "pt": {
-                    "name": "Weak Link"
-                },
-                "th": {
-                    "name": "Weak Link"
-                },
-                "vi": {
-                    "name": "Weak Link"
-                },
-                "zhhans": {
-                    "name": "Weak Link"
-                },
-                "zhhant": {
                     "name": "Weak Link"
                 }
             }
@@ -14607,9 +5851,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "beast"
-            ],
+            "traits": ["beast"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -14617,37 +5859,7 @@
             "power": 5,
             "text": "After Fight: Your opponent discards\n2 random cards from their hand.\n",
             "locale": {
-                "de": {
-                    "name": "Verderbensfisch"
-                },
                 "en": {
-                    "name": "Addlefish"
-                },
-                "es": {
-                    "name": "Addlefish"
-                },
-                "fr": {
-                    "name": "Poisson Iridescent"
-                },
-                "it": {
-                    "name": "Addlefish"
-                },
-                "pl": {
-                    "name": "Addlefish"
-                },
-                "pt": {
-                    "name": "Addlefish"
-                },
-                "th": {
-                    "name": "Addlefish"
-                },
-                "vi": {
-                    "name": "Addlefish"
-                },
-                "zhhans": {
-                    "name": "Addlefish"
-                },
-                "zhhant": {
                     "name": "Addlefish"
                 }
             }
@@ -14668,37 +5880,7 @@
             "power": null,
             "text": "Play: Choose a house on your opponent’s identity card. If your opponent does not choose that house as their active house on their next turn, gain 3.",
             "locale": {
-                "de": {
-                    "name": "Dezenter Größenwahn"
-                },
                 "en": {
-                    "name": "Allusions of Grandeur"
-                },
-                "es": {
-                    "name": "Allusions of Grandeur"
-                },
-                "fr": {
-                    "name": "Allusions de Grandeur"
-                },
-                "it": {
-                    "name": "Allusions of Grandeur"
-                },
-                "pl": {
-                    "name": "Allusions of Grandeur"
-                },
-                "pt": {
-                    "name": "Allusions of Grandeur"
-                },
-                "th": {
-                    "name": "Allusions of Grandeur"
-                },
-                "vi": {
-                    "name": "Allusions of Grandeur"
-                },
-                "zhhans": {
-                    "name": "Allusions of Grandeur"
-                },
-                "zhhant": {
                     "name": "Allusions of Grandeur"
                 }
             }
@@ -14711,9 +5893,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "location"
-            ],
+            "traits": ["location"],
             "type": "artifact",
             "rarity": "Uncommon",
             "amber": 1,
@@ -14721,37 +5901,7 @@
             "power": null,
             "text": "Action: Put a friendly creature on the bottom of its owner’s deck. If you do, exhaust 3 enemy creatures.",
             "locale": {
-                "de": {
-                    "name": "Azur-Becken-Außenposten"
-                },
                 "en": {
-                    "name": "Azure Basin Outpost"
-                },
-                "es": {
-                    "name": "Azure Basin Outpost"
-                },
-                "fr": {
-                    "name": "Avant-Poste Azuréen"
-                },
-                "it": {
-                    "name": "Azure Basin Outpost"
-                },
-                "pl": {
-                    "name": "Azure Basin Outpost"
-                },
-                "pt": {
-                    "name": "Azure Basin Outpost"
-                },
-                "th": {
-                    "name": "Azure Basin Outpost"
-                },
-                "vi": {
-                    "name": "Azure Basin Outpost"
-                },
-                "zhhans": {
-                    "name": "Azure Basin Outpost"
-                },
-                "zhhant": {
                     "name": "Azure Basin Outpost"
                 }
             }
@@ -14772,37 +5922,7 @@
             "power": null,
             "text": "Play: Return each creature to its owner’s hand. Each player discards random cards from their hand until they have 6 or fewer cards in hand. Gain 2 chains.",
             "locale": {
-                "de": {
-                    "name": "Fangen und Freilassen"
-                },
                 "en": {
-                    "name": "Catch and Release"
-                },
-                "es": {
-                    "name": "Catch and Release"
-                },
-                "fr": {
-                    "name": "Attrapé-Relâché"
-                },
-                "it": {
-                    "name": "Catch and Release"
-                },
-                "pl": {
-                    "name": "Catch and Release"
-                },
-                "pt": {
-                    "name": "Catch and Release"
-                },
-                "th": {
-                    "name": "Catch and Release"
-                },
-                "vi": {
-                    "name": "Catch and Release"
-                },
-                "zhhans": {
-                    "name": "Catch and Release"
-                },
-                "zhhant": {
                     "name": "Catch and Release"
                 }
             }
@@ -14823,37 +5943,7 @@
             "power": null,
             "text": "Play: Exhaust a creature. For each copy of Dreamcall in your discard pile, exhaust another creature and draw a card.\n",
             "locale": {
-                "de": {
-                    "name": "Traumruf"
-                },
                 "en": {
-                    "name": "Dreamcall"
-                },
-                "es": {
-                    "name": "Dreamcall"
-                },
-                "fr": {
-                    "name": "Chant des Sirènes"
-                },
-                "it": {
-                    "name": "Dreamcall"
-                },
-                "pl": {
-                    "name": "Dreamcall"
-                },
-                "pt": {
-                    "name": "Dreamcall"
-                },
-                "th": {
-                    "name": "Dreamcall"
-                },
-                "vi": {
-                    "name": "Dreamcall"
-                },
-                "zhhans": {
-                    "name": "Dreamcall"
-                },
-                "zhhant": {
                     "name": "Dreamcall"
                 }
             }
@@ -14874,37 +5964,7 @@
             "power": null,
             "text": "Play: Capture half of your opponent’s  (rounding down), distributed among any number of friendly creatures.\n",
             "locale": {
-                "de": {
-                    "name": "Tiefenteilung"
-                },
                 "en": {
-                    "name": "Fathomshare"
-                },
-                "es": {
-                    "name": "Fathomshare"
-                },
-                "fr": {
-                    "name": "Partage Sous le Rivage"
-                },
-                "it": {
-                    "name": "Fathomshare"
-                },
-                "pl": {
-                    "name": "Fathomshare"
-                },
-                "pt": {
-                    "name": "Fathomshare"
-                },
-                "th": {
-                    "name": "Fathomshare"
-                },
-                "vi": {
-                    "name": "Fathomshare"
-                },
-                "zhhans": {
-                    "name": "Fathomshare"
-                },
-                "zhhant": {
                     "name": "Fathomshare"
                 }
             }
@@ -14917,10 +5977,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "aquan",
-                "scientist"
-            ],
+            "traits": ["aquan", "scientist"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -14928,37 +5985,7 @@
             "power": 3,
             "text": "After Reap: Choose a house. Exhaust each creature of that house.\nScrap: Exhaust a creature or an artifact.\n",
             "locale": {
-                "de": {
-                    "name": "Hukaru Eisflosse"
-                },
                 "en": {
-                    "name": "Hukaru Icefin"
-                },
-                "es": {
-                    "name": "Hukaru Icefin"
-                },
-                "fr": {
-                    "name": "Hukaru Congèleron"
-                },
-                "it": {
-                    "name": "Hukaru Icefin"
-                },
-                "pl": {
-                    "name": "Hukaru Icefin"
-                },
-                "pt": {
-                    "name": "Hukaru Icefin"
-                },
-                "th": {
-                    "name": "Hukaru Icefin"
-                },
-                "vi": {
-                    "name": "Hukaru Icefin"
-                },
-                "zhhans": {
-                    "name": "Hukaru Icefin"
-                },
-                "zhhant": {
                     "name": "Hukaru Icefin"
                 }
             }
@@ -14970,12 +5997,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_261_4e89d2db94ef_en.png",
             "expansion": 928,
             "house": "unfathomable",
-            "keywords": [
-                "taunt"
-            ],
-            "traits": [
-                "aquan"
-            ],
+            "keywords": ["taunt"],
+            "traits": ["aquan"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -14983,37 +6006,7 @@
             "power": 5,
             "text": "Taunt.\nAt the end of your turn, fully heal each of Kaipo’s neighbors.\n",
             "locale": {
-                "de": {
-                    "name": "Kaipo"
-                },
                 "en": {
-                    "name": "Kaipo"
-                },
-                "es": {
-                    "name": "Kaipo"
-                },
-                "fr": {
-                    "name": "Kayto"
-                },
-                "it": {
-                    "name": "Kaipo"
-                },
-                "pl": {
-                    "name": "Kaipo"
-                },
-                "pt": {
-                    "name": "Kaipo"
-                },
-                "th": {
-                    "name": "Kaipo"
-                },
-                "vi": {
-                    "name": "Kaipo"
-                },
-                "zhhans": {
-                    "name": "Kaipo"
-                },
-                "zhhant": {
                     "name": "Kaipo"
                 }
             }
@@ -15025,10 +6018,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_262_c1336dc81704_en.png",
             "expansion": 928,
             "house": "unfathomable",
-            "keywords": [],
-            "traits": [
-                "aquan"
-            ],
+            "keywords": ["entrench"],
+            "traits": ["aquan"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -15036,37 +6027,7 @@
             "power": 4,
             "text": "Entrench.\nWhile Malina is exhausted, your opponent cannot play creatures more powerful than the most powerful creature in play.\n",
             "locale": {
-                "de": {
-                    "name": "Malina"
-                },
                 "en": {
-                    "name": "Malina"
-                },
-                "es": {
-                    "name": "Malina"
-                },
-                "fr": {
-                    "name": "Mannina"
-                },
-                "it": {
-                    "name": "Malina"
-                },
-                "pl": {
-                    "name": "Malina"
-                },
-                "pt": {
-                    "name": "Malina"
-                },
-                "th": {
-                    "name": "Malina"
-                },
-                "vi": {
-                    "name": "Malina"
-                },
-                "zhhans": {
-                    "name": "Malina"
-                },
-                "zhhant": {
                     "name": "Malina"
                 }
             }
@@ -15078,12 +6039,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_263_ca130e963324_en.png",
             "expansion": 928,
             "house": "unfathomable",
-            "keywords": [
-                "skirmish"
-            ],
-            "traits": [
-                "aquan"
-            ],
+            "keywords": ["skirmish"],
+            "traits": ["aquan"],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -15091,37 +6048,7 @@
             "power": 2,
             "text": "Skirmish. (When you use this creature to fight, it is dealt no damage in return.)\nAfter Fight: Stun and exhaust the creature Sparkfist fights.",
             "locale": {
-                "de": {
-                    "name": "Funkelfaust"
-                },
                 "en": {
-                    "name": "Sparkfist"
-                },
-                "es": {
-                    "name": "Sparkfist"
-                },
-                "fr": {
-                    "name": "Poing-Étincelle"
-                },
-                "it": {
-                    "name": "Sparkfist"
-                },
-                "pl": {
-                    "name": "Sparkfist"
-                },
-                "pt": {
-                    "name": "Sparkfist"
-                },
-                "th": {
-                    "name": "Sparkfist"
-                },
-                "vi": {
-                    "name": "Sparkfist"
-                },
-                "zhhans": {
-                    "name": "Sparkfist"
-                },
-                "zhhant": {
                     "name": "Sparkfist"
                 }
             }
@@ -15142,37 +6069,7 @@
             "power": null,
             "text": "Play: Deal 4 to each ready creature.\n",
             "locale": {
-                "de": {
-                    "name": "Tsunami"
-                },
                 "en": {
-                    "name": "Tsunami"
-                },
-                "es": {
-                    "name": "Tsunami"
-                },
-                "fr": {
-                    "name": "Tsunami"
-                },
-                "it": {
-                    "name": "Tsunami"
-                },
-                "pl": {
-                    "name": "Tsunami"
-                },
-                "pt": {
-                    "name": "Tsunami"
-                },
-                "th": {
-                    "name": "Tsunami"
-                },
-                "vi": {
-                    "name": "Tsunami"
-                },
-                "zhhans": {
-                    "name": "Tsunami"
-                },
-                "zhhant": {
                     "name": "Tsunami"
                 }
             }
@@ -15193,37 +6090,7 @@
             "power": null,
             "text": "This creature cannot ready.\n",
             "locale": {
-                "de": {
-                    "name": "Unter Druck"
-                },
                 "en": {
-                    "name": "Under Pressure"
-                },
-                "es": {
-                    "name": "Under Pressure"
-                },
-                "fr": {
-                    "name": "Sous Pression"
-                },
-                "it": {
-                    "name": "Under Pressure"
-                },
-                "pl": {
-                    "name": "Under Pressure"
-                },
-                "pt": {
-                    "name": "Under Pressure"
-                },
-                "th": {
-                    "name": "Under Pressure"
-                },
-                "vi": {
-                    "name": "Under Pressure"
-                },
-                "zhhans": {
-                    "name": "Under Pressure"
-                },
-                "zhhant": {
                     "name": "Under Pressure"
                 }
             }
@@ -15244,37 +6111,7 @@
             "power": null,
             "text": "Play: Destroy a friendly creature. If you do, look at your opponent’s hand and choose a card from it. That player discards that card.\n",
             "locale": {
-                "de": {
-                    "name": "Blick aus dem Abgrund"
-                },
                 "en": {
-                    "name": "Abyssal Sight"
-                },
-                "es": {
-                    "name": "Abyssal Sight"
-                },
-                "fr": {
-                    "name": "Vision Abyssale"
-                },
-                "it": {
-                    "name": "Abyssal Sight"
-                },
-                "pl": {
-                    "name": "Abyssal Sight"
-                },
-                "pt": {
-                    "name": "Abyssal Sight"
-                },
-                "th": {
-                    "name": "Abyssal Sight"
-                },
-                "vi": {
-                    "name": "Abyssal Sight"
-                },
-                "zhhans": {
-                    "name": "Abyssal Sight"
-                },
-                "zhhant": {
                     "name": "Abyssal Sight"
                 }
             }
@@ -15295,37 +6132,7 @@
             "power": null,
             "text": "Play: Each player discards the top 5 cards of their deck.\n",
             "locale": {
-                "de": {
-                    "name": "Brackwasser-Abrechnung"
-                },
                 "en": {
-                    "name": "Brine Reckoning"
-                },
-                "es": {
-                    "name": "Brine Reckoning"
-                },
-                "fr": {
-                    "name": "Montée des Eaux"
-                },
-                "it": {
-                    "name": "Brine Reckoning"
-                },
-                "pl": {
-                    "name": "Brine Reckoning"
-                },
-                "pt": {
-                    "name": "Brine Reckoning"
-                },
-                "th": {
-                    "name": "Brine Reckoning"
-                },
-                "vi": {
-                    "name": "Brine Reckoning"
-                },
-                "zhhans": {
-                    "name": "Brine Reckoning"
-                },
-                "zhhant": {
                     "name": "Brine Reckoning"
                 }
             }
@@ -15346,37 +6153,7 @@
             "power": null,
             "text": "Play: Exhaust a creature. If it was already exhausted, destroy it instead and its controller loses 1.\n",
             "locale": {
-                "de": {
-                    "name": "Ruf der Leere"
-                },
                 "en": {
-                    "name": "Call of the Void"
-                },
-                "es": {
-                    "name": "Call of the Void"
-                },
-                "fr": {
-                    "name": "Appel du Vide"
-                },
-                "it": {
-                    "name": "Call of the Void"
-                },
-                "pl": {
-                    "name": "Call of the Void"
-                },
-                "pt": {
-                    "name": "Call of the Void"
-                },
-                "th": {
-                    "name": "Call of the Void"
-                },
-                "vi": {
-                    "name": "Call of the Void"
-                },
-                "zhhans": {
-                    "name": "Call of the Void"
-                },
-                "zhhant": {
                     "name": "Call of the Void"
                 }
             }
@@ -15389,9 +6166,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "item"
-            ],
+            "traits": ["item"],
             "type": "artifact",
             "rarity": "Common",
             "amber": 1,
@@ -15399,37 +6174,7 @@
             "power": null,
             "text": "Action: Exhaust a creature or artifact.\n",
             "locale": {
-                "de": {
-                    "name": "Stab der Kälte"
-                },
                 "en": {
-                    "name": "Frigorific Rod"
-                },
-                "es": {
-                    "name": "Frigorific Rod"
-                },
-                "fr": {
-                    "name": "Baguette Frigorifique"
-                },
-                "it": {
-                    "name": "Frigorific Rod"
-                },
-                "pl": {
-                    "name": "Frigorific Rod"
-                },
-                "pt": {
-                    "name": "Frigorific Rod"
-                },
-                "th": {
-                    "name": "Frigorific Rod"
-                },
-                "vi": {
-                    "name": "Frigorific Rod"
-                },
-                "zhhans": {
-                    "name": "Frigorific Rod"
-                },
-                "zhhant": {
                     "name": "Frigorific Rod"
                 }
             }
@@ -15442,9 +6187,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "beast"
-            ],
+            "traits": ["beast"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -15452,37 +6195,7 @@
             "power": 2,
             "text": "Play: If there are no enemy exhausted creatures, your opponent loses 2.\n",
             "locale": {
-                "de": {
-                    "name": "Hermogrith"
-                },
                 "en": {
-                    "name": "Hemogrith"
-                },
-                "es": {
-                    "name": "Hemogrith"
-                },
-                "fr": {
-                    "name": "Hémogritte"
-                },
-                "it": {
-                    "name": "Hemogrith"
-                },
-                "pl": {
-                    "name": "Hemogrith"
-                },
-                "pt": {
-                    "name": "Hemogrith"
-                },
-                "th": {
-                    "name": "Hemogrith"
-                },
-                "vi": {
-                    "name": "Hemogrith"
-                },
-                "zhhans": {
-                    "name": "Hemogrith"
-                },
-                "zhhant": {
                     "name": "Hemogrith"
                 }
             }
@@ -15495,9 +6208,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "aquan"
-            ],
+            "traits": ["aquan"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -15505,37 +6216,7 @@
             "power": 2,
             "text": "Enhance .\nPlay: Choose an enemy creature with no +1 power counters on it. Exhaust that creature and each of its neighbors.\n",
             "locale": {
-                "de": {
-                    "name": "Keenu"
-                },
                 "en": {
-                    "name": "Keenu"
-                },
-                "es": {
-                    "name": "Keenu"
-                },
-                "fr": {
-                    "name": "Keenu"
-                },
-                "it": {
-                    "name": "Keenu"
-                },
-                "pl": {
-                    "name": "Keenu"
-                },
-                "pt": {
-                    "name": "Keenu"
-                },
-                "th": {
-                    "name": "Keenu"
-                },
-                "vi": {
-                    "name": "Keenu"
-                },
-                "zhhans": {
-                    "name": "Keenu"
-                },
-                "zhhant": {
                     "name": "Keenu"
                 }
             }
@@ -15547,12 +6228,8 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_272_4fc0eb72b696_en.png",
             "expansion": 928,
             "house": "unfathomable",
-            "keywords": [
-                "deploy"
-            ],
-            "traits": [
-                "beast"
-            ],
+            "keywords": ["deploy", "entrench"],
+            "traits": ["beast"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -15560,37 +6237,7 @@
             "power": 3,
             "text": "Deploy. Entrench.\nWhile Knuckler is exhausted, each of its neighbors gets +2 armor.\n",
             "locale": {
-                "de": {
-                    "name": "Knöchelkriecher"
-                },
                 "en": {
-                    "name": "Knuckler"
-                },
-                "es": {
-                    "name": "Knuckler"
-                },
-                "fr": {
-                    "name": "Petite Frappe"
-                },
-                "it": {
-                    "name": "Knuckler"
-                },
-                "pl": {
-                    "name": "Knuckler"
-                },
-                "pt": {
-                    "name": "Knuckler"
-                },
-                "th": {
-                    "name": "Knuckler"
-                },
-                "vi": {
-                    "name": "Knuckler"
-                },
-                "zhhans": {
-                    "name": "Knuckler"
-                },
-                "zhhant": {
                     "name": "Knuckler"
                 }
             }
@@ -15603,9 +6250,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "beast"
-            ],
+            "traits": ["beast"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -15613,37 +6258,7 @@
             "power": 3,
             "text": "After Reap: Stun, enrage, and exhaust a creature.\n",
             "locale": {
-                "de": {
-                    "name": "Lähmender Steinfisch"
-                },
                 "en": {
-                    "name": "Paralysis Synan"
-                },
-                "es": {
-                    "name": "Paralysis Synan"
-                },
-                "fr": {
-                    "name": "Synan le Curarisant"
-                },
-                "it": {
-                    "name": "Paralysis Synan"
-                },
-                "pl": {
-                    "name": "Paralysis Synan"
-                },
-                "pt": {
-                    "name": "Paralysis Synan"
-                },
-                "th": {
-                    "name": "Paralysis Synan"
-                },
-                "vi": {
-                    "name": "Paralysis Synan"
-                },
-                "zhhans": {
-                    "name": "Paralysis Synan"
-                },
-                "zhhant": {
                     "name": "Paralysis Synan"
                 }
             }
@@ -15656,10 +6271,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "aquan",
-                "priest"
-            ],
+            "traits": ["aquan", "priest"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -15667,37 +6279,7 @@
             "power": 3,
             "text": "After Reap: Exhaust an enemy creature. If you do, ready a non-Priest creature.\n",
             "locale": {
-                "de": {
-                    "name": "Priesterin Leilani"
-                },
                 "en": {
-                    "name": "Priestess Leilani"
-                },
-                "es": {
-                    "name": "Priestess Leilani"
-                },
-                "fr": {
-                    "name": "Prêtresse Leilani"
-                },
-                "it": {
-                    "name": "Priestess Leilani"
-                },
-                "pl": {
-                    "name": "Priestess Leilani"
-                },
-                "pt": {
-                    "name": "Priestess Leilani"
-                },
-                "th": {
-                    "name": "Priestess Leilani"
-                },
-                "vi": {
-                    "name": "Priestess Leilani"
-                },
-                "zhhans": {
-                    "name": "Priestess Leilani"
-                },
-                "zhhant": {
                     "name": "Priestess Leilani"
                 }
             }
@@ -15710,9 +6292,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "vehicle"
-            ],
+            "traits": ["vehicle"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -15720,37 +6300,7 @@
             "power": 4,
             "text": "After Fight/After Reap: Discard the top card of a player’s deck. For each bonus icon on the discarded card, your opponent loses 1.\n",
             "locale": {
-                "de": {
-                    "name": "Siphonrachen"
-                },
                 "en": {
-                    "name": "Siphon Maw"
-                },
-                "es": {
-                    "name": "Siphon Maw"
-                },
-                "fr": {
-                    "name": "Gueule à Siphon"
-                },
-                "it": {
-                    "name": "Siphon Maw"
-                },
-                "pl": {
-                    "name": "Siphon Maw"
-                },
-                "pt": {
-                    "name": "Siphon Maw"
-                },
-                "th": {
-                    "name": "Siphon Maw"
-                },
-                "vi": {
-                    "name": "Siphon Maw"
-                },
-                "zhhans": {
-                    "name": "Siphon Maw"
-                },
-                "zhhant": {
                     "name": "Siphon Maw"
                 }
             }
@@ -15763,9 +6313,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "item"
-            ],
+            "traits": ["item"],
             "type": "artifact",
             "rarity": "Common",
             "amber": 0,
@@ -15773,37 +6321,7 @@
             "power": null,
             "text": "At the start of your turn, destroy each card with a corrosion counter on it.\nAction: Put a corrosion counter on a card in play.\n",
             "locale": {
-                "de": {
-                    "name": "Pfuschlack"
-                },
                 "en": {
-                    "name": "Slapdash Enamel"
-                },
-                "es": {
-                    "name": "Slapdash Enamel"
-                },
-                "fr": {
-                    "name": "Eaux Corrosives"
-                },
-                "it": {
-                    "name": "Slapdash Enamel"
-                },
-                "pl": {
-                    "name": "Slapdash Enamel"
-                },
-                "pt": {
-                    "name": "Slapdash Enamel"
-                },
-                "th": {
-                    "name": "Slapdash Enamel"
-                },
-                "vi": {
-                    "name": "Slapdash Enamel"
-                },
-                "zhhans": {
-                    "name": "Slapdash Enamel"
-                },
-                "zhhant": {
                     "name": "Slapdash Enamel"
                 }
             }
@@ -15816,9 +6334,7 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [
-                "aquan"
-            ],
+            "traits": ["aquan"],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -15826,37 +6342,7 @@
             "power": 5,
             "text": "Play: Put an enemy creature on top of its owner’s deck.\n",
             "locale": {
-                "de": {
-                    "name": "„Blubber“"
-                },
                 "en": {
-                    "name": "“Bubbles”"
-                },
-                "es": {
-                    "name": "“Bubbles”"
-                },
-                "fr": {
-                    "name": "« Bubulles »"
-                },
-                "it": {
-                    "name": "“Bubbles”"
-                },
-                "pl": {
-                    "name": "“Bubbles”"
-                },
-                "pt": {
-                    "name": "“Bubbles”"
-                },
-                "th": {
-                    "name": "“Bubbles”"
-                },
-                "vi": {
-                    "name": "“Bubbles”"
-                },
-                "zhhans": {
-                    "name": "“Bubbles”"
-                },
-                "zhhant": {
                     "name": "“Bubbles”"
                 }
             }
@@ -15877,37 +6363,7 @@
             "power": null,
             "text": "Enhance . (These icons have already been added to cards in your deck.)\n",
             "locale": {
-                "de": {
-                    "name": "Öffnet das Siegel"
-                },
                 "en": {
-                    "name": "Open the Seal"
-                },
-                "es": {
-                    "name": "Open the Seal"
-                },
-                "fr": {
-                    "name": "Briser le Sceau"
-                },
-                "it": {
-                    "name": "Open the Seal"
-                },
-                "pl": {
-                    "name": "Open the Seal"
-                },
-                "pt": {
-                    "name": "Open the Seal"
-                },
-                "th": {
-                    "name": "Open the Seal"
-                },
-                "vi": {
-                    "name": "Open the Seal"
-                },
-                "zhhans": {
-                    "name": "Open the Seal"
-                },
-                "zhhant": {
                     "name": "Open the Seal"
                 }
             }

--- a/packs/DM.json
+++ b/packs/DM.json
@@ -4,7 +4,7 @@
     ],
     "code": "DM",
     "name": "Draconian Measures",
-    "cardCount": "370",
+    "cardCount": "303",
     "releaseDate": "2026-04-28",
     "cards": [
         {

--- a/packs/DM.json
+++ b/packs/DM.json
@@ -23,7 +23,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -44,7 +74,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -65,7 +125,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -86,7 +176,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -107,7 +227,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -128,7 +278,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -149,7 +329,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -170,7 +380,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -191,7 +431,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -212,7 +482,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -233,7 +533,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -254,7 +584,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -275,7 +635,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -296,7 +686,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -317,7 +737,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -338,7 +788,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -359,7 +839,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -380,7 +890,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -401,7 +941,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -422,7 +992,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -443,7 +1043,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -464,7 +1094,37 @@
             "power": null,
             "text": "Play: Unforge an opponent’s key. If you do, purge Art Project, and your opponent draws 10 cards.\n",
             "locale": {
+                "de": {
+                    "name": "Kunstprojekt"
+                },
                 "en": {
+                    "name": "Art Project"
+                },
+                "es": {
+                    "name": "Art Project"
+                },
+                "fr": {
+                    "name": "Projet Artistique"
+                },
+                "it": {
+                    "name": "Art Project"
+                },
+                "pl": {
+                    "name": "Art Project"
+                },
+                "pt": {
+                    "name": "Art Project"
+                },
+                "th": {
+                    "name": "Art Project"
+                },
+                "vi": {
+                    "name": "Art Project"
+                },
+                "zhhans": {
+                    "name": "Art Project"
+                },
+                "zhhant": {
                     "name": "Art Project"
                 }
             }
@@ -485,7 +1145,37 @@
             "power": null,
             "text": "Play: Each player reveals a random card from their hand or archives. Each player gains 1 for each  bonus icon on their revealed card. Destroy each creature that shares a house with at least one of the revealed cards. Discard the revealed cards.\n",
             "locale": {
+                "de": {
+                    "name": "Tausch und Spiele"
+                },
                 "en": {
+                    "name": "Barter and Games"
+                },
+                "es": {
+                    "name": "Barter and Games"
+                },
+                "fr": {
+                    "name": "Jeux de Troc"
+                },
+                "it": {
+                    "name": "Barter and Games"
+                },
+                "pl": {
+                    "name": "Barter and Games"
+                },
+                "pt": {
+                    "name": "Barter and Games"
+                },
+                "th": {
+                    "name": "Barter and Games"
+                },
+                "vi": {
+                    "name": "Barter and Games"
+                },
+                "zhhans": {
+                    "name": "Barter and Games"
+                },
+                "zhhant": {
                     "name": "Barter and Games"
                 }
             }
@@ -511,7 +1201,37 @@
             "power": 4,
             "text": "Treachery. (This card enters play under your opponent’s control.)\nAfter you forge a key, give control of the most powerful friendly creature to your opponent.\n",
             "locale": {
+                "de": {
+                    "name": "Elenya die Bezaubernde"
+                },
                 "en": {
+                    "name": "Elenya the Charming"
+                },
+                "es": {
+                    "name": "Elenya the Charming"
+                },
+                "fr": {
+                    "name": "Hĕlĕnya la Charmante"
+                },
+                "it": {
+                    "name": "Elenya the Charming"
+                },
+                "pl": {
+                    "name": "Elenya the Charming"
+                },
+                "pt": {
+                    "name": "Elenya the Charming"
+                },
+                "th": {
+                    "name": "Elenya the Charming"
+                },
+                "vi": {
+                    "name": "Elenya the Charming"
+                },
+                "zhhans": {
+                    "name": "Elenya the Charming"
+                },
+                "zhhant": {
                     "name": "Elenya the Charming"
                 }
             }
@@ -532,7 +1252,37 @@
             "power": null,
             "text": "Play: Give control of two friendly creatures to your opponent, one at a time. If you do, take control of two enemy creatures, one at a time.\n",
             "locale": {
+                "de": {
+                    "name": "Fairer Tausch"
+                },
                 "en": {
+                    "name": "Even Swap"
+                },
+                "es": {
+                    "name": "Even Swap"
+                },
+                "fr": {
+                    "name": "Échange Équitable"
+                },
+                "it": {
+                    "name": "Even Swap"
+                },
+                "pl": {
+                    "name": "Even Swap"
+                },
+                "pt": {
+                    "name": "Even Swap"
+                },
+                "th": {
+                    "name": "Even Swap"
+                },
+                "vi": {
+                    "name": "Even Swap"
+                },
+                "zhhans": {
+                    "name": "Even Swap"
+                },
+                "zhhant": {
                     "name": "Even Swap"
                 }
             }
@@ -555,7 +1305,37 @@
             "power": null,
             "text": "Action: Lose 1. If you do, take control of an enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Willenskodierer"
+                },
                 "en": {
+                    "name": "Fiat Transcoder"
+                },
+                "es": {
+                    "name": "Fiat Transcoder"
+                },
+                "fr": {
+                    "name": "Transcodeur Fiduciaire"
+                },
+                "it": {
+                    "name": "Fiat Transcoder"
+                },
+                "pl": {
+                    "name": "Fiat Transcoder"
+                },
+                "pt": {
+                    "name": "Fiat Transcoder"
+                },
+                "th": {
+                    "name": "Fiat Transcoder"
+                },
+                "vi": {
+                    "name": "Fiat Transcoder"
+                },
+                "zhhans": {
+                    "name": "Fiat Transcoder"
+                },
+                "zhhant": {
                     "name": "Fiat Transcoder"
                 }
             }
@@ -576,7 +1356,37 @@
             "power": null,
             "text": "Play: Move each +1 power counter and each  from friendly creatures to the common supply. Forge a key at +6 current cost, reduced by 1 for the total number of +1 power counters and  moved to the common supply this way (to a minimum of 6).\n",
             "locale": {
+                "de": {
+                    "name": "Falsche Währung"
+                },
                 "en": {
+                    "name": "Forged Currency"
+                },
+                "es": {
+                    "name": "Forged Currency"
+                },
+                "fr": {
+                    "name": "Monnaie Contrefaite"
+                },
+                "it": {
+                    "name": "Forged Currency"
+                },
+                "pl": {
+                    "name": "Forged Currency"
+                },
+                "pt": {
+                    "name": "Forged Currency"
+                },
+                "th": {
+                    "name": "Forged Currency"
+                },
+                "vi": {
+                    "name": "Forged Currency"
+                },
+                "zhhans": {
+                    "name": "Forged Currency"
+                },
+                "zhhant": {
                     "name": "Forged Currency"
                 }
             }
@@ -597,7 +1407,37 @@
             "power": null,
             "text": "At the start of each turn, the active player takes control of this creature.\nThis creature may be used as if it belonged to the active house.\n",
             "locale": {
+                "de": {
+                    "name": "Freiberufler"
+                },
                 "en": {
+                    "name": "Freelancer"
+                },
+                "es": {
+                    "name": "Freelancer"
+                },
+                "fr": {
+                    "name": "Franc-Tireur"
+                },
+                "it": {
+                    "name": "Freelancer"
+                },
+                "pl": {
+                    "name": "Freelancer"
+                },
+                "pt": {
+                    "name": "Freelancer"
+                },
+                "th": {
+                    "name": "Freelancer"
+                },
+                "vi": {
+                    "name": "Freelancer"
+                },
+                "zhhans": {
+                    "name": "Freelancer"
+                },
+                "zhhant": {
                     "name": "Freelancer"
                 }
             }
@@ -621,7 +1461,37 @@
             "power": 3,
             "text": "Enhance  . (These icons have already been added to cards in your deck.)\nEach friendly Ekwidon creature cannot reap and gains, “Action: Steal 1.”\n",
             "locale": {
+                "de": {
+                    "name": "Spielveränderer"
+                },
                 "en": {
+                    "name": "Game Changer"
+                },
+                "es": {
+                    "name": "Game Changer"
+                },
+                "fr": {
+                    "name": "Dĕs Sizĩph"
+                },
+                "it": {
+                    "name": "Game Changer"
+                },
+                "pl": {
+                    "name": "Game Changer"
+                },
+                "pt": {
+                    "name": "Game Changer"
+                },
+                "th": {
+                    "name": "Game Changer"
+                },
+                "vi": {
+                    "name": "Game Changer"
+                },
+                "zhhans": {
+                    "name": "Game Changer"
+                },
+                "zhhant": {
                     "name": "Game Changer"
                 }
             }
@@ -642,7 +1512,37 @@
             "power": null,
             "text": "Play: Choose 9 creatures. Move all  on the chosen creatures to their controllers’ pools. Destroy the chosen creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Festlichkeiten zur Jahresmitte"
+                },
                 "en": {
+                    "name": "Midyear Festivities"
+                },
+                "es": {
+                    "name": "Midyear Festivities"
+                },
+                "fr": {
+                    "name": "Festival des Héritiers"
+                },
+                "it": {
+                    "name": "Midyear Festivities"
+                },
+                "pl": {
+                    "name": "Midyear Festivities"
+                },
+                "pt": {
+                    "name": "Midyear Festivities"
+                },
+                "th": {
+                    "name": "Midyear Festivities"
+                },
+                "vi": {
+                    "name": "Midyear Festivities"
+                },
+                "zhhans": {
+                    "name": "Midyear Festivities"
+                },
+                "zhhant": {
                     "name": "Midyear Festivities"
                 }
             }
@@ -666,7 +1566,37 @@
             "power": 6,
             "text": "After Reap: You may pay your opponent 1. If you do, your opponent’s keys cost +4 during their next turn.\n",
             "locale": {
+                "de": {
+                    "name": "Oŏni-Lars"
+                },
                 "en": {
+                    "name": "Oŏni-Lars"
+                },
+                "es": {
+                    "name": "Oŏni-Lars"
+                },
+                "fr": {
+                    "name": "Oŏni-Lars"
+                },
+                "it": {
+                    "name": "Oŏni-Lars"
+                },
+                "pl": {
+                    "name": "Oŏni-Lars"
+                },
+                "pt": {
+                    "name": "Oŏni-Lars"
+                },
+                "th": {
+                    "name": "Oŏni-Lars"
+                },
+                "vi": {
+                    "name": "Oŏni-Lars"
+                },
+                "zhhans": {
+                    "name": "Oŏni-Lars"
+                },
+                "zhhant": {
                     "name": "Oŏni-Lars"
                 }
             }
@@ -691,7 +1621,37 @@
             "power": 2,
             "text": "Versatile. (This card may be used as if it belonged to the active house.)\nPlay: Look at your opponent’s hand and play a creature from it as if it were yours. Your opponent takes control of Talent Scout.\n",
             "locale": {
+                "de": {
+                    "name": "Talentsucher"
+                },
                 "en": {
+                    "name": "Talent Scout"
+                },
+                "es": {
+                    "name": "Talent Scout"
+                },
+                "fr": {
+                    "name": "Dénicheur de Talents"
+                },
+                "it": {
+                    "name": "Talent Scout"
+                },
+                "pl": {
+                    "name": "Talent Scout"
+                },
+                "pt": {
+                    "name": "Talent Scout"
+                },
+                "th": {
+                    "name": "Talent Scout"
+                },
+                "vi": {
+                    "name": "Talent Scout"
+                },
+                "zhhans": {
+                    "name": "Talent Scout"
+                },
+                "zhhant": {
                     "name": "Talent Scout"
                 }
             }
@@ -715,7 +1675,37 @@
             "power": 10,
             "text": "(Play only with the other half of The Golden Queen.)\nEach player refills their hand to 1 additional card during their “draw cards” step.\nAfter Fight/After Reap: Each player discards a random card from their hand. For each non-Ekwidon card discarded this way, gain 1.\n",
             "locale": {
+                "de": {
+                    "name": "Die Goldene Königin"
+                },
                 "en": {
+                    "name": "The Golden Queen"
+                },
+                "es": {
+                    "name": "The Golden Queen"
+                },
+                "fr": {
+                    "name": "La Reine Dorée"
+                },
+                "it": {
+                    "name": "The Golden Queen"
+                },
+                "pl": {
+                    "name": "The Golden Queen"
+                },
+                "pt": {
+                    "name": "The Golden Queen"
+                },
+                "th": {
+                    "name": "The Golden Queen"
+                },
+                "vi": {
+                    "name": "The Golden Queen"
+                },
+                "zhhans": {
+                    "name": "The Golden Queen"
+                },
+                "zhhant": {
                     "name": "The Golden Queen"
                 }
             }
@@ -736,7 +1726,37 @@
             "power": null,
             "text": "",
             "locale": {
+                "de": {
+                    "name": "Die Goldene Königin"
+                },
                 "en": {
+                    "name": "The Golden Queen"
+                },
+                "es": {
+                    "name": "The Golden Queen"
+                },
+                "fr": {
+                    "name": "La Reine Dorée"
+                },
+                "it": {
+                    "name": "The Golden Queen"
+                },
+                "pl": {
+                    "name": "The Golden Queen"
+                },
+                "pt": {
+                    "name": "The Golden Queen"
+                },
+                "th": {
+                    "name": "The Golden Queen"
+                },
+                "vi": {
+                    "name": "The Golden Queen"
+                },
+                "zhhans": {
+                    "name": "The Golden Queen"
+                },
+                "zhhant": {
                     "name": "The Golden Queen"
                 }
             }
@@ -757,7 +1777,37 @@
             "power": null,
             "text": "Play: Your opponent draws 3 cards, discards a random card from their hand, puts a random card from their hand on top of their deck, and purges a random card from their hand.\n",
             "locale": {
+                "de": {
+                    "name": "Ganz schön betrunken"
+                },
                 "en": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "es": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "fr": {
+                    "name": "Torchon Chiffon Carpette"
+                },
+                "it": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "pl": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "pt": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "th": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "vi": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "zhhans": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "zhhant": {
                     "name": "Three Sheets to the Wind"
                 }
             }
@@ -781,7 +1831,37 @@
             "power": 4,
             "text": "Each time you play an artifact from your discard pile, gain 1.\nPlay/After Reap: You may play an artifact from your discard pile.\n",
             "locale": {
+                "de": {
+                    "name": "Zavel, „Archäologe“"
+                },
                 "en": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "es": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "fr": {
+                    "name": "Zavel, « Archéologue »"
+                },
+                "it": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "pl": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "pt": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "th": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "vi": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "zhhans": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "zhhant": {
                     "name": "Zavel, “Archaeologist”"
                 }
             }
@@ -804,7 +1884,37 @@
             "power": null,
             "text": "Your keys cost +1. \nDuring your “draw cards” step, refill your hand to 1 additional card.\n",
             "locale": {
+                "de": {
+                    "name": "Æmbitrage"
+                },
                 "en": {
+                    "name": "Æmbitrage"
+                },
+                "es": {
+                    "name": "Æmbitrage"
+                },
+                "fr": {
+                    "name": "Aombitrage"
+                },
+                "it": {
+                    "name": "Æmbitrage"
+                },
+                "pl": {
+                    "name": "Æmbitrage"
+                },
+                "pt": {
+                    "name": "Æmbitrage"
+                },
+                "th": {
+                    "name": "Æmbitrage"
+                },
+                "vi": {
+                    "name": "Æmbitrage"
+                },
+                "zhhans": {
+                    "name": "Æmbitrage"
+                },
+                "zhhant": {
                     "name": "Æmbitrage"
                 }
             }
@@ -825,7 +1935,37 @@
             "power": null,
             "text": "Play: A friendly creature captures 2. Draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Autorisierter Einzug"
+                },
                 "en": {
+                    "name": "Authorized Requisitions"
+                },
+                "es": {
+                    "name": "Authorized Requisitions"
+                },
+                "fr": {
+                    "name": "Réquisition Autorisée"
+                },
+                "it": {
+                    "name": "Authorized Requisitions"
+                },
+                "pl": {
+                    "name": "Authorized Requisitions"
+                },
+                "pt": {
+                    "name": "Authorized Requisitions"
+                },
+                "th": {
+                    "name": "Authorized Requisitions"
+                },
+                "vi": {
+                    "name": "Authorized Requisitions"
+                },
+                "zhhans": {
+                    "name": "Authorized Requisitions"
+                },
+                "zhhant": {
                     "name": "Authorized Requisitions"
                 }
             }
@@ -849,7 +1989,37 @@
             "power": 4,
             "text": "After Fight/After Reap: For each card in your opponent’s hand in excess of 5, they lose 1.\n",
             "locale": {
+                "de": {
+                    "name": "Betreiber des Wandels"
+                },
                 "en": {
+                    "name": "Change Agent"
+                },
+                "es": {
+                    "name": "Change Agent"
+                },
+                "fr": {
+                    "name": "Agent de Change"
+                },
+                "it": {
+                    "name": "Change Agent"
+                },
+                "pl": {
+                    "name": "Change Agent"
+                },
+                "pt": {
+                    "name": "Change Agent"
+                },
+                "th": {
+                    "name": "Change Agent"
+                },
+                "vi": {
+                    "name": "Change Agent"
+                },
+                "zhhans": {
+                    "name": "Change Agent"
+                },
+                "zhhant": {
                     "name": "Change Agent"
                 }
             }
@@ -870,7 +2040,37 @@
             "power": null,
             "text": "This creature gains, “Action: Deal 4 to a creature. If this damage destroys that creature, return Dapper Chapeau to its owner’s hand. Otherwise, attach Dapper Chapeau to that creature.”\n",
             "locale": {
+                "de": {
+                    "name": "Schicker Hut"
+                },
                 "en": {
+                    "name": "Dapper Chapeau"
+                },
+                "es": {
+                    "name": "Dapper Chapeau"
+                },
+                "fr": {
+                    "name": "Chapeau Pimpant"
+                },
+                "it": {
+                    "name": "Dapper Chapeau"
+                },
+                "pl": {
+                    "name": "Dapper Chapeau"
+                },
+                "pt": {
+                    "name": "Dapper Chapeau"
+                },
+                "th": {
+                    "name": "Dapper Chapeau"
+                },
+                "vi": {
+                    "name": "Dapper Chapeau"
+                },
+                "zhhans": {
+                    "name": "Dapper Chapeau"
+                },
+                "zhhant": {
                     "name": "Dapper Chapeau"
                 }
             }
@@ -891,7 +2091,37 @@
             "power": null,
             "text": "Play: Purge up to 2 cards from your hand. For each card purged this way, gain 1.\n",
             "locale": {
+                "de": {
+                    "name": "Drastische Maßnahmen"
+                },
                 "en": {
+                    "name": "Drastic Measures"
+                },
+                "es": {
+                    "name": "Drastic Measures"
+                },
+                "fr": {
+                    "name": "Mesures Drastiques"
+                },
+                "it": {
+                    "name": "Drastic Measures"
+                },
+                "pl": {
+                    "name": "Drastic Measures"
+                },
+                "pt": {
+                    "name": "Drastic Measures"
+                },
+                "th": {
+                    "name": "Drastic Measures"
+                },
+                "vi": {
+                    "name": "Drastic Measures"
+                },
+                "zhhans": {
+                    "name": "Drastic Measures"
+                },
+                "zhhant": {
                     "name": "Drastic Measures"
                 }
             }
@@ -915,7 +2145,37 @@
             "power": 3,
             "text": "After Reap: Capture 2. You may discard a card. If you do, move 1 from Exeldon Yash to your pool.\n",
             "locale": {
+                "de": {
+                    "name": "Händlerfürst Yash"
+                },
                 "en": {
+                    "name": "Exeldon Yash"
+                },
+                "es": {
+                    "name": "Exeldon Yash"
+                },
+                "fr": {
+                    "name": "Exeldon Vălnŏr"
+                },
+                "it": {
+                    "name": "Exeldon Yash"
+                },
+                "pl": {
+                    "name": "Exeldon Yash"
+                },
+                "pt": {
+                    "name": "Exeldon Yash"
+                },
+                "th": {
+                    "name": "Exeldon Yash"
+                },
+                "vi": {
+                    "name": "Exeldon Yash"
+                },
+                "zhhans": {
+                    "name": "Exeldon Yash"
+                },
+                "zhhant": {
                     "name": "Exeldon Yash"
                 }
             }
@@ -936,7 +2196,37 @@
             "power": null,
             "text": "This creature's text box is considered blank, except for traits.\nPlay: Destroy all other upgrades attached to this creature.\n",
             "locale": {
+                "de": {
+                    "name": "Glücksumkehrer"
+                },
                 "en": {
+                    "name": "Fortune Reverser"
+                },
+                "es": {
+                    "name": "Fortune Reverser"
+                },
+                "fr": {
+                    "name": "Inverseur de Bonne Fortune"
+                },
+                "it": {
+                    "name": "Fortune Reverser"
+                },
+                "pl": {
+                    "name": "Fortune Reverser"
+                },
+                "pt": {
+                    "name": "Fortune Reverser"
+                },
+                "th": {
+                    "name": "Fortune Reverser"
+                },
+                "vi": {
+                    "name": "Fortune Reverser"
+                },
+                "zhhans": {
+                    "name": "Fortune Reverser"
+                },
+                "zhhant": {
                     "name": "Fortune Reverser"
                 }
             }
@@ -960,7 +2250,37 @@
             "power": 3,
             "text": "Play/After Fight: Take control of an enemy artifact. Give your opponent control of Gegrrŏkŭŭ Sapper.\nScrap: Destroy a friendly artifact. If you do, destroy an enemy artifact.\n",
             "locale": {
+                "de": {
+                    "name": "Gegrrŏkŭŭ-Pionier"
+                },
                 "en": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "es": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "fr": {
+                    "name": "Sapeur Gegrrŏkŭŭ"
+                },
+                "it": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "pl": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "pt": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "th": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "vi": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "zhhans": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "zhhant": {
                     "name": "Gegrrŏkŭŭ Sapper"
                 }
             }
@@ -983,7 +2303,37 @@
             "power": 4,
             "text": "After Fight: Take control of an enemy artifact.\n",
             "locale": {
+                "de": {
+                    "name": "Krisper Ruld"
+                },
                 "en": {
+                    "name": "Krisper Ruld"
+                },
+                "es": {
+                    "name": "Krisper Ruld"
+                },
+                "fr": {
+                    "name": "Krisper Ruld"
+                },
+                "it": {
+                    "name": "Krisper Ruld"
+                },
+                "pl": {
+                    "name": "Krisper Ruld"
+                },
+                "pt": {
+                    "name": "Krisper Ruld"
+                },
+                "th": {
+                    "name": "Krisper Ruld"
+                },
+                "vi": {
+                    "name": "Krisper Ruld"
+                },
+                "zhhans": {
+                    "name": "Krisper Ruld"
+                },
+                "zhhant": {
                     "name": "Krisper Ruld"
                 }
             }
@@ -1006,7 +2356,37 @@
             "power": 5,
             "text": "Action: Exhaust an enemy creature. If you do, each player gains 1.\n",
             "locale": {
+                "de": {
+                    "name": "Brieffreund"
+                },
                 "en": {
+                    "name": "Pen Pal"
+                },
+                "es": {
+                    "name": "Pen Pal"
+                },
+                "fr": {
+                    "name": "Correspondant"
+                },
+                "it": {
+                    "name": "Pen Pal"
+                },
+                "pl": {
+                    "name": "Pen Pal"
+                },
+                "pt": {
+                    "name": "Pen Pal"
+                },
+                "th": {
+                    "name": "Pen Pal"
+                },
+                "vi": {
+                    "name": "Pen Pal"
+                },
+                "zhhans": {
+                    "name": "Pen Pal"
+                },
+                "zhhant": {
                     "name": "Pen Pal"
                 }
             }
@@ -1027,7 +2407,37 @@
             "power": null,
             "text": "Enhance .\nPlay: Each player reveals a random card from their hand and gains 1 for each  bonus icon on their revealed card.\n",
             "locale": {
+                "de": {
+                    "name": "Ernte des wilden Windes"
+                },
                 "en": {
+                    "name": "Reap the Wild Wind"
+                },
+                "es": {
+                    "name": "Reap the Wild Wind"
+                },
+                "fr": {
+                    "name": "Récolte la Tempête"
+                },
+                "it": {
+                    "name": "Reap the Wild Wind"
+                },
+                "pl": {
+                    "name": "Reap the Wild Wind"
+                },
+                "pt": {
+                    "name": "Reap the Wild Wind"
+                },
+                "th": {
+                    "name": "Reap the Wild Wind"
+                },
+                "vi": {
+                    "name": "Reap the Wild Wind"
+                },
+                "zhhans": {
+                    "name": "Reap the Wild Wind"
+                },
+                "zhhant": {
                     "name": "Reap the Wild Wind"
                 }
             }
@@ -1048,7 +2458,37 @@
             "power": null,
             "text": "Play: Discard the top 10 cards of your deck. If you discard 5 or more cards of the same house this way, steal 2.\n",
             "locale": {
+                "de": {
+                    "name": "Technorachnophobie"
+                },
                 "en": {
+                    "name": "Technorachnophobia"
+                },
+                "es": {
+                    "name": "Technorachnophobia"
+                },
+                "fr": {
+                    "name": "Technoarachnophobie"
+                },
+                "it": {
+                    "name": "Technorachnophobia"
+                },
+                "pl": {
+                    "name": "Technorachnophobia"
+                },
+                "pt": {
+                    "name": "Technorachnophobia"
+                },
+                "th": {
+                    "name": "Technorachnophobia"
+                },
+                "vi": {
+                    "name": "Technorachnophobia"
+                },
+                "zhhans": {
+                    "name": "Technorachnophobia"
+                },
+                "zhhant": {
                     "name": "Technorachnophobia"
                 }
             }
@@ -1074,7 +2514,37 @@
             "power": 2,
             "text": "Entrench. Poison.\nAt the start of your turn, if Waspscream is exhausted, take control of an enemy creature. \n",
             "locale": {
+                "de": {
+                    "name": "Wespenschrei"
+                },
                 "en": {
+                    "name": "Waspscream"
+                },
+                "es": {
+                    "name": "Waspscream"
+                },
+                "fr": {
+                    "name": "Guêpe Envoûtante"
+                },
+                "it": {
+                    "name": "Waspscream"
+                },
+                "pl": {
+                    "name": "Waspscream"
+                },
+                "pt": {
+                    "name": "Waspscream"
+                },
+                "th": {
+                    "name": "Waspscream"
+                },
+                "vi": {
+                    "name": "Waspscream"
+                },
+                "zhhans": {
+                    "name": "Waspscream"
+                },
+                "zhhant": {
                     "name": "Waspscream"
                 }
             }
@@ -1098,7 +2568,37 @@
             "power": 4,
             "text": "After Fight: Heal up to 2 damage from a creature. For each damage healed this way, exalt that creature.\n",
             "locale": {
+                "de": {
+                    "name": "Bleă-Fŏrh"
+                },
                 "en": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "es": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "fr": {
+                    "name": "Tŏmă-Wăky"
+                },
+                "it": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "pl": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "pt": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "th": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "vi": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "zhhans": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "zhhant": {
                     "name": "Bleă-Fŏrh"
                 }
             }
@@ -1122,7 +2622,37 @@
             "power": 2,
             "text": "Entrench.\nWhile Bypass Burglar is exhausted, each of its neighbors gains, “Action: Steal 1. Deal 1 to this creature.”\n",
             "locale": {
+                "de": {
+                    "name": "Drahtzieher-Einbrecher"
+                },
                 "en": {
+                    "name": "Bypass Burglar"
+                },
+                "es": {
+                    "name": "Bypass Burglar"
+                },
+                "fr": {
+                    "name": "Avide Commanditaire"
+                },
+                "it": {
+                    "name": "Bypass Burglar"
+                },
+                "pl": {
+                    "name": "Bypass Burglar"
+                },
+                "pt": {
+                    "name": "Bypass Burglar"
+                },
+                "th": {
+                    "name": "Bypass Burglar"
+                },
+                "vi": {
+                    "name": "Bypass Burglar"
+                },
+                "zhhans": {
+                    "name": "Bypass Burglar"
+                },
+                "zhhant": {
                     "name": "Bypass Burglar"
                 }
             }
@@ -1146,7 +2676,37 @@
             "power": 4,
             "text": "After Fight/After Reap: If you are overwhelmed, destroy an enemy creature. Otherwise, destroy an enemy artifact.\n",
             "locale": {
+                "de": {
+                    "name": "Chromatischer Wächter"
+                },
                 "en": {
+                    "name": "Chromatic Guardian"
+                },
+                "es": {
+                    "name": "Chromatic Guardian"
+                },
+                "fr": {
+                    "name": "Gardien Chromatique"
+                },
+                "it": {
+                    "name": "Chromatic Guardian"
+                },
+                "pl": {
+                    "name": "Chromatic Guardian"
+                },
+                "pt": {
+                    "name": "Chromatic Guardian"
+                },
+                "th": {
+                    "name": "Chromatic Guardian"
+                },
+                "vi": {
+                    "name": "Chromatic Guardian"
+                },
+                "zhhans": {
+                    "name": "Chromatic Guardian"
+                },
+                "zhhant": {
                     "name": "Chromatic Guardian"
                 }
             }
@@ -1169,7 +2729,37 @@
             "power": 2,
             "text": "Enhance .\nPlay: You may move each +1 power counter from a creature to another creature.\n",
             "locale": {
+                "de": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
                 "en": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "es": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "fr": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "it": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "pl": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "pt": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "th": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "vi": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "zhhans": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "zhhant": {
                     "name": "Cŏnrăd Fisiquĕ"
                 }
             }
@@ -1193,7 +2783,37 @@
             "power": 6,
             "text": "Action: Steal 1. Deal 1 to Gemcoat Vendor.\n",
             "locale": {
+                "de": {
+                    "name": "Edelstein-Händler"
+                },
                 "en": {
+                    "name": "Gemcoat Vendor"
+                },
+                "es": {
+                    "name": "Gemcoat Vendor"
+                },
+                "fr": {
+                    "name": "Vendeur Sous Cape"
+                },
+                "it": {
+                    "name": "Gemcoat Vendor"
+                },
+                "pl": {
+                    "name": "Gemcoat Vendor"
+                },
+                "pt": {
+                    "name": "Gemcoat Vendor"
+                },
+                "th": {
+                    "name": "Gemcoat Vendor"
+                },
+                "vi": {
+                    "name": "Gemcoat Vendor"
+                },
+                "zhhans": {
+                    "name": "Gemcoat Vendor"
+                },
+                "zhhant": {
                     "name": "Gemcoat Vendor"
                 }
             }
@@ -1217,7 +2837,37 @@
             "power": 3,
             "text": "After Reap: Deal 3 to a creature. If this damage destroys that creature, its owner gains 1.\n",
             "locale": {
+                "de": {
+                    "name": "Goldener Dolch"
+                },
                 "en": {
+                    "name": "Golden Dagger"
+                },
+                "es": {
+                    "name": "Golden Dagger"
+                },
+                "fr": {
+                    "name": "Dague d'Or"
+                },
+                "it": {
+                    "name": "Golden Dagger"
+                },
+                "pl": {
+                    "name": "Golden Dagger"
+                },
+                "pt": {
+                    "name": "Golden Dagger"
+                },
+                "th": {
+                    "name": "Golden Dagger"
+                },
+                "vi": {
+                    "name": "Golden Dagger"
+                },
+                "zhhans": {
+                    "name": "Golden Dagger"
+                },
+                "zhhant": {
                     "name": "Golden Dagger"
                 }
             }
@@ -1238,7 +2888,37 @@
             "power": null,
             "text": "Play: Put a creature into its owner’s archives.\n",
             "locale": {
+                "de": {
+                    "name": "Hebevorgänge"
+                },
                 "en": {
+                    "name": "Hoist Operations"
+                },
+                "es": {
+                    "name": "Hoist Operations"
+                },
+                "fr": {
+                    "name": "Opérations de Levage"
+                },
+                "it": {
+                    "name": "Hoist Operations"
+                },
+                "pl": {
+                    "name": "Hoist Operations"
+                },
+                "pt": {
+                    "name": "Hoist Operations"
+                },
+                "th": {
+                    "name": "Hoist Operations"
+                },
+                "vi": {
+                    "name": "Hoist Operations"
+                },
+                "zhhans": {
+                    "name": "Hoist Operations"
+                },
+                "zhhant": {
                     "name": "Hoist Operations"
                 }
             }
@@ -1259,7 +2939,37 @@
             "power": null,
             "text": "Play: Exhaust a creature. If you do, ready a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Warmes Bett"
+                },
                 "en": {
+                    "name": "Hot Bunk"
+                },
+                "es": {
+                    "name": "Hot Bunk"
+                },
+                "fr": {
+                    "name": "Changement de Quart"
+                },
+                "it": {
+                    "name": "Hot Bunk"
+                },
+                "pl": {
+                    "name": "Hot Bunk"
+                },
+                "pt": {
+                    "name": "Hot Bunk"
+                },
+                "th": {
+                    "name": "Hot Bunk"
+                },
+                "vi": {
+                    "name": "Hot Bunk"
+                },
+                "zhhans": {
+                    "name": "Hot Bunk"
+                },
+                "zhhant": {
                     "name": "Hot Bunk"
                 }
             }
@@ -1280,7 +2990,37 @@
             "power": null,
             "text": "Play: Your opponent discards a random card from their hand. For each bonus icon on the discarded card, they lose 1.\n",
             "locale": {
+                "de": {
+                    "name": "Nullsteuer"
+                },
                 "en": {
+                    "name": "Nada Tax"
+                },
+                "es": {
+                    "name": "Nada Tax"
+                },
+                "fr": {
+                    "name": "La Taxe Nada"
+                },
+                "it": {
+                    "name": "Nada Tax"
+                },
+                "pl": {
+                    "name": "Nada Tax"
+                },
+                "pt": {
+                    "name": "Nada Tax"
+                },
+                "th": {
+                    "name": "Nada Tax"
+                },
+                "vi": {
+                    "name": "Nada Tax"
+                },
+                "zhhans": {
+                    "name": "Nada Tax"
+                },
+                "zhhant": {
                     "name": "Nada Tax"
                 }
             }
@@ -1301,7 +3041,37 @@
             "power": null,
             "text": "Play: Return a creature to its owner’s hand and archive a card. If you are overwhelmed, repeat the preceding effect.\n",
             "locale": {
+                "de": {
+                    "name": "Jetzt und später"
+                },
                 "en": {
+                    "name": "Now and Later"
+                },
+                "es": {
+                    "name": "Now and Later"
+                },
+                "fr": {
+                    "name": "Maintenant et Après"
+                },
+                "it": {
+                    "name": "Now and Later"
+                },
+                "pl": {
+                    "name": "Now and Later"
+                },
+                "pt": {
+                    "name": "Now and Later"
+                },
+                "th": {
+                    "name": "Now and Later"
+                },
+                "vi": {
+                    "name": "Now and Later"
+                },
+                "zhhans": {
+                    "name": "Now and Later"
+                },
+                "zhhant": {
                     "name": "Now and Later"
                 }
             }
@@ -1322,7 +3092,37 @@
             "power": null,
             "text": "Play: Exhaust a friendly creature. If you do, steal 2.\n",
             "locale": {
+                "de": {
+                    "name": "Akte"
+                },
                 "en": {
+                    "name": "Permanent Record"
+                },
+                "es": {
+                    "name": "Permanent Record"
+                },
+                "fr": {
+                    "name": "Rodomontade"
+                },
+                "it": {
+                    "name": "Permanent Record"
+                },
+                "pl": {
+                    "name": "Permanent Record"
+                },
+                "pt": {
+                    "name": "Permanent Record"
+                },
+                "th": {
+                    "name": "Permanent Record"
+                },
+                "vi": {
+                    "name": "Permanent Record"
+                },
+                "zhhans": {
+                    "name": "Permanent Record"
+                },
+                "zhhant": {
                     "name": "Permanent Record"
                 }
             }
@@ -1348,7 +3148,37 @@
             "power": 4,
             "text": "Taunt.\nAfter Fight: Move 1 from a creature to the common supply. If you do, draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Văst Stŏik"
+                },
                 "en": {
+                    "name": "Văst Stŏik"
+                },
+                "es": {
+                    "name": "Văst Stŏik"
+                },
+                "fr": {
+                    "name": "Văst Stŏik"
+                },
+                "it": {
+                    "name": "Văst Stŏik"
+                },
+                "pl": {
+                    "name": "Văst Stŏik"
+                },
+                "pt": {
+                    "name": "Văst Stŏik"
+                },
+                "th": {
+                    "name": "Văst Stŏik"
+                },
+                "vi": {
+                    "name": "Văst Stŏik"
+                },
+                "zhhans": {
+                    "name": "Văst Stŏik"
+                },
+                "zhhant": {
                     "name": "Văst Stŏik"
                 }
             }
@@ -1371,7 +3201,37 @@
             "power": null,
             "text": "Action: Discard a card. If you do, purge a card of the same type as the discarded card from a discard pile.\n",
             "locale": {
+                "de": {
+                    "name": "Auraskop"
+                },
                 "en": {
+                    "name": "Aurascope"
+                },
+                "es": {
+                    "name": "Aurascope"
+                },
+                "fr": {
+                    "name": "Auratoscope"
+                },
+                "it": {
+                    "name": "Aurascope"
+                },
+                "pl": {
+                    "name": "Aurascope"
+                },
+                "pt": {
+                    "name": "Aurascope"
+                },
+                "th": {
+                    "name": "Aurascope"
+                },
+                "vi": {
+                    "name": "Aurascope"
+                },
+                "zhhans": {
+                    "name": "Aurascope"
+                },
+                "zhhant": {
                     "name": "Aurascope"
                 }
             }
@@ -1392,7 +3252,37 @@
             "power": null,
             "text": "Enhance .\nPlay: A friendly creature captures 3. If you are haunted, put Empathic Malice on the bottom of your deck.\n",
             "locale": {
+                "de": {
+                    "name": "Empathische Bosheit"
+                },
                 "en": {
+                    "name": "Empathic Malice"
+                },
+                "es": {
+                    "name": "Empathic Malice"
+                },
+                "fr": {
+                    "name": "Hypocrisie"
+                },
+                "it": {
+                    "name": "Empathic Malice"
+                },
+                "pl": {
+                    "name": "Empathic Malice"
+                },
+                "pt": {
+                    "name": "Empathic Malice"
+                },
+                "th": {
+                    "name": "Empathic Malice"
+                },
+                "vi": {
+                    "name": "Empathic Malice"
+                },
+                "zhhans": {
+                    "name": "Empathic Malice"
+                },
+                "zhhant": {
                     "name": "Empathic Malice"
                 }
             }
@@ -1413,7 +3303,37 @@
             "power": null,
             "text": "Play: Swap each player's deck with their discard pile. Shuffle each player's deck.\n",
             "locale": {
+                "de": {
+                    "name": "Zukunft ist Vergangenheit"
+                },
                 "en": {
+                    "name": "Future is Past"
+                },
+                "es": {
+                    "name": "Future is Past"
+                },
+                "fr": {
+                    "name": "Avenir Révolu"
+                },
+                "it": {
+                    "name": "Future is Past"
+                },
+                "pl": {
+                    "name": "Future is Past"
+                },
+                "pt": {
+                    "name": "Future is Past"
+                },
+                "th": {
+                    "name": "Future is Past"
+                },
+                "vi": {
+                    "name": "Future is Past"
+                },
+                "zhhans": {
+                    "name": "Future is Past"
+                },
+                "zhhant": {
                     "name": "Future is Past"
                 }
             }
@@ -1436,7 +3356,37 @@
             "power": null,
             "text": "Action: If you are haunted, archive a card. Otherwise, discard a card. \n",
             "locale": {
+                "de": {
+                    "name": "Geisterstadt"
+                },
                 "en": {
+                    "name": "Ghost Town"
+                },
+                "es": {
+                    "name": "Ghost Town"
+                },
+                "fr": {
+                    "name": "Ville Fantôme"
+                },
+                "it": {
+                    "name": "Ghost Town"
+                },
+                "pl": {
+                    "name": "Ghost Town"
+                },
+                "pt": {
+                    "name": "Ghost Town"
+                },
+                "th": {
+                    "name": "Ghost Town"
+                },
+                "vi": {
+                    "name": "Ghost Town"
+                },
+                "zhhans": {
+                    "name": "Ghost Town"
+                },
+                "zhhant": {
                     "name": "Ghost Town"
                 }
             }
@@ -1460,7 +3410,37 @@
             "power": 8,
             "text": "(Play only with the other half of Gigantor.)\nAfter Fight/After Reap: Purge up to 3 cards from a discard pile. For each card purged this way, draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Gigantor"
+                },
                 "en": {
+                    "name": "Gigantor"
+                },
+                "es": {
+                    "name": "Gigantor"
+                },
+                "fr": {
+                    "name": "Gigantor"
+                },
+                "it": {
+                    "name": "Gigantor"
+                },
+                "pl": {
+                    "name": "Gigantor"
+                },
+                "pt": {
+                    "name": "Gigantor"
+                },
+                "th": {
+                    "name": "Gigantor"
+                },
+                "vi": {
+                    "name": "Gigantor"
+                },
+                "zhhans": {
+                    "name": "Gigantor"
+                },
+                "zhhant": {
                     "name": "Gigantor"
                 }
             }
@@ -1481,7 +3461,37 @@
             "power": null,
             "text": "",
             "locale": {
+                "de": {
+                    "name": "Gigantor"
+                },
                 "en": {
+                    "name": "Gigantor"
+                },
+                "es": {
+                    "name": "Gigantor"
+                },
+                "fr": {
+                    "name": "Gigantor"
+                },
+                "it": {
+                    "name": "Gigantor"
+                },
+                "pl": {
+                    "name": "Gigantor"
+                },
+                "pt": {
+                    "name": "Gigantor"
+                },
+                "th": {
+                    "name": "Gigantor"
+                },
+                "vi": {
+                    "name": "Gigantor"
+                },
+                "zhhans": {
+                    "name": "Gigantor"
+                },
+                "zhhant": {
                     "name": "Gigantor"
                 }
             }
@@ -1505,7 +3515,37 @@
             "power": 3,
             "text": "Enhance .\nEach friendly Geistoid creature gains versatile.\n",
             "locale": {
+                "de": {
+                    "name": "Holografische Todesfee"
+                },
                 "en": {
+                    "name": "Holographic Banshee"
+                },
+                "es": {
+                    "name": "Holographic Banshee"
+                },
+                "fr": {
+                    "name": "Hurlographique"
+                },
+                "it": {
+                    "name": "Holographic Banshee"
+                },
+                "pl": {
+                    "name": "Holographic Banshee"
+                },
+                "pt": {
+                    "name": "Holographic Banshee"
+                },
+                "th": {
+                    "name": "Holographic Banshee"
+                },
+                "vi": {
+                    "name": "Holographic Banshee"
+                },
+                "zhhans": {
+                    "name": "Holographic Banshee"
+                },
+                "zhhant": {
                     "name": "Holographic Banshee"
                 }
             }
@@ -1529,7 +3569,37 @@
             "power": 3,
             "text": "Enhance .\nEach friendly creature with  on it gains, “After Reap: Move 1 from this creature to your pool.”\n",
             "locale": {
+                "de": {
+                    "name": "Jahnspuk"
+                },
                 "en": {
+                    "name": "Jahneerie"
+                },
+                "es": {
+                    "name": "Jahneerie"
+                },
+                "fr": {
+                    "name": "Jane Eerie"
+                },
+                "it": {
+                    "name": "Jahneerie"
+                },
+                "pl": {
+                    "name": "Jahneerie"
+                },
+                "pt": {
+                    "name": "Jahneerie"
+                },
+                "th": {
+                    "name": "Jahneerie"
+                },
+                "vi": {
+                    "name": "Jahneerie"
+                },
+                "zhhans": {
+                    "name": "Jahneerie"
+                },
+                "zhhant": {
                     "name": "Jahneerie"
                 }
             }
@@ -1553,7 +3623,37 @@
             "power": 3,
             "text": "After a friendly Geistoid creature enters play, each player discards the top 2 cards of their deck.\nAfter Reap: Play the topmost creature from your discard pile.\n",
             "locale": {
+                "de": {
+                    "name": "Fräulein Unfug"
+                },
                 "en": {
+                    "name": "Miss Chievous"
+                },
+                "es": {
+                    "name": "Miss Chievous"
+                },
+                "fr": {
+                    "name": "Ma' Licieuse"
+                },
+                "it": {
+                    "name": "Miss Chievous"
+                },
+                "pl": {
+                    "name": "Miss Chievous"
+                },
+                "pt": {
+                    "name": "Miss Chievous"
+                },
+                "th": {
+                    "name": "Miss Chievous"
+                },
+                "vi": {
+                    "name": "Miss Chievous"
+                },
+                "zhhans": {
+                    "name": "Miss Chievous"
+                },
+                "zhhant": {
                     "name": "Miss Chievous"
                 }
             }
@@ -1576,7 +3676,37 @@
             "power": 2,
             "text": "Play: Gain 1 for each card in your opponent’s archives. Your opponent discards each card in their archives.\n",
             "locale": {
+                "de": {
+                    "name": "P.K.E.-Absauger"
+                },
                 "en": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "es": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "fr": {
+                    "name": "Sniffeur P.K.E"
+                },
+                "it": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "pl": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "pt": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "th": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "vi": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "zhhans": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "zhhant": {
                     "name": "P.K.E. Syphonator"
                 }
             }
@@ -1597,7 +3727,37 @@
             "power": null,
             "text": "This creature gains, “After Reap: If you are haunted, gain 2.”\n",
             "locale": {
+                "de": {
+                    "name": "Phantastischer Mantel"
+                },
                 "en": {
+                    "name": "Phantasm Cloak"
+                },
+                "es": {
+                    "name": "Phantasm Cloak"
+                },
+                "fr": {
+                    "name": "Cape Fantômatique"
+                },
+                "it": {
+                    "name": "Phantasm Cloak"
+                },
+                "pl": {
+                    "name": "Phantasm Cloak"
+                },
+                "pt": {
+                    "name": "Phantasm Cloak"
+                },
+                "th": {
+                    "name": "Phantasm Cloak"
+                },
+                "vi": {
+                    "name": "Phantasm Cloak"
+                },
+                "zhhans": {
+                    "name": "Phantasm Cloak"
+                },
+                "zhhant": {
                     "name": "Phantasm Cloak"
                 }
             }
@@ -1618,7 +3778,37 @@
             "power": null,
             "text": "Play: Purge a card from a discard pile. If you do, play a creature or artifact from your purged zone as if it were in your hand. Attach Poltergeistoids to it as an upgrade with the text, “This card belongs to house Geistoid.”\n",
             "locale": {
+                "de": {
+                    "name": "Poltergeistoiden"
+                },
                 "en": {
+                    "name": "Poltergeistoids"
+                },
+                "es": {
+                    "name": "Poltergeistoids"
+                },
+                "fr": {
+                    "name": "Polterspectroïdes"
+                },
+                "it": {
+                    "name": "Poltergeistoids"
+                },
+                "pl": {
+                    "name": "Poltergeistoids"
+                },
+                "pt": {
+                    "name": "Poltergeistoids"
+                },
+                "th": {
+                    "name": "Poltergeistoids"
+                },
+                "vi": {
+                    "name": "Poltergeistoids"
+                },
+                "zhhans": {
+                    "name": "Poltergeistoids"
+                },
+                "zhhant": {
                     "name": "Poltergeistoids"
                 }
             }
@@ -1643,7 +3833,37 @@
             "power": 3,
             "text": "Taunt.\nWhile you are haunted, Protective Playmate gets +6 power. Otherwise, Protective Playmate gains elusive.\n",
             "locale": {
+                "de": {
+                    "name": "Beschützender Kamerad"
+                },
                 "en": {
+                    "name": "Protective Playmate"
+                },
+                "es": {
+                    "name": "Protective Playmate"
+                },
+                "fr": {
+                    "name": "Parangon"
+                },
+                "it": {
+                    "name": "Protective Playmate"
+                },
+                "pl": {
+                    "name": "Protective Playmate"
+                },
+                "pt": {
+                    "name": "Protective Playmate"
+                },
+                "th": {
+                    "name": "Protective Playmate"
+                },
+                "vi": {
+                    "name": "Protective Playmate"
+                },
+                "zhhans": {
+                    "name": "Protective Playmate"
+                },
+                "zhhant": {
                     "name": "Protective Playmate"
                 }
             }
@@ -1664,7 +3884,37 @@
             "power": null,
             "text": "Play: Destroy each creature that is not on a flank. Put a creature from any discard pile into play under your control. Gain 2 chains.\n",
             "locale": {
+                "de": {
+                    "name": "Hülle eines Geistes"
+                },
                 "en": {
+                    "name": "Shell of a Ghost"
+                },
+                "es": {
+                    "name": "Shell of a Ghost"
+                },
+                "fr": {
+                    "name": "Équiper les Morts"
+                },
+                "it": {
+                    "name": "Shell of a Ghost"
+                },
+                "pl": {
+                    "name": "Shell of a Ghost"
+                },
+                "pt": {
+                    "name": "Shell of a Ghost"
+                },
+                "th": {
+                    "name": "Shell of a Ghost"
+                },
+                "vi": {
+                    "name": "Shell of a Ghost"
+                },
+                "zhhans": {
+                    "name": "Shell of a Ghost"
+                },
+                "zhhant": {
                     "name": "Shell of a Ghost"
                 }
             }
@@ -1685,7 +3935,37 @@
             "power": null,
             "text": "Play: Destroy each creature. Each player reveals their hand and discards each creature revealed this way. Each player refills their hand as if it were their “draw cards” step.\n",
             "locale": {
+                "de": {
+                    "name": "Müllhalde"
+                },
                 "en": {
+                    "name": "Trash Heap"
+                },
+                "es": {
+                    "name": "Trash Heap"
+                },
+                "fr": {
+                    "name": "Tas d'Ordures"
+                },
+                "it": {
+                    "name": "Trash Heap"
+                },
+                "pl": {
+                    "name": "Trash Heap"
+                },
+                "pt": {
+                    "name": "Trash Heap"
+                },
+                "th": {
+                    "name": "Trash Heap"
+                },
+                "vi": {
+                    "name": "Trash Heap"
+                },
+                "zhhans": {
+                    "name": "Trash Heap"
+                },
+                "zhhant": {
                     "name": "Trash Heap"
                 }
             }
@@ -1709,7 +3989,37 @@
             "power": 4,
             "text": "Varad the Indulgent gets +1 power for each  on it.\nAfter another friendly Geistoid creature fights, Varad the Indulgent captures 1.\n",
             "locale": {
+                "de": {
+                    "name": "Varad der Nachsichtige"
+                },
                 "en": {
+                    "name": "Varad the Indulgent"
+                },
+                "es": {
+                    "name": "Varad the Indulgent"
+                },
+                "fr": {
+                    "name": "Alvad l'Indulgent"
+                },
+                "it": {
+                    "name": "Varad the Indulgent"
+                },
+                "pl": {
+                    "name": "Varad the Indulgent"
+                },
+                "pt": {
+                    "name": "Varad the Indulgent"
+                },
+                "th": {
+                    "name": "Varad the Indulgent"
+                },
+                "vi": {
+                    "name": "Varad the Indulgent"
+                },
+                "zhhans": {
+                    "name": "Varad the Indulgent"
+                },
+                "zhhant": {
                     "name": "Varad the Indulgent"
                 }
             }
@@ -1732,7 +4042,37 @@
             "power": null,
             "text": "Omni: Name a card. Until the start of your next turn, cards with that name cannot be played or used. Gain 2 chains.\nScrap: Purge a card from your opponent's discard pile. Your opponent shuffles their discard pile into their deck.\n",
             "locale": {
+                "de": {
+                    "name": "Varghasts Rache"
+                },
                 "en": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "es": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "fr": {
+                    "name": "Vengeance de Varghast"
+                },
+                "it": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "pl": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "pt": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "th": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "vi": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "zhhans": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "zhhant": {
                     "name": "Varghast’s Vengeance"
                 }
             }
@@ -1753,7 +4093,37 @@
             "power": null,
             "text": "Play: Purge a card from your discard pile. If you do, a friendly creature captures 2.\n",
             "locale": {
+                "de": {
+                    "name": "Apoptose"
+                },
                 "en": {
+                    "name": "Apoptosis"
+                },
+                "es": {
+                    "name": "Apoptosis"
+                },
+                "fr": {
+                    "name": "Apoptose"
+                },
+                "it": {
+                    "name": "Apoptosis"
+                },
+                "pl": {
+                    "name": "Apoptosis"
+                },
+                "pt": {
+                    "name": "Apoptosis"
+                },
+                "th": {
+                    "name": "Apoptosis"
+                },
+                "vi": {
+                    "name": "Apoptosis"
+                },
+                "zhhans": {
+                    "name": "Apoptosis"
+                },
+                "zhhant": {
                     "name": "Apoptosis"
                 }
             }
@@ -1777,7 +4147,37 @@
             "power": 2,
             "text": "Destroyed: Deal 6 to each enemy flank creature.\nScrap: Deal 1 to each enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Dampfkessel"
+                },
                 "en": {
+                    "name": "Boiler"
+                },
+                "es": {
+                    "name": "Boiler"
+                },
+                "fr": {
+                    "name": "Chaudière"
+                },
+                "it": {
+                    "name": "Boiler"
+                },
+                "pl": {
+                    "name": "Boiler"
+                },
+                "pt": {
+                    "name": "Boiler"
+                },
+                "th": {
+                    "name": "Boiler"
+                },
+                "vi": {
+                    "name": "Boiler"
+                },
+                "zhhans": {
+                    "name": "Boiler"
+                },
+                "zhhant": {
                     "name": "Boiler"
                 }
             }
@@ -1798,7 +4198,37 @@
             "power": null,
             "text": "Play: Choose a friendly creature. Move each  from that creature to your pool. Destroy that creature.\n",
             "locale": {
+                "de": {
+                    "name": "Dämmerungsstrahlen"
+                },
                 "en": {
+                    "name": "Crepuscular Rays"
+                },
+                "es": {
+                    "name": "Crepuscular Rays"
+                },
+                "fr": {
+                    "name": "Rayons Crépusculaires"
+                },
+                "it": {
+                    "name": "Crepuscular Rays"
+                },
+                "pl": {
+                    "name": "Crepuscular Rays"
+                },
+                "pt": {
+                    "name": "Crepuscular Rays"
+                },
+                "th": {
+                    "name": "Crepuscular Rays"
+                },
+                "vi": {
+                    "name": "Crepuscular Rays"
+                },
+                "zhhans": {
+                    "name": "Crepuscular Rays"
+                },
+                "zhhant": {
                     "name": "Crepuscular Rays"
                 }
             }
@@ -1822,7 +4252,37 @@
             "power": 2,
             "text": "Play: Draw 3 cards. Discard 2 cards. Archive a card.\n",
             "locale": {
+                "de": {
+                    "name": "Datamator"
+                },
                 "en": {
+                    "name": "Dammater"
+                },
+                "es": {
+                    "name": "Dammater"
+                },
+                "fr": {
+                    "name": "Dammater"
+                },
+                "it": {
+                    "name": "Dammater"
+                },
+                "pl": {
+                    "name": "Dammater"
+                },
+                "pt": {
+                    "name": "Dammater"
+                },
+                "th": {
+                    "name": "Dammater"
+                },
+                "vi": {
+                    "name": "Dammater"
+                },
+                "zhhans": {
+                    "name": "Dammater"
+                },
+                "zhhant": {
                     "name": "Dammater"
                 }
             }
@@ -1843,7 +4303,37 @@
             "power": null,
             "text": "Play: Shuffle Out of Ideas and the top card of your discard pile into their owner’s deck.\n",
             "locale": {
+                "de": {
+                    "name": "Keine Ideen mehr"
+                },
                 "en": {
+                    "name": "Out of Ideas"
+                },
+                "es": {
+                    "name": "Out of Ideas"
+                },
+                "fr": {
+                    "name": "À Court d'Idées"
+                },
+                "it": {
+                    "name": "Out of Ideas"
+                },
+                "pl": {
+                    "name": "Out of Ideas"
+                },
+                "pt": {
+                    "name": "Out of Ideas"
+                },
+                "th": {
+                    "name": "Out of Ideas"
+                },
+                "vi": {
+                    "name": "Out of Ideas"
+                },
+                "zhhans": {
+                    "name": "Out of Ideas"
+                },
+                "zhhant": {
                     "name": "Out of Ideas"
                 }
             }
@@ -1867,7 +4357,37 @@
             "power": 3,
             "text": "Entrench.\nWhile Paranormal Palisade is exhausted, it gets +4 armor and gains taunt.\n",
             "locale": {
+                "de": {
+                    "name": "Paranormale Palisade"
+                },
                 "en": {
+                    "name": "Paranormal Palisade"
+                },
+                "es": {
+                    "name": "Paranormal Palisade"
+                },
+                "fr": {
+                    "name": "Palissade Paranormale"
+                },
+                "it": {
+                    "name": "Paranormal Palisade"
+                },
+                "pl": {
+                    "name": "Paranormal Palisade"
+                },
+                "pt": {
+                    "name": "Paranormal Palisade"
+                },
+                "th": {
+                    "name": "Paranormal Palisade"
+                },
+                "vi": {
+                    "name": "Paranormal Palisade"
+                },
+                "zhhans": {
+                    "name": "Paranormal Palisade"
+                },
+                "zhhant": {
                     "name": "Paranormal Palisade"
                 }
             }
@@ -1888,7 +4408,37 @@
             "power": null,
             "text": "Play: Shuffle the top 10 cards of your discard pile into your deck. If you do, destroy each creature.\n",
             "locale": {
+                "de": {
+                    "name": "Asche zu Asche"
+                },
                 "en": {
+                    "name": "Return to Rubble"
+                },
+                "es": {
+                    "name": "Return to Rubble"
+                },
+                "fr": {
+                    "name": "Redevenir Poussière"
+                },
+                "it": {
+                    "name": "Return to Rubble"
+                },
+                "pl": {
+                    "name": "Return to Rubble"
+                },
+                "pt": {
+                    "name": "Return to Rubble"
+                },
+                "th": {
+                    "name": "Return to Rubble"
+                },
+                "vi": {
+                    "name": "Return to Rubble"
+                },
+                "zhhans": {
+                    "name": "Return to Rubble"
+                },
+                "zhhant": {
                     "name": "Return to Rubble"
                 }
             }
@@ -1909,7 +4459,37 @@
             "power": null,
             "text": "Play: If your opponent is haunted, destroy an enemy artifact, Cyborg creature, or Robot creature. If you do, play that card as if it were in your hand. Attach Spontaneous Awakening to it as an upgrade with the text, “This card belongs to house Geistoid.”\n",
             "locale": {
+                "de": {
+                    "name": "Spontanes Erwachen"
+                },
                 "en": {
+                    "name": "Spontaneous Awakening"
+                },
+                "es": {
+                    "name": "Spontaneous Awakening"
+                },
+                "fr": {
+                    "name": "Réveil Spontané"
+                },
+                "it": {
+                    "name": "Spontaneous Awakening"
+                },
+                "pl": {
+                    "name": "Spontaneous Awakening"
+                },
+                "pt": {
+                    "name": "Spontaneous Awakening"
+                },
+                "th": {
+                    "name": "Spontaneous Awakening"
+                },
+                "vi": {
+                    "name": "Spontaneous Awakening"
+                },
+                "zhhans": {
+                    "name": "Spontaneous Awakening"
+                },
+                "zhhant": {
                     "name": "Spontaneous Awakening"
                 }
             }
@@ -1933,7 +4513,37 @@
             "power": 3,
             "text": "After Fight/After Reap: Your opponent shuffles a random card from their hand into their deck.\n",
             "locale": {
+                "de": {
+                    "name": "Techno-Schatten"
+                },
                 "en": {
+                    "name": "Techno-Shade"
+                },
+                "es": {
+                    "name": "Techno-Shade"
+                },
+                "fr": {
+                    "name": "Techn'Ombre"
+                },
+                "it": {
+                    "name": "Techno-Shade"
+                },
+                "pl": {
+                    "name": "Techno-Shade"
+                },
+                "pt": {
+                    "name": "Techno-Shade"
+                },
+                "th": {
+                    "name": "Techno-Shade"
+                },
+                "vi": {
+                    "name": "Techno-Shade"
+                },
+                "zhhans": {
+                    "name": "Techno-Shade"
+                },
+                "zhhant": {
                     "name": "Techno-Shade"
                 }
             }
@@ -1957,7 +4567,37 @@
             "power": 5,
             "text": "Enhance .\nEach friendly creature with  on it gains, “Destroyed: Draw 1 card.”\n",
             "locale": {
+                "de": {
+                    "name": "Gedankenfänger"
+                },
                 "en": {
+                    "name": "Thoughtcatcher"
+                },
+                "es": {
+                    "name": "Thoughtcatcher"
+                },
+                "fr": {
+                    "name": "Attrape-Pensées"
+                },
+                "it": {
+                    "name": "Thoughtcatcher"
+                },
+                "pl": {
+                    "name": "Thoughtcatcher"
+                },
+                "pt": {
+                    "name": "Thoughtcatcher"
+                },
+                "th": {
+                    "name": "Thoughtcatcher"
+                },
+                "vi": {
+                    "name": "Thoughtcatcher"
+                },
+                "zhhans": {
+                    "name": "Thoughtcatcher"
+                },
+                "zhhant": {
                     "name": "Thoughtcatcher"
                 }
             }
@@ -1983,7 +4623,37 @@
             "power": 6,
             "text": "Taunt.\nDestroyed: If it is not your turn, your opponent discards 5 cards from the top of their deck. Otherwise, discard 5 cards from the top of your deck.\n",
             "locale": {
+                "de": {
+                    "name": "Titanische Erscheinung"
+                },
                 "en": {
+                    "name": "Titan Apparition"
+                },
+                "es": {
+                    "name": "Titan Apparition"
+                },
+                "fr": {
+                    "name": "Titan Revenant"
+                },
+                "it": {
+                    "name": "Titan Apparition"
+                },
+                "pl": {
+                    "name": "Titan Apparition"
+                },
+                "pt": {
+                    "name": "Titan Apparition"
+                },
+                "th": {
+                    "name": "Titan Apparition"
+                },
+                "vi": {
+                    "name": "Titan Apparition"
+                },
+                "zhhans": {
+                    "name": "Titan Apparition"
+                },
+                "zhhant": {
                     "name": "Titan Apparition"
                 }
             }
@@ -2009,7 +4679,37 @@
             "power": 4,
             "text": "Taunt.\nPlay/After Fight: A friendly creature captures 1.\n",
             "locale": {
+                "de": {
+                    "name": "Tributsammler"
+                },
                 "en": {
+                    "name": "Tribute Collector"
+                },
+                "es": {
+                    "name": "Tribute Collector"
+                },
+                "fr": {
+                    "name": "Collecteur de Tributs"
+                },
+                "it": {
+                    "name": "Tribute Collector"
+                },
+                "pl": {
+                    "name": "Tribute Collector"
+                },
+                "pt": {
+                    "name": "Tribute Collector"
+                },
+                "th": {
+                    "name": "Tribute Collector"
+                },
+                "vi": {
+                    "name": "Tribute Collector"
+                },
+                "zhhans": {
+                    "name": "Tribute Collector"
+                },
+                "zhhant": {
                     "name": "Tribute Collector"
                 }
             }
@@ -2030,7 +4730,37 @@
             "power": null,
             "text": "Play: Forge a key at +20 current cost, reduced by 1 for each card in your discard pile (to a minimum of 6). If you do, purge Ecto-Charge.\n",
             "locale": {
+                "de": {
+                    "name": "Ekto-Ladung"
+                },
                 "en": {
+                    "name": "Ecto-Charge"
+                },
+                "es": {
+                    "name": "Ecto-Charge"
+                },
+                "fr": {
+                    "name": "Ecto-Charge"
+                },
+                "it": {
+                    "name": "Ecto-Charge"
+                },
+                "pl": {
+                    "name": "Ecto-Charge"
+                },
+                "pt": {
+                    "name": "Ecto-Charge"
+                },
+                "th": {
+                    "name": "Ecto-Charge"
+                },
+                "vi": {
+                    "name": "Ecto-Charge"
+                },
+                "zhhans": {
+                    "name": "Ecto-Charge"
+                },
+                "zhhant": {
                     "name": "Ecto-Charge"
                 }
             }
@@ -2054,7 +4784,37 @@
             "power": 3,
             "text": "Entrench.\nWhile Fading Apparition is exhausted, any  you would gain by reaping may be taken from  among friendly creatures instead of the common supply.\n",
             "locale": {
+                "de": {
+                    "name": "Verblassende Erscheinung"
+                },
                 "en": {
+                    "name": "Fading Apparition"
+                },
+                "es": {
+                    "name": "Fading Apparition"
+                },
+                "fr": {
+                    "name": "Apparition Estompée"
+                },
+                "it": {
+                    "name": "Fading Apparition"
+                },
+                "pl": {
+                    "name": "Fading Apparition"
+                },
+                "pt": {
+                    "name": "Fading Apparition"
+                },
+                "th": {
+                    "name": "Fading Apparition"
+                },
+                "vi": {
+                    "name": "Fading Apparition"
+                },
+                "zhhans": {
+                    "name": "Fading Apparition"
+                },
+                "zhhant": {
                     "name": "Fading Apparition"
                 }
             }
@@ -2078,7 +4838,37 @@
             "power": 2,
             "text": "After Reap: Deal 2 to a creature. If this damage destroys that creature, give a friendly creature two +1 power counters.\n",
             "locale": {
+                "de": {
+                    "name": "Hammer-Schmied"
+                },
                 "en": {
+                    "name": "Hammer Smythe"
+                },
+                "es": {
+                    "name": "Hammer Smythe"
+                },
+                "fr": {
+                    "name": "Plume l'Enclume"
+                },
+                "it": {
+                    "name": "Hammer Smythe"
+                },
+                "pl": {
+                    "name": "Hammer Smythe"
+                },
+                "pt": {
+                    "name": "Hammer Smythe"
+                },
+                "th": {
+                    "name": "Hammer Smythe"
+                },
+                "vi": {
+                    "name": "Hammer Smythe"
+                },
+                "zhhans": {
+                    "name": "Hammer Smythe"
+                },
+                "zhhant": {
                     "name": "Hammer Smythe"
                 }
             }
@@ -2099,7 +4889,37 @@
             "power": null,
             "text": "Enhance . (These icons have already been added to cards in your deck.)\nPlay: If you are haunted, purge a card from a discard pile.\n",
             "locale": {
+                "de": {
+                    "name": "Spukdeck"
+                },
                 "en": {
+                    "name": "Haunting Deck"
+                },
+                "es": {
+                    "name": "Haunting Deck"
+                },
+                "fr": {
+                    "name": "Pont Hanté"
+                },
+                "it": {
+                    "name": "Haunting Deck"
+                },
+                "pl": {
+                    "name": "Haunting Deck"
+                },
+                "pt": {
+                    "name": "Haunting Deck"
+                },
+                "th": {
+                    "name": "Haunting Deck"
+                },
+                "vi": {
+                    "name": "Haunting Deck"
+                },
+                "zhhans": {
+                    "name": "Haunting Deck"
+                },
+                "zhhant": {
                     "name": "Haunting Deck"
                 }
             }
@@ -2120,7 +4940,37 @@
             "power": null,
             "text": "Play: Discard the top 6 cards of your deck. You may put a non-Geistoid card discarded this way into your hand.\n",
             "locale": {
+                "de": {
+                    "name": "Spukmaßnahmen"
+                },
                 "en": {
+                    "name": "Haunting Measures"
+                },
+                "es": {
+                    "name": "Haunting Measures"
+                },
+                "fr": {
+                    "name": "Décantation"
+                },
+                "it": {
+                    "name": "Haunting Measures"
+                },
+                "pl": {
+                    "name": "Haunting Measures"
+                },
+                "pt": {
+                    "name": "Haunting Measures"
+                },
+                "th": {
+                    "name": "Haunting Measures"
+                },
+                "vi": {
+                    "name": "Haunting Measures"
+                },
+                "zhhans": {
+                    "name": "Haunting Measures"
+                },
+                "zhhant": {
                     "name": "Haunting Measures"
                 }
             }
@@ -2144,7 +4994,37 @@
             "power": 3,
             "text": "After Fight: If you are overwhelmed, an enemy creature captures 1 from its own side. Otherwise, capture 1.\n",
             "locale": {
+                "de": {
+                    "name": "Schrott-Jimmy"
+                },
                 "en": {
+                    "name": "Janky Jimmy"
+                },
+                "es": {
+                    "name": "Janky Jimmy"
+                },
+                "fr": {
+                    "name": "Pascal le Bancal"
+                },
+                "it": {
+                    "name": "Janky Jimmy"
+                },
+                "pl": {
+                    "name": "Janky Jimmy"
+                },
+                "pt": {
+                    "name": "Janky Jimmy"
+                },
+                "th": {
+                    "name": "Janky Jimmy"
+                },
+                "vi": {
+                    "name": "Janky Jimmy"
+                },
+                "zhhans": {
+                    "name": "Janky Jimmy"
+                },
+                "zhhant": {
                     "name": "Janky Jimmy"
                 }
             }
@@ -2168,7 +5048,37 @@
             "power": 1,
             "text": "Play/Destroyed: Archive the top card of your discard pile.\n",
             "locale": {
+                "de": {
+                    "name": "Memette"
+                },
                 "en": {
+                    "name": "Memette"
+                },
+                "es": {
+                    "name": "Memette"
+                },
+                "fr": {
+                    "name": "Mémotte"
+                },
+                "it": {
+                    "name": "Memette"
+                },
+                "pl": {
+                    "name": "Memette"
+                },
+                "pt": {
+                    "name": "Memette"
+                },
+                "th": {
+                    "name": "Memette"
+                },
+                "vi": {
+                    "name": "Memette"
+                },
+                "zhhans": {
+                    "name": "Memette"
+                },
+                "zhhant": {
                     "name": "Memette"
                 }
             }
@@ -2189,7 +5099,37 @@
             "power": null,
             "text": "Enhance .\nPlay: A friendly creature captures 1. Give control of that creature to your opponent.\n",
             "locale": {
+                "de": {
+                    "name": "Alter Tauschtrick"
+                },
                 "en": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "es": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "fr": {
+                    "name": "Bon Vieux Troc"
+                },
+                "it": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "pl": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "pt": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "th": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "vi": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "zhhans": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "zhhant": {
                     "name": "Ol’ Switcheroo"
                 }
             }
@@ -2213,7 +5153,37 @@
             "power": 2,
             "text": "Enhance .\nAfter Reap: Discard a card. If you do, give a creature two +1 power counters.\n",
             "locale": {
+                "de": {
+                    "name": "Rezyklops"
+                },
                 "en": {
+                    "name": "Recyclops"
+                },
+                "es": {
+                    "name": "Recyclops"
+                },
+                "fr": {
+                    "name": "Recyclope"
+                },
+                "it": {
+                    "name": "Recyclops"
+                },
+                "pl": {
+                    "name": "Recyclops"
+                },
+                "pt": {
+                    "name": "Recyclops"
+                },
+                "th": {
+                    "name": "Recyclops"
+                },
+                "vi": {
+                    "name": "Recyclops"
+                },
+                "zhhans": {
+                    "name": "Recyclops"
+                },
+                "zhhant": {
                     "name": "Recyclops"
                 }
             }
@@ -2234,7 +5204,37 @@
             "power": null,
             "text": "Play: If you are haunted, deal 5 to a creature. Otherwise, return a creature to its owner’s hand.\n",
             "locale": {
+                "de": {
+                    "name": "Zerlegen und Wiederverwerten"
+                },
                 "en": {
+                    "name": "Reduce, Reuse"
+                },
+                "es": {
+                    "name": "Reduce, Reuse"
+                },
+                "fr": {
+                    "name": "Réduire, Réutiliser"
+                },
+                "it": {
+                    "name": "Reduce, Reuse"
+                },
+                "pl": {
+                    "name": "Reduce, Reuse"
+                },
+                "pt": {
+                    "name": "Reduce, Reuse"
+                },
+                "th": {
+                    "name": "Reduce, Reuse"
+                },
+                "vi": {
+                    "name": "Reduce, Reuse"
+                },
+                "zhhans": {
+                    "name": "Reduce, Reuse"
+                },
+                "zhhant": {
                     "name": "Reduce, Reuse"
                 }
             }
@@ -2260,7 +5260,37 @@
             "power": 4,
             "text": "Taunt. \nIf you are overwhelmed, Spikey Goeff gains hazardous 2.\nScrap: Deal 2 to a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Goeff der Stachelige"
+                },
                 "en": {
+                    "name": "Spikey Goeff"
+                },
+                "es": {
+                    "name": "Spikey Goeff"
+                },
+                "fr": {
+                    "name": "Geoff le Hérissé"
+                },
+                "it": {
+                    "name": "Spikey Goeff"
+                },
+                "pl": {
+                    "name": "Spikey Goeff"
+                },
+                "pt": {
+                    "name": "Spikey Goeff"
+                },
+                "th": {
+                    "name": "Spikey Goeff"
+                },
+                "vi": {
+                    "name": "Spikey Goeff"
+                },
+                "zhhans": {
+                    "name": "Spikey Goeff"
+                },
+                "zhhant": {
                     "name": "Spikey Goeff"
                 }
             }
@@ -2284,7 +5314,37 @@
             "power": 4,
             "text": "At the start of your turn, discard a card from your hand.\n",
             "locale": {
+                "de": {
+                    "name": "Geisterkonstrukt"
+                },
                 "en": {
+                    "name": "Wraith Construct"
+                },
+                "es": {
+                    "name": "Wraith Construct"
+                },
+                "fr": {
+                    "name": "Colère Noire"
+                },
+                "it": {
+                    "name": "Wraith Construct"
+                },
+                "pl": {
+                    "name": "Wraith Construct"
+                },
+                "pt": {
+                    "name": "Wraith Construct"
+                },
+                "th": {
+                    "name": "Wraith Construct"
+                },
+                "vi": {
+                    "name": "Wraith Construct"
+                },
+                "zhhans": {
+                    "name": "Wraith Construct"
+                },
+                "zhhant": {
                     "name": "Wraith Construct"
                 }
             }
@@ -2308,7 +5368,37 @@
             "power": 2,
             "text": "Each non-Mars creature and artifact gains, “After this card is used, destroy it.”\n",
             "locale": {
+                "de": {
+                    "name": "Bartos der Verwüster"
+                },
                 "en": {
+                    "name": "Bartos the Ruiner"
+                },
+                "es": {
+                    "name": "Bartos the Ruiner"
+                },
+                "fr": {
+                    "name": "Bartos le Ravageur"
+                },
+                "it": {
+                    "name": "Bartos the Ruiner"
+                },
+                "pl": {
+                    "name": "Bartos the Ruiner"
+                },
+                "pt": {
+                    "name": "Bartos the Ruiner"
+                },
+                "th": {
+                    "name": "Bartos the Ruiner"
+                },
+                "vi": {
+                    "name": "Bartos the Ruiner"
+                },
+                "zhhans": {
+                    "name": "Bartos the Ruiner"
+                },
+                "zhhant": {
                     "name": "Bartos the Ruiner"
                 }
             }
@@ -2329,7 +5419,37 @@
             "power": null,
             "text": "This creature gains, “After you play a Mars creature, ready this creature and for the remainder of the turn it belongs to house Mars.”",
             "locale": {
+                "de": {
+                    "name": "Hirnstamm-Antenne"
+                },
                 "en": {
+                    "name": "Brain Stem Antenna"
+                },
+                "es": {
+                    "name": "Brain Stem Antenna"
+                },
+                "fr": {
+                    "name": "Antenne Cérébrale"
+                },
+                "it": {
+                    "name": "Brain Stem Antenna"
+                },
+                "pl": {
+                    "name": "Brain Stem Antenna"
+                },
+                "pt": {
+                    "name": "Brain Stem Antenna"
+                },
+                "th": {
+                    "name": "Brain Stem Antenna"
+                },
+                "vi": {
+                    "name": "Brain Stem Antenna"
+                },
+                "zhhans": {
+                    "name": "Brain Stem Antenna"
+                },
+                "zhhant": {
                     "name": "Brain Stem Antenna"
                 }
             }
@@ -2353,7 +5473,37 @@
             "power": 3,
             "text": "Enhance  . (These icons have already been added to cards in your deck.)\nAt the end of your turn, give each other Mars creature two +1 power counters.\n",
             "locale": {
+                "de": {
+                    "name": "Ältester Chargenbetreuer"
+                },
                 "en": {
+                    "name": "Eldest Batchminder"
+                },
+                "es": {
+                    "name": "Eldest Batchminder"
+                },
+                "fr": {
+                    "name": "Doyen des Lots"
+                },
+                "it": {
+                    "name": "Eldest Batchminder"
+                },
+                "pl": {
+                    "name": "Eldest Batchminder"
+                },
+                "pt": {
+                    "name": "Eldest Batchminder"
+                },
+                "th": {
+                    "name": "Eldest Batchminder"
+                },
+                "vi": {
+                    "name": "Eldest Batchminder"
+                },
+                "zhhans": {
+                    "name": "Eldest Batchminder"
+                },
+                "zhhant": {
                     "name": "Eldest Batchminder"
                 }
             }
@@ -2378,7 +5528,37 @@
             "power": 5,
             "text": "While Emperor Memrox is in the center of your battleline, it gains invulnerable.\nAfter Reap: Archive a card. Gain 1 for each card in your archives.\n",
             "locale": {
+                "de": {
+                    "name": "Imperator Memrox"
+                },
                 "en": {
+                    "name": "Emperor Memrox"
+                },
+                "es": {
+                    "name": "Emperor Memrox"
+                },
+                "fr": {
+                    "name": "Empereur Memrox"
+                },
+                "it": {
+                    "name": "Emperor Memrox"
+                },
+                "pl": {
+                    "name": "Emperor Memrox"
+                },
+                "pt": {
+                    "name": "Emperor Memrox"
+                },
+                "th": {
+                    "name": "Emperor Memrox"
+                },
+                "vi": {
+                    "name": "Emperor Memrox"
+                },
+                "zhhans": {
+                    "name": "Emperor Memrox"
+                },
+                "zhhant": {
                     "name": "Emperor Memrox"
                 }
             }
@@ -2399,7 +5579,37 @@
             "power": null,
             "text": "Play: Destroy a creature and each creature that shares a trait with it. Gain 1 chain.",
             "locale": {
+                "de": {
+                    "name": "Vernichtung"
+                },
                 "en": {
+                    "name": "Extinction"
+                },
+                "es": {
+                    "name": "Extinction"
+                },
+                "fr": {
+                    "name": "Extinction"
+                },
+                "it": {
+                    "name": "Extinction"
+                },
+                "pl": {
+                    "name": "Extinction"
+                },
+                "pt": {
+                    "name": "Extinction"
+                },
+                "th": {
+                    "name": "Extinction"
+                },
+                "vi": {
+                    "name": "Extinction"
+                },
+                "zhhans": {
+                    "name": "Extinction"
+                },
+                "zhhant": {
                     "name": "Extinction"
                 }
             }
@@ -2420,7 +5630,37 @@
             "power": null,
             "text": "Play: For each friendly Mars creature, choose an enemy creature to capture 1 from its own side.",
             "locale": {
+                "de": {
+                    "name": "Hypnotischer Befehl"
+                },
                 "en": {
+                    "name": "Hypnotic Command"
+                },
+                "es": {
+                    "name": "Hypnotic Command"
+                },
+                "fr": {
+                    "name": "Ordre Hypnotique"
+                },
+                "it": {
+                    "name": "Hypnotic Command"
+                },
+                "pl": {
+                    "name": "Hypnotic Command"
+                },
+                "pt": {
+                    "name": "Hypnotic Command"
+                },
+                "th": {
+                    "name": "Hypnotic Command"
+                },
+                "vi": {
+                    "name": "Hypnotic Command"
+                },
+                "zhhans": {
+                    "name": "Hypnotic Command"
+                },
+                "zhhant": {
                     "name": "Hypnotic Command"
                 }
             }
@@ -2441,7 +5681,37 @@
             "power": null,
             "text": "Play: Destroy each friendly creature. For each creature destroyed this way, draw 2 cards.\n",
             "locale": {
+                "de": {
+                    "name": "Marsianische Ausbreitung"
+                },
                 "en": {
+                    "name": "Martian Propagation"
+                },
+                "es": {
+                    "name": "Martian Propagation"
+                },
+                "fr": {
+                    "name": "Propagation Martienne"
+                },
+                "it": {
+                    "name": "Martian Propagation"
+                },
+                "pl": {
+                    "name": "Martian Propagation"
+                },
+                "pt": {
+                    "name": "Martian Propagation"
+                },
+                "th": {
+                    "name": "Martian Propagation"
+                },
+                "vi": {
+                    "name": "Martian Propagation"
+                },
+                "zhhans": {
+                    "name": "Martian Propagation"
+                },
+                "zhhant": {
                     "name": "Martian Propagation"
                 }
             }
@@ -2462,7 +5732,37 @@
             "power": null,
             "text": "Play: Put up to 3 damaged enemy creatures into your archives. If any of these creatures leave your archives, they are put into their owner’s hand instead.",
             "locale": {
+                "de": {
+                    "name": "Massenentführung"
+                },
                 "en": {
+                    "name": "Mass Abduction"
+                },
+                "es": {
+                    "name": "Mass Abduction"
+                },
+                "fr": {
+                    "name": "Enlèvement de Masse"
+                },
+                "it": {
+                    "name": "Mass Abduction"
+                },
+                "pl": {
+                    "name": "Mass Abduction"
+                },
+                "pt": {
+                    "name": "Mass Abduction"
+                },
+                "th": {
+                    "name": "Mass Abduction"
+                },
+                "vi": {
+                    "name": "Mass Abduction"
+                },
+                "zhhans": {
+                    "name": "Mass Abduction"
+                },
+                "zhhant": {
                     "name": "Mass Abduction"
                 }
             }
@@ -2488,7 +5788,37 @@
             "power": 1,
             "text": "(Play only with the other half of Monster Zero.)\nDeploy.\nEach of Monster Zero's neighbors belongs to house Mars (instead of its other houses).\nPlay: Give Monster Zero a number of +1 power counters equal to the most powerful friendly creature’s power.\n",
             "locale": {
+                "de": {
+                    "name": "Monster Zero"
+                },
                 "en": {
+                    "name": "Monster Zero"
+                },
+                "es": {
+                    "name": "Monster Zero"
+                },
+                "fr": {
+                    "name": "Monstre Zéro"
+                },
+                "it": {
+                    "name": "Monster Zero"
+                },
+                "pl": {
+                    "name": "Monster Zero"
+                },
+                "pt": {
+                    "name": "Monster Zero"
+                },
+                "th": {
+                    "name": "Monster Zero"
+                },
+                "vi": {
+                    "name": "Monster Zero"
+                },
+                "zhhans": {
+                    "name": "Monster Zero"
+                },
+                "zhhant": {
                     "name": "Monster Zero"
                 }
             }
@@ -2509,7 +5839,37 @@
             "power": null,
             "text": "",
             "locale": {
+                "de": {
+                    "name": "Monster Zero"
+                },
                 "en": {
+                    "name": "Monster Zero"
+                },
+                "es": {
+                    "name": "Monster Zero"
+                },
+                "fr": {
+                    "name": "Monstre Zéro"
+                },
+                "it": {
+                    "name": "Monster Zero"
+                },
+                "pl": {
+                    "name": "Monster Zero"
+                },
+                "pt": {
+                    "name": "Monster Zero"
+                },
+                "th": {
+                    "name": "Monster Zero"
+                },
+                "vi": {
+                    "name": "Monster Zero"
+                },
+                "zhhans": {
+                    "name": "Monster Zero"
+                },
+                "zhhant": {
                     "name": "Monster Zero"
                 }
             }
@@ -2532,7 +5892,37 @@
             "power": null,
             "text": "Enraged creatures cannot be used to fight friendly Mars creatures.\nAction: Enrage each enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Psychischer Dunst"
+                },
                 "en": {
+                    "name": "Psychic Haze"
+                },
+                "es": {
+                    "name": "Psychic Haze"
+                },
+                "fr": {
+                    "name": "Brume Psychique"
+                },
+                "it": {
+                    "name": "Psychic Haze"
+                },
+                "pl": {
+                    "name": "Psychic Haze"
+                },
+                "pt": {
+                    "name": "Psychic Haze"
+                },
+                "th": {
+                    "name": "Psychic Haze"
+                },
+                "vi": {
+                    "name": "Psychic Haze"
+                },
+                "zhhans": {
+                    "name": "Psychic Haze"
+                },
+                "zhhant": {
                     "name": "Psychic Haze"
                 }
             }
@@ -2555,7 +5945,37 @@
             "power": 4,
             "text": "You may play a Mars card during each turn in which Mars is not your active house.\n",
             "locale": {
+                "de": {
+                    "name": "Tangrant"
+                },
                 "en": {
+                    "name": "Tangrant"
+                },
+                "es": {
+                    "name": "Tangrant"
+                },
+                "fr": {
+                    "name": "Tangrant"
+                },
+                "it": {
+                    "name": "Tangrant"
+                },
+                "pl": {
+                    "name": "Tangrant"
+                },
+                "pt": {
+                    "name": "Tangrant"
+                },
+                "th": {
+                    "name": "Tangrant"
+                },
+                "vi": {
+                    "name": "Tangrant"
+                },
+                "zhhans": {
+                    "name": "Tangrant"
+                },
+                "zhhant": {
                     "name": "Tangrant"
                 }
             }
@@ -2576,7 +5996,37 @@
             "power": null,
             "text": "Play: For the remainder of the turn, each enemy creature gains, “Destroyed: Fully heal this creature and give control of it to your opponent instead.”\n",
             "locale": {
+                "de": {
+                    "name": "Die Körperfresser"
+                },
                 "en": {
+                    "name": "The Body Snatchers"
+                },
+                "es": {
+                    "name": "The Body Snatchers"
+                },
+                "fr": {
+                    "name": "Usurpation des Corps"
+                },
+                "it": {
+                    "name": "The Body Snatchers"
+                },
+                "pl": {
+                    "name": "The Body Snatchers"
+                },
+                "pt": {
+                    "name": "The Body Snatchers"
+                },
+                "th": {
+                    "name": "The Body Snatchers"
+                },
+                "vi": {
+                    "name": "The Body Snatchers"
+                },
+                "zhhans": {
+                    "name": "The Body Snatchers"
+                },
+                "zhhant": {
                     "name": "The Body Snatchers"
                 }
             }
@@ -2602,7 +6052,37 @@
             "power": 2,
             "text": "Elusive.\nAfter Reap: Lose all your . Destroy an enemy non-Mars creature for each  lost this way.\n",
             "locale": {
+                "de": {
+                    "name": "Urxym der „Diplomat“"
+                },
                 "en": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "es": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "fr": {
+                    "name": "Urxym le « Diplomate »"
+                },
+                "it": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "pl": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "pt": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "th": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "vi": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "zhhans": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "zhhant": {
                     "name": "Urxym the “Diplomat”"
                 }
             }
@@ -2625,7 +6105,37 @@
             "power": null,
             "text": "Action: Put a creature on the bottom of its owner’s deck. If you do, give a creature two +1 power counters.\n",
             "locale": {
+                "de": {
+                    "name": "Zzysz’ Verdichter"
+                },
                 "en": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "es": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "fr": {
+                    "name": "Compacteur de Zzyszzys"
+                },
+                "it": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "pl": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "pt": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "th": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "vi": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "zhhans": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "zhhant": {
                     "name": "Zzyszz’s Compactor"
                 }
             }
@@ -2648,7 +6158,37 @@
             "power": null,
             "text": "Action: Ready and use a friendly creature.\n",
             "locale": {
+                "de": {
+                    "name": "Alle sind Mars"
+                },
                 "en": {
+                    "name": "All Are Mars"
+                },
+                "es": {
+                    "name": "All Are Mars"
+                },
+                "fr": {
+                    "name": "Tous Sont Mars"
+                },
+                "it": {
+                    "name": "All Are Mars"
+                },
+                "pl": {
+                    "name": "All Are Mars"
+                },
+                "pt": {
+                    "name": "All Are Mars"
+                },
+                "th": {
+                    "name": "All Are Mars"
+                },
+                "vi": {
+                    "name": "All Are Mars"
+                },
+                "zhhans": {
+                    "name": "All Are Mars"
+                },
+                "zhhant": {
                     "name": "All Are Mars"
                 }
             }
@@ -2669,7 +6209,37 @@
             "power": null,
             "text": "Play: Destroy an artifact, a creature, and an upgrade.",
             "locale": {
+                "de": {
+                    "name": "Vernichtet sie alle!"
+                },
                 "en": {
+                    "name": "Destroy Them All!"
+                },
+                "es": {
+                    "name": "Destroy Them All!"
+                },
+                "fr": {
+                    "name": "Détruisez-les Tous !"
+                },
+                "it": {
+                    "name": "Destroy Them All!"
+                },
+                "pl": {
+                    "name": "Destroy Them All!"
+                },
+                "pt": {
+                    "name": "Destroy Them All!"
+                },
+                "th": {
+                    "name": "Destroy Them All!"
+                },
+                "vi": {
+                    "name": "Destroy Them All!"
+                },
+                "zhhans": {
+                    "name": "Destroy Them All!"
+                },
+                "zhhant": {
                     "name": "Destroy Them All!"
                 }
             }
@@ -2690,7 +6260,37 @@
             "power": null,
             "text": "Play: Destroy a non-Mars artifact. If you do, you may ready a friendly card. \n",
             "locale": {
+                "de": {
+                    "name": "Mars-Monument"
+                },
                 "en": {
+                    "name": "Edifice for Mars"
+                },
+                "es": {
+                    "name": "Edifice for Mars"
+                },
+                "fr": {
+                    "name": "Édifice à Mars"
+                },
+                "it": {
+                    "name": "Edifice for Mars"
+                },
+                "pl": {
+                    "name": "Edifice for Mars"
+                },
+                "pt": {
+                    "name": "Edifice for Mars"
+                },
+                "th": {
+                    "name": "Edifice for Mars"
+                },
+                "vi": {
+                    "name": "Edifice for Mars"
+                },
+                "zhhans": {
+                    "name": "Edifice for Mars"
+                },
+                "zhhant": {
                     "name": "Edifice for Mars"
                 }
             }
@@ -2714,7 +6314,37 @@
             "power": 3,
             "text": "After Fight: Capture 2. If there are 3 or more on Empowered Zark, you may move 3 from it to the common supply and ready each non-Agent Mars creature.\n",
             "locale": {
+                "de": {
+                    "name": "Ermächtigter Zark"
+                },
                 "en": {
+                    "name": "Empowered Zark"
+                },
+                "es": {
+                    "name": "Empowered Zark"
+                },
+                "fr": {
+                    "name": "Zark l’Augmenté"
+                },
+                "it": {
+                    "name": "Empowered Zark"
+                },
+                "pl": {
+                    "name": "Empowered Zark"
+                },
+                "pt": {
+                    "name": "Empowered Zark"
+                },
+                "th": {
+                    "name": "Empowered Zark"
+                },
+                "vi": {
+                    "name": "Empowered Zark"
+                },
+                "zhhans": {
+                    "name": "Empowered Zark"
+                },
+                "zhhant": {
                     "name": "Empowered Zark"
                 }
             }
@@ -2737,7 +6367,37 @@
             "power": 4,
             "text": "Entrench.\nWhile Golden K1-TT13 is exhausted, each of its neighbors gains, “After Reap: Gain 1.”\n",
             "locale": {
+                "de": {
+                    "name": "Goldenes K4-3TZ3CH3N"
+                },
                 "en": {
+                    "name": "Golden K1-TT13"
+                },
+                "es": {
+                    "name": "Golden K1-TT13"
+                },
+                "fr": {
+                    "name": "CH4-T0N Doré"
+                },
+                "it": {
+                    "name": "Golden K1-TT13"
+                },
+                "pl": {
+                    "name": "Golden K1-TT13"
+                },
+                "pt": {
+                    "name": "Golden K1-TT13"
+                },
+                "th": {
+                    "name": "Golden K1-TT13"
+                },
+                "vi": {
+                    "name": "Golden K1-TT13"
+                },
+                "zhhans": {
+                    "name": "Golden K1-TT13"
+                },
+                "zhhant": {
                     "name": "Golden K1-TT13"
                 }
             }
@@ -2762,7 +6422,37 @@
             "power": 3,
             "text": "Elusive. Enhance .\nAction: Lose 1. If you do, move all  from a creature to your pool.\n",
             "locale": {
+                "de": {
+                    "name": "Iyxrenu der Kluge"
+                },
                 "en": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "es": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "fr": {
+                    "name": "Iyxrenu le Rusé"
+                },
+                "it": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "pl": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "pt": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "th": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "vi": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "zhhans": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "zhhant": {
                     "name": "Iyxrenu the Clever"
                 }
             }
@@ -2783,7 +6473,37 @@
             "power": null,
             "text": "Play: You may discard any number of cards from your hand. Then, forge a key at +9 current cost, reduced by 1 for each card discarded this way.\n",
             "locale": {
+                "de": {
+                    "name": "Schlüsselentzug"
+                },
                 "en": {
+                    "name": "Key Drain"
+                },
+                "es": {
+                    "name": "Key Drain"
+                },
+                "fr": {
+                    "name": "Clé en Sous-Pression"
+                },
+                "it": {
+                    "name": "Key Drain"
+                },
+                "pl": {
+                    "name": "Key Drain"
+                },
+                "pt": {
+                    "name": "Key Drain"
+                },
+                "th": {
+                    "name": "Key Drain"
+                },
+                "vi": {
+                    "name": "Key Drain"
+                },
+                "zhhans": {
+                    "name": "Key Drain"
+                },
+                "zhhant": {
                     "name": "Key Drain"
                 }
             }
@@ -2807,7 +6527,37 @@
             "power": 2,
             "text": "For each neighbor Nyzyk Resonator has, your opponent’s keys cost +2.",
             "locale": {
+                "de": {
+                    "name": "Nyzyk-Resonator"
+                },
                 "en": {
+                    "name": "Nyzyk Resonator"
+                },
+                "es": {
+                    "name": "Nyzyk Resonator"
+                },
+                "fr": {
+                    "name": "Résonateur Nyzyk"
+                },
+                "it": {
+                    "name": "Nyzyk Resonator"
+                },
+                "pl": {
+                    "name": "Nyzyk Resonator"
+                },
+                "pt": {
+                    "name": "Nyzyk Resonator"
+                },
+                "th": {
+                    "name": "Nyzyk Resonator"
+                },
+                "vi": {
+                    "name": "Nyzyk Resonator"
+                },
+                "zhhans": {
+                    "name": "Nyzyk Resonator"
+                },
+                "zhhant": {
                     "name": "Nyzyk Resonator"
                 }
             }
@@ -2828,7 +6578,37 @@
             "power": null,
             "text": "Play: Reveal any number of Mars cards from your hand. For each card revealed this way, deal 2 to a creature. (You may choose a different creature each time.)",
             "locale": {
+                "de": {
+                    "name": "Orbitalbombardement"
+                },
                 "en": {
+                    "name": "Orbital Bombardment"
+                },
+                "es": {
+                    "name": "Orbital Bombardment"
+                },
+                "fr": {
+                    "name": "Bombardement Orbital"
+                },
+                "it": {
+                    "name": "Orbital Bombardment"
+                },
+                "pl": {
+                    "name": "Orbital Bombardment"
+                },
+                "pt": {
+                    "name": "Orbital Bombardment"
+                },
+                "th": {
+                    "name": "Orbital Bombardment"
+                },
+                "vi": {
+                    "name": "Orbital Bombardment"
+                },
+                "zhhans": {
+                    "name": "Orbital Bombardment"
+                },
+                "zhhant": {
                     "name": "Orbital Bombardment"
                 }
             }
@@ -2849,7 +6629,37 @@
             "power": null,
             "text": "Play: Deal 2 to a friendly non-Mars creature. If it is not destroyed, it captures 2.\n",
             "locale": {
+                "de": {
+                    "name": "Haiköder"
+                },
                 "en": {
+                    "name": "Shark Bait"
+                },
+                "es": {
+                    "name": "Shark Bait"
+                },
+                "fr": {
+                    "name": "Appât à Requin"
+                },
+                "it": {
+                    "name": "Shark Bait"
+                },
+                "pl": {
+                    "name": "Shark Bait"
+                },
+                "pt": {
+                    "name": "Shark Bait"
+                },
+                "th": {
+                    "name": "Shark Bait"
+                },
+                "vi": {
+                    "name": "Shark Bait"
+                },
+                "zhhans": {
+                    "name": "Shark Bait"
+                },
+                "zhhant": {
                     "name": "Shark Bait"
                 }
             }
@@ -2872,7 +6682,37 @@
             "power": 12,
             "text": "Enhance .\nThe Red Death cannot ready unless you are haunted.\nAfter Fight: Gain 1 and draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Der Rote Tod"
+                },
                 "en": {
+                    "name": "The Red Death"
+                },
+                "es": {
+                    "name": "The Red Death"
+                },
+                "fr": {
+                    "name": "La Mort Rouge"
+                },
+                "it": {
+                    "name": "The Red Death"
+                },
+                "pl": {
+                    "name": "The Red Death"
+                },
+                "pt": {
+                    "name": "The Red Death"
+                },
+                "th": {
+                    "name": "The Red Death"
+                },
+                "vi": {
+                    "name": "The Red Death"
+                },
+                "zhhans": {
+                    "name": "The Red Death"
+                },
+                "zhhant": {
                     "name": "The Red Death"
                 }
             }
@@ -2898,7 +6738,37 @@
             "power": 3,
             "text": "Elusive.\nAfter Reap: The least powerful enemy creature captures 1 from its own side.\n",
             "locale": {
+                "de": {
+                    "name": "lyylyug"
+                },
                 "en": {
+                    "name": "lyylyug"
+                },
+                "es": {
+                    "name": "lyylyug"
+                },
+                "fr": {
+                    "name": "lyylyug"
+                },
+                "it": {
+                    "name": "lyylyug"
+                },
+                "pl": {
+                    "name": "lyylyug"
+                },
+                "pt": {
+                    "name": "lyylyug"
+                },
+                "th": {
+                    "name": "lyylyug"
+                },
+                "vi": {
+                    "name": "lyylyug"
+                },
+                "zhhans": {
+                    "name": "lyylyug"
+                },
+                "zhhant": {
                     "name": "lyylyug"
                 }
             }
@@ -2922,7 +6792,37 @@
             "power": 4,
             "text": "After Reap: If you are overwhelmed, give a friendly creature three +1 power counters. Otherwise, give each friendly creature a +1 power counter.\n",
             "locale": {
+                "de": {
+                    "name": "Agent Buuff"
+                },
                 "en": {
+                    "name": "Agent Buuff"
+                },
+                "es": {
+                    "name": "Agent Buuff"
+                },
+                "fr": {
+                    "name": "Agent Buuff"
+                },
+                "it": {
+                    "name": "Agent Buuff"
+                },
+                "pl": {
+                    "name": "Agent Buuff"
+                },
+                "pt": {
+                    "name": "Agent Buuff"
+                },
+                "th": {
+                    "name": "Agent Buuff"
+                },
+                "vi": {
+                    "name": "Agent Buuff"
+                },
+                "zhhans": {
+                    "name": "Agent Buuff"
+                },
+                "zhhant": {
                     "name": "Agent Buuff"
                 }
             }
@@ -2945,7 +6845,37 @@
             "power": 3,
             "text": "After Reap: Destroy a friendly non-Mars creature. If you do, take control of an enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Vermittler Vyynx"
+                },
                 "en": {
+                    "name": "Arbiter Vyynx"
+                },
+                "es": {
+                    "name": "Arbiter Vyynx"
+                },
+                "fr": {
+                    "name": "Médiateur Vyynx"
+                },
+                "it": {
+                    "name": "Arbiter Vyynx"
+                },
+                "pl": {
+                    "name": "Arbiter Vyynx"
+                },
+                "pt": {
+                    "name": "Arbiter Vyynx"
+                },
+                "th": {
+                    "name": "Arbiter Vyynx"
+                },
+                "vi": {
+                    "name": "Arbiter Vyynx"
+                },
+                "zhhans": {
+                    "name": "Arbiter Vyynx"
+                },
+                "zhhant": {
                     "name": "Arbiter Vyynx"
                 }
             }
@@ -2968,7 +6898,37 @@
             "power": 2,
             "text": "After Fight: Put the creature Collector Worm fights into your archives. (Both creatures must survive the fight.) If that creature leaves your archives, put it in its owner’s hand instead.\n",
             "locale": {
+                "de": {
+                    "name": "Sammler-Wurm"
+                },
                 "en": {
+                    "name": "Collector Worm"
+                },
+                "es": {
+                    "name": "Collector Worm"
+                },
+                "fr": {
+                    "name": "Ver Collectionneur"
+                },
+                "it": {
+                    "name": "Collector Worm"
+                },
+                "pl": {
+                    "name": "Collector Worm"
+                },
+                "pt": {
+                    "name": "Collector Worm"
+                },
+                "th": {
+                    "name": "Collector Worm"
+                },
+                "vi": {
+                    "name": "Collector Worm"
+                },
+                "zhhans": {
+                    "name": "Collector Worm"
+                },
+                "zhhant": {
                     "name": "Collector Worm"
                 }
             }
@@ -2989,7 +6949,37 @@
             "power": null,
             "text": "Play: Discard the top card of your opponent’s deck. If it is not a Mars card, an enemy creature captures 1 from its own side.\n",
             "locale": {
+                "de": {
+                    "name": "Digitale Manipulation"
+                },
                 "en": {
+                    "name": "Digital Manipulation"
+                },
+                "es": {
+                    "name": "Digital Manipulation"
+                },
+                "fr": {
+                    "name": "Manipulation Numérique"
+                },
+                "it": {
+                    "name": "Digital Manipulation"
+                },
+                "pl": {
+                    "name": "Digital Manipulation"
+                },
+                "pt": {
+                    "name": "Digital Manipulation"
+                },
+                "th": {
+                    "name": "Digital Manipulation"
+                },
+                "vi": {
+                    "name": "Digital Manipulation"
+                },
+                "zhhans": {
+                    "name": "Digital Manipulation"
+                },
+                "zhhant": {
                     "name": "Digital Manipulation"
                 }
             }
@@ -3010,7 +7000,37 @@
             "power": null,
             "text": "Play: Deal 2 to a creature. Reveal a random card from a player’s archives. If you do, deal an additional 3 to the same creature. Discard the revealed card.\n",
             "locale": {
+                "de": {
+                    "name": "Harmonisches Rudel"
+                },
                 "en": {
+                    "name": "Harmonic Pack"
+                },
+                "es": {
+                    "name": "Harmonic Pack"
+                },
+                "fr": {
+                    "name": "Meute Harmonique"
+                },
+                "it": {
+                    "name": "Harmonic Pack"
+                },
+                "pl": {
+                    "name": "Harmonic Pack"
+                },
+                "pt": {
+                    "name": "Harmonic Pack"
+                },
+                "th": {
+                    "name": "Harmonic Pack"
+                },
+                "vi": {
+                    "name": "Harmonic Pack"
+                },
+                "zhhans": {
+                    "name": "Harmonic Pack"
+                },
+                "zhhant": {
                     "name": "Harmonic Pack"
                 }
             }
@@ -3031,7 +7051,37 @@
             "power": null,
             "text": "Play: Put each Mars creature into its owner’s archives. Destroy each creature. Gain 3 chains.\n",
             "locale": {
+                "de": {
+                    "name": "Kabumm!"
+                },
                 "en": {
+                    "name": "Kaboom!"
+                },
+                "es": {
+                    "name": "Kaboom!"
+                },
+                "fr": {
+                    "name": "Bâaoum !"
+                },
+                "it": {
+                    "name": "Kaboom!"
+                },
+                "pl": {
+                    "name": "Kaboom!"
+                },
+                "pt": {
+                    "name": "Kaboom!"
+                },
+                "th": {
+                    "name": "Kaboom!"
+                },
+                "vi": {
+                    "name": "Kaboom!"
+                },
+                "zhhans": {
+                    "name": "Kaboom!"
+                },
+                "zhhant": {
                     "name": "Kaboom!"
                 }
             }
@@ -3055,7 +7105,37 @@
             "power": 3,
             "text": "Enhance .\nAfter Reap: You may remove each +1 power counter from a creature. If one or more counters are removed this way, archive a card.\n",
             "locale": {
+                "de": {
+                    "name": "Klyyhnug"
+                },
                 "en": {
+                    "name": "Klyyhnug"
+                },
+                "es": {
+                    "name": "Klyyhnug"
+                },
+                "fr": {
+                    "name": "Klyyhnug"
+                },
+                "it": {
+                    "name": "Klyyhnug"
+                },
+                "pl": {
+                    "name": "Klyyhnug"
+                },
+                "pt": {
+                    "name": "Klyyhnug"
+                },
+                "th": {
+                    "name": "Klyyhnug"
+                },
+                "vi": {
+                    "name": "Klyyhnug"
+                },
+                "zhhans": {
+                    "name": "Klyyhnug"
+                },
+                "zhhant": {
                     "name": "Klyyhnug"
                 }
             }
@@ -3079,7 +7159,37 @@
             "power": 3,
             "text": "Entrench.\nWhile Operator Olluyyg is exhausted, your opponent’s keys cost +3.\n",
             "locale": {
+                "de": {
+                    "name": "Operator Olluyyg"
+                },
                 "en": {
+                    "name": "Operator Olluyyg"
+                },
+                "es": {
+                    "name": "Operator Olluyyg"
+                },
+                "fr": {
+                    "name": "Opérateur Olluyyg"
+                },
+                "it": {
+                    "name": "Operator Olluyyg"
+                },
+                "pl": {
+                    "name": "Operator Olluyyg"
+                },
+                "pt": {
+                    "name": "Operator Olluyyg"
+                },
+                "th": {
+                    "name": "Operator Olluyyg"
+                },
+                "vi": {
+                    "name": "Operator Olluyyg"
+                },
+                "zhhans": {
+                    "name": "Operator Olluyyg"
+                },
+                "zhhant": {
                     "name": "Operator Olluyyg"
                 }
             }
@@ -3100,7 +7210,37 @@
             "power": null,
             "text": "Play: You may discard a non-Mars card. If you do, a friendly creature captures 1 for each bonus icon on the discarded card.\n",
             "locale": {
+                "de": {
+                    "name": "Produktiver Müll"
+                },
                 "en": {
+                    "name": "Productive Trash"
+                },
+                "es": {
+                    "name": "Productive Trash"
+                },
+                "fr": {
+                    "name": "Déchets Productifs"
+                },
+                "it": {
+                    "name": "Productive Trash"
+                },
+                "pl": {
+                    "name": "Productive Trash"
+                },
+                "pt": {
+                    "name": "Productive Trash"
+                },
+                "th": {
+                    "name": "Productive Trash"
+                },
+                "vi": {
+                    "name": "Productive Trash"
+                },
+                "zhhans": {
+                    "name": "Productive Trash"
+                },
+                "zhhant": {
                     "name": "Productive Trash"
                 }
             }
@@ -3126,7 +7266,37 @@
             "power": 3,
             "text": "Deploy.\nPlay: Put a neighboring non-Soldier creature into its owner’s hand. If you do, the most powerful friendly creature captures 2.\n",
             "locale": {
+                "de": {
+                    "name": "Ersatz-Ziel"
+                },
                 "en": {
+                    "name": "Replacement Targ"
+                },
+                "es": {
+                    "name": "Replacement Targ"
+                },
+                "fr": {
+                    "name": "Agent de Remplacement"
+                },
+                "it": {
+                    "name": "Replacement Targ"
+                },
+                "pl": {
+                    "name": "Replacement Targ"
+                },
+                "pt": {
+                    "name": "Replacement Targ"
+                },
+                "th": {
+                    "name": "Replacement Targ"
+                },
+                "vi": {
+                    "name": "Replacement Targ"
+                },
+                "zhhans": {
+                    "name": "Replacement Targ"
+                },
+                "zhhant": {
                     "name": "Replacement Targ"
                 }
             }
@@ -3147,7 +7317,37 @@
             "power": null,
             "text": "Play: Give a creature two +1 power counters. You may remove any number of +1 power counters from a friendly creature. That creature captures 1 for each counter removed this way.\n",
             "locale": {
+                "de": {
+                    "name": "Transmutation"
+                },
                 "en": {
+                    "name": "Transmutation"
+                },
+                "es": {
+                    "name": "Transmutation"
+                },
+                "fr": {
+                    "name": "Transmutation"
+                },
+                "it": {
+                    "name": "Transmutation"
+                },
+                "pl": {
+                    "name": "Transmutation"
+                },
+                "pt": {
+                    "name": "Transmutation"
+                },
+                "th": {
+                    "name": "Transmutation"
+                },
+                "vi": {
+                    "name": "Transmutation"
+                },
+                "zhhans": {
+                    "name": "Transmutation"
+                },
+                "zhhant": {
                     "name": "Transmutation"
                 }
             }
@@ -3171,7 +7371,37 @@
             "power": 2,
             "text": "After Fight/After Reap: If you are overwhelmed, stun an enemy creature and each of its neighbors. Otherwise, stun a creature. \n",
             "locale": {
+                "de": {
+                    "name": "Ujkyytr der Primus"
+                },
                 "en": {
+                    "name": "Ujkyytr Prime"
+                },
+                "es": {
+                    "name": "Ujkyytr Prime"
+                },
+                "fr": {
+                    "name": "Ujkyytr Premier"
+                },
+                "it": {
+                    "name": "Ujkyytr Prime"
+                },
+                "pl": {
+                    "name": "Ujkyytr Prime"
+                },
+                "pt": {
+                    "name": "Ujkyytr Prime"
+                },
+                "th": {
+                    "name": "Ujkyytr Prime"
+                },
+                "vi": {
+                    "name": "Ujkyytr Prime"
+                },
+                "zhhans": {
+                    "name": "Ujkyytr Prime"
+                },
+                "zhhant": {
                     "name": "Ujkyytr Prime"
                 }
             }
@@ -3195,7 +7425,37 @@
             "power": 7,
             "text": "While Agorim is in the center of your battleline, friendly creatures get +5 power.\n",
             "locale": {
+                "de": {
+                    "name": "Agorim"
+                },
                 "en": {
+                    "name": "Agorim"
+                },
+                "es": {
+                    "name": "Agorim"
+                },
+                "fr": {
+                    "name": "Agorim"
+                },
+                "it": {
+                    "name": "Agorim"
+                },
+                "pl": {
+                    "name": "Agorim"
+                },
+                "pt": {
+                    "name": "Agorim"
+                },
+                "th": {
+                    "name": "Agorim"
+                },
+                "vi": {
+                    "name": "Agorim"
+                },
+                "zhhans": {
+                    "name": "Agorim"
+                },
+                "zhhant": {
                     "name": "Agorim"
                 }
             }
@@ -3216,7 +7476,37 @@
             "power": null,
             "text": "Play: If you are overwhelmed, draw 3 cards.\n",
             "locale": {
+                "de": {
+                    "name": "Ascheflügel-Protokoll"
+                },
                 "en": {
+                    "name": "Ashwing Protocol"
+                },
+                "es": {
+                    "name": "Ashwing Protocol"
+                },
+                "fr": {
+                    "name": "Protocole Cendraile"
+                },
+                "it": {
+                    "name": "Ashwing Protocol"
+                },
+                "pl": {
+                    "name": "Ashwing Protocol"
+                },
+                "pt": {
+                    "name": "Ashwing Protocol"
+                },
+                "th": {
+                    "name": "Ashwing Protocol"
+                },
+                "vi": {
+                    "name": "Ashwing Protocol"
+                },
+                "zhhans": {
+                    "name": "Ashwing Protocol"
+                },
+                "zhhant": {
                     "name": "Ashwing Protocol"
                 }
             }
@@ -3237,7 +7527,37 @@
             "power": null,
             "text": "Play: Deal 3 to each creature. For each creature destroyed this way, exhaust a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Chloroschlummer-Nebel"
+                },
                 "en": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "es": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "fr": {
+                    "name": "Vapeur Sédative"
+                },
+                "it": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "pl": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "pt": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "th": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "vi": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "zhhans": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "zhhant": {
                     "name": "Chlorodoze Vapor"
                 }
             }
@@ -3260,7 +7580,37 @@
             "power": null,
             "text": "Keys cost +2.\nAfter your opponent forges a key, gain 2, draw 4 cards, and destroy Cyn Dynasty.\n",
             "locale": {
+                "de": {
+                    "name": "Cyn-Dynastie"
+                },
                 "en": {
+                    "name": "Cyn Dynasty"
+                },
+                "es": {
+                    "name": "Cyn Dynasty"
+                },
+                "fr": {
+                    "name": "Dynastie des Cyn"
+                },
+                "it": {
+                    "name": "Cyn Dynasty"
+                },
+                "pl": {
+                    "name": "Cyn Dynasty"
+                },
+                "pt": {
+                    "name": "Cyn Dynasty"
+                },
+                "th": {
+                    "name": "Cyn Dynasty"
+                },
+                "vi": {
+                    "name": "Cyn Dynasty"
+                },
+                "zhhans": {
+                    "name": "Cyn Dynasty"
+                },
+                "zhhant": {
                     "name": "Cyn Dynasty"
                 }
             }
@@ -3283,7 +7633,37 @@
             "power": 5,
             "text": "Entrench.\nAt the start of your turn, if Dray Conis is exhausted, destroy each creature.\n",
             "locale": {
+                "de": {
+                    "name": "Dray Conis"
+                },
                 "en": {
+                    "name": "Dray Conis"
+                },
+                "es": {
+                    "name": "Dray Conis"
+                },
+                "fr": {
+                    "name": "Dray Conis"
+                },
+                "it": {
+                    "name": "Dray Conis"
+                },
+                "pl": {
+                    "name": "Dray Conis"
+                },
+                "pt": {
+                    "name": "Dray Conis"
+                },
+                "th": {
+                    "name": "Dray Conis"
+                },
+                "vi": {
+                    "name": "Dray Conis"
+                },
+                "zhhans": {
+                    "name": "Dray Conis"
+                },
+                "zhhant": {
                     "name": "Dray Conis"
                 }
             }
@@ -3304,7 +7684,37 @@
             "power": null,
             "text": "Play: For each forged key your opponent has, an enemy creature captures 2 from its own side.\n",
             "locale": {
+                "de": {
+                    "name": "Goldene Bürde"
+                },
                 "en": {
+                    "name": "Gilded Burden"
+                },
+                "es": {
+                    "name": "Gilded Burden"
+                },
+                "fr": {
+                    "name": "Fardeau Doré"
+                },
+                "it": {
+                    "name": "Gilded Burden"
+                },
+                "pl": {
+                    "name": "Gilded Burden"
+                },
+                "pt": {
+                    "name": "Gilded Burden"
+                },
+                "th": {
+                    "name": "Gilded Burden"
+                },
+                "vi": {
+                    "name": "Gilded Burden"
+                },
+                "zhhans": {
+                    "name": "Gilded Burden"
+                },
+                "zhhant": {
                     "name": "Gilded Burden"
                 }
             }
@@ -3325,7 +7735,37 @@
             "power": null,
             "text": "This creature gains, “After Fight/After Reap: If you are overwhelmed, gain 1 and deal 3 to an enemy creature.”\n",
             "locale": {
+                "de": {
+                    "name": "Schatzschürfer"
+                },
                 "en": {
+                    "name": "Hoardgouge"
+                },
+                "es": {
+                    "name": "Hoardgouge"
+                },
+                "fr": {
+                    "name": "Creuse-Butin"
+                },
+                "it": {
+                    "name": "Hoardgouge"
+                },
+                "pl": {
+                    "name": "Hoardgouge"
+                },
+                "pt": {
+                    "name": "Hoardgouge"
+                },
+                "th": {
+                    "name": "Hoardgouge"
+                },
+                "vi": {
+                    "name": "Hoardgouge"
+                },
+                "zhhans": {
+                    "name": "Hoardgouge"
+                },
+                "zhhant": {
                     "name": "Hoardgouge"
                 }
             }
@@ -3346,7 +7786,37 @@
             "power": null,
             "text": "",
             "locale": {
+                "de": {
+                    "name": "Kulsha"
+                },
                 "en": {
+                    "name": "Kulsha"
+                },
+                "es": {
+                    "name": "Kulsha"
+                },
+                "fr": {
+                    "name": "Kulsha"
+                },
+                "it": {
+                    "name": "Kulsha"
+                },
+                "pl": {
+                    "name": "Kulsha"
+                },
+                "pt": {
+                    "name": "Kulsha"
+                },
+                "th": {
+                    "name": "Kulsha"
+                },
+                "vi": {
+                    "name": "Kulsha"
+                },
+                "zhhans": {
+                    "name": "Kulsha"
+                },
+                "zhhant": {
                     "name": "Kulsha"
                 }
             }
@@ -3369,7 +7839,37 @@
             "power": 15,
             "text": "(Play only with the other half of Kulsha.)\nYour opponent’s keys cost +2 for each forged key they have. \nAfter Fight/After Reap: Exhaust up to 3 creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Kulsha"
+                },
                 "en": {
+                    "name": "Kulsha"
+                },
+                "es": {
+                    "name": "Kulsha"
+                },
+                "fr": {
+                    "name": "Kulsha"
+                },
+                "it": {
+                    "name": "Kulsha"
+                },
+                "pl": {
+                    "name": "Kulsha"
+                },
+                "pt": {
+                    "name": "Kulsha"
+                },
+                "th": {
+                    "name": "Kulsha"
+                },
+                "vi": {
+                    "name": "Kulsha"
+                },
+                "zhhans": {
+                    "name": "Kulsha"
+                },
+                "zhhant": {
                     "name": "Kulsha"
                 }
             }
@@ -3393,7 +7893,37 @@
             "power": 6,
             "text": "While fighting, Nizak, The Forgotten gains invulnerable. (It cannot be destroyed or dealt damage.)\nAfter an enemy creature is destroyed fighting Nizak, The Forgotten, return that creature to its owner’s hand.\n",
             "locale": {
+                "de": {
+                    "name": "Nizak der Vergessene"
+                },
                 "en": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "es": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "fr": {
+                    "name": "Nizak, l’Oublié"
+                },
+                "it": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "pl": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "pt": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "th": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "vi": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "zhhans": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "zhhant": {
                     "name": "Nizak, The Forgotten"
                 }
             }
@@ -3414,7 +7944,37 @@
             "power": null,
             "text": "Play: Ready or exhaust a creature. If there are more exhausted friendly creatures than exhausted enemy creatures, gain 2.\n",
             "locale": {
+                "de": {
+                    "name": "Höchste Autorität"
+                },
                 "en": {
+                    "name": "Prime Authority"
+                },
+                "es": {
+                    "name": "Prime Authority"
+                },
+                "fr": {
+                    "name": "Autorité Primaire"
+                },
+                "it": {
+                    "name": "Prime Authority"
+                },
+                "pl": {
+                    "name": "Prime Authority"
+                },
+                "pt": {
+                    "name": "Prime Authority"
+                },
+                "th": {
+                    "name": "Prime Authority"
+                },
+                "vi": {
+                    "name": "Prime Authority"
+                },
+                "zhhans": {
+                    "name": "Prime Authority"
+                },
+                "zhhant": {
                     "name": "Prime Authority"
                 }
             }
@@ -3437,7 +7997,37 @@
             "power": 6,
             "text": "While Seda the Sleeper is exhausted and on a flank, it gains invulnerable. \nAfter you ready Seda the Sleeper, you may deal 2 to it. If you do, exhaust it.\nPlay: Capture 6.\n",
             "locale": {
+                "de": {
+                    "name": "Seda der Schläfer"
+                },
                 "en": {
+                    "name": "Seda the Sleeper"
+                },
+                "es": {
+                    "name": "Seda the Sleeper"
+                },
+                "fr": {
+                    "name": "Satya l’Endormi"
+                },
+                "it": {
+                    "name": "Seda the Sleeper"
+                },
+                "pl": {
+                    "name": "Seda the Sleeper"
+                },
+                "pt": {
+                    "name": "Seda the Sleeper"
+                },
+                "th": {
+                    "name": "Seda the Sleeper"
+                },
+                "vi": {
+                    "name": "Seda the Sleeper"
+                },
+                "zhhans": {
+                    "name": "Seda the Sleeper"
+                },
+                "zhhant": {
                     "name": "Seda the Sleeper"
                 }
             }
@@ -3458,7 +8048,37 @@
             "power": null,
             "text": "Enhance .\nPlay: Destroy an Ouboros creature. If you do, gain 2.\n",
             "locale": {
+                "de": {
+                    "name": "Schlafschwund"
+                },
                 "en": {
+                    "name": "Sleepwither"
+                },
+                "es": {
+                    "name": "Sleepwither"
+                },
+                "fr": {
+                    "name": "Sommeil Flétrissant"
+                },
+                "it": {
+                    "name": "Sleepwither"
+                },
+                "pl": {
+                    "name": "Sleepwither"
+                },
+                "pt": {
+                    "name": "Sleepwither"
+                },
+                "th": {
+                    "name": "Sleepwither"
+                },
+                "vi": {
+                    "name": "Sleepwither"
+                },
+                "zhhans": {
+                    "name": "Sleepwither"
+                },
+                "zhhant": {
                     "name": "Sleepwither"
                 }
             }
@@ -3481,7 +8101,37 @@
             "power": null,
             "text": "Action: Destroy Spherular Gem. If you do, gain  equal to the number of forged keys.\n",
             "locale": {
+                "de": {
+                    "name": "Kugelartige Gemme"
+                },
                 "en": {
+                    "name": "Spherular Gem"
+                },
+                "es": {
+                    "name": "Spherular Gem"
+                },
+                "fr": {
+                    "name": "Gemme Sphérulaire"
+                },
+                "it": {
+                    "name": "Spherular Gem"
+                },
+                "pl": {
+                    "name": "Spherular Gem"
+                },
+                "pt": {
+                    "name": "Spherular Gem"
+                },
+                "th": {
+                    "name": "Spherular Gem"
+                },
+                "vi": {
+                    "name": "Spherular Gem"
+                },
+                "zhhans": {
+                    "name": "Spherular Gem"
+                },
+                "zhhant": {
                     "name": "Spherular Gem"
                 }
             }
@@ -3504,7 +8154,37 @@
             "power": 6,
             "text": "Tranquil Reiner does not ready during your “ready cards” step.\nAfter Fight/After Reap: Ready an exhausted non-Dragon creature. If you do, gain 3.\n",
             "locale": {
+                "de": {
+                    "name": "Reiner der Friedvolle"
+                },
                 "en": {
+                    "name": "Tranquil Reiner"
+                },
+                "es": {
+                    "name": "Tranquil Reiner"
+                },
+                "fr": {
+                    "name": "Tranquille Émile"
+                },
+                "it": {
+                    "name": "Tranquil Reiner"
+                },
+                "pl": {
+                    "name": "Tranquil Reiner"
+                },
+                "pt": {
+                    "name": "Tranquil Reiner"
+                },
+                "th": {
+                    "name": "Tranquil Reiner"
+                },
+                "vi": {
+                    "name": "Tranquil Reiner"
+                },
+                "zhhans": {
+                    "name": "Tranquil Reiner"
+                },
+                "zhhant": {
                     "name": "Tranquil Reiner"
                 }
             }
@@ -3528,7 +8208,37 @@
             "power": 6,
             "text": "After Reap: Choose a creature. Until the start of your next turn, that creature gains invulnerable. (It cannot be destroyed or dealt damage.)\n",
             "locale": {
+                "de": {
+                    "name": "Treok der Weise"
+                },
                 "en": {
+                    "name": "Treok, The Wise"
+                },
+                "es": {
+                    "name": "Treok, The Wise"
+                },
+                "fr": {
+                    "name": "Treok, le Judicieux"
+                },
+                "it": {
+                    "name": "Treok, The Wise"
+                },
+                "pl": {
+                    "name": "Treok, The Wise"
+                },
+                "pt": {
+                    "name": "Treok, The Wise"
+                },
+                "th": {
+                    "name": "Treok, The Wise"
+                },
+                "vi": {
+                    "name": "Treok, The Wise"
+                },
+                "zhhans": {
+                    "name": "Treok, The Wise"
+                },
+                "zhhant": {
                     "name": "Treok, The Wise"
                 }
             }
@@ -3551,7 +8261,37 @@
             "power": 4,
             "text": "Your keys cost –1 for each forged key your opponent has.\n",
             "locale": {
+                "de": {
+                    "name": "Bollwerkklaue"
+                },
                 "en": {
+                    "name": "Bastionclaw"
+                },
+                "es": {
+                    "name": "Bastionclaw"
+                },
+                "fr": {
+                    "name": "Bastus le Griffu"
+                },
+                "it": {
+                    "name": "Bastionclaw"
+                },
+                "pl": {
+                    "name": "Bastionclaw"
+                },
+                "pt": {
+                    "name": "Bastionclaw"
+                },
+                "th": {
+                    "name": "Bastionclaw"
+                },
+                "vi": {
+                    "name": "Bastionclaw"
+                },
+                "zhhans": {
+                    "name": "Bastionclaw"
+                },
+                "zhhant": {
                     "name": "Bastionclaw"
                 }
             }
@@ -3574,7 +8314,37 @@
             "power": 3,
             "text": "Entrench.\nAt the end of your turn, if Caspart is exhausted, exhaust 2 other creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Caspart"
+                },
                 "en": {
+                    "name": "Caspart"
+                },
+                "es": {
+                    "name": "Caspart"
+                },
+                "fr": {
+                    "name": "Caspard"
+                },
+                "it": {
+                    "name": "Caspart"
+                },
+                "pl": {
+                    "name": "Caspart"
+                },
+                "pt": {
+                    "name": "Caspart"
+                },
+                "th": {
+                    "name": "Caspart"
+                },
+                "vi": {
+                    "name": "Caspart"
+                },
+                "zhhans": {
+                    "name": "Caspart"
+                },
+                "zhhant": {
                     "name": "Caspart"
                 }
             }
@@ -3595,7 +8365,37 @@
             "power": null,
             "text": "Play: Shuffle any number of Dragon creatures from your discard pile into your deck.\n",
             "locale": {
+                "de": {
+                    "name": "DRACHEN!!!"
+                },
                 "en": {
+                    "name": "DRAGONS!!!"
+                },
+                "es": {
+                    "name": "DRAGONS!!!"
+                },
+                "fr": {
+                    "name": "DRAGONS !!!"
+                },
+                "it": {
+                    "name": "DRAGONS!!!"
+                },
+                "pl": {
+                    "name": "DRAGONS!!!"
+                },
+                "pt": {
+                    "name": "DRAGONS!!!"
+                },
+                "th": {
+                    "name": "DRAGONS!!!"
+                },
+                "vi": {
+                    "name": "DRAGONS!!!"
+                },
+                "zhhans": {
+                    "name": "DRAGONS!!!"
+                },
+                "zhhant": {
                     "name": "DRAGONS!!!"
                 }
             }
@@ -3616,7 +8416,37 @@
             "power": null,
             "text": "Play: Exhaust each non-Dragon creature.\n",
             "locale": {
+                "de": {
+                    "name": "Schnarchschwinge"
+                },
                 "en": {
+                    "name": "Doze Wing"
+                },
+                "es": {
+                    "name": "Doze Wing"
+                },
+                "fr": {
+                    "name": "Sous Son Aile"
+                },
+                "it": {
+                    "name": "Doze Wing"
+                },
+                "pl": {
+                    "name": "Doze Wing"
+                },
+                "pt": {
+                    "name": "Doze Wing"
+                },
+                "th": {
+                    "name": "Doze Wing"
+                },
+                "vi": {
+                    "name": "Doze Wing"
+                },
+                "zhhans": {
+                    "name": "Doze Wing"
+                },
+                "zhhant": {
                     "name": "Doze Wing"
                 }
             }
@@ -3637,7 +8467,37 @@
             "power": null,
             "text": "Play: For each color represented among forged keys, steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Glitzernde Horde"
+                },
                 "en": {
+                    "name": "Glittering Horde"
+                },
+                "es": {
+                    "name": "Glittering Horde"
+                },
+                "fr": {
+                    "name": "Horde Scintillante"
+                },
+                "it": {
+                    "name": "Glittering Horde"
+                },
+                "pl": {
+                    "name": "Glittering Horde"
+                },
+                "pt": {
+                    "name": "Glittering Horde"
+                },
+                "th": {
+                    "name": "Glittering Horde"
+                },
+                "vi": {
+                    "name": "Glittering Horde"
+                },
+                "zhhans": {
+                    "name": "Glittering Horde"
+                },
+                "zhhant": {
                     "name": "Glittering Horde"
                 }
             }
@@ -3660,7 +8520,37 @@
             "power": 4,
             "text": "Ignitus gains splash-attack X, where X is the number of exhausted creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Ignitus"
+                },
                 "en": {
+                    "name": "Ignitus"
+                },
+                "es": {
+                    "name": "Ignitus"
+                },
+                "fr": {
+                    "name": "Allumax"
+                },
+                "it": {
+                    "name": "Ignitus"
+                },
+                "pl": {
+                    "name": "Ignitus"
+                },
+                "pt": {
+                    "name": "Ignitus"
+                },
+                "th": {
+                    "name": "Ignitus"
+                },
+                "vi": {
+                    "name": "Ignitus"
+                },
+                "zhhans": {
+                    "name": "Ignitus"
+                },
+                "zhhant": {
                     "name": "Ignitus"
                 }
             }
@@ -3683,7 +8573,37 @@
             "power": 4,
             "text": "Entrench.\nAt the start of your turn, if Noxious Ionox is exhausted, destroy an enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Toxischer Ionos"
+                },
                 "en": {
+                    "name": "Noxious Ionox"
+                },
+                "es": {
+                    "name": "Noxious Ionox"
+                },
+                "fr": {
+                    "name": "Smaragdin le Nocif"
+                },
+                "it": {
+                    "name": "Noxious Ionox"
+                },
+                "pl": {
+                    "name": "Noxious Ionox"
+                },
+                "pt": {
+                    "name": "Noxious Ionox"
+                },
+                "th": {
+                    "name": "Noxious Ionox"
+                },
+                "vi": {
+                    "name": "Noxious Ionox"
+                },
+                "zhhans": {
+                    "name": "Noxious Ionox"
+                },
+                "zhhant": {
                     "name": "Noxious Ionox"
                 }
             }
@@ -3704,7 +8624,37 @@
             "power": null,
             "text": "Play: Forge a key at +8 current cost, reduced by 1 for each  in your opponent’s pool. If you do, purge Parasitic Charge.\n",
             "locale": {
+                "de": {
+                    "name": "Parasitäre Aufladung"
+                },
                 "en": {
+                    "name": "Parasitic Charge"
+                },
+                "es": {
+                    "name": "Parasitic Charge"
+                },
+                "fr": {
+                    "name": "Charge Parasite"
+                },
+                "it": {
+                    "name": "Parasitic Charge"
+                },
+                "pl": {
+                    "name": "Parasitic Charge"
+                },
+                "pt": {
+                    "name": "Parasitic Charge"
+                },
+                "th": {
+                    "name": "Parasitic Charge"
+                },
+                "vi": {
+                    "name": "Parasitic Charge"
+                },
+                "zhhans": {
+                    "name": "Parasitic Charge"
+                },
+                "zhhant": {
                     "name": "Parasitic Charge"
                 }
             }
@@ -3725,7 +8675,37 @@
             "power": null,
             "text": "Play: Until the start of your next turn, creatures cannot ready.\n",
             "locale": {
+                "de": {
+                    "name": "Thermische Erschöpfung"
+                },
                 "en": {
+                    "name": "Thermal Depletion"
+                },
+                "es": {
+                    "name": "Thermal Depletion"
+                },
+                "fr": {
+                    "name": "Réduire en Cendres"
+                },
+                "it": {
+                    "name": "Thermal Depletion"
+                },
+                "pl": {
+                    "name": "Thermal Depletion"
+                },
+                "pt": {
+                    "name": "Thermal Depletion"
+                },
+                "th": {
+                    "name": "Thermal Depletion"
+                },
+                "vi": {
+                    "name": "Thermal Depletion"
+                },
+                "zhhans": {
+                    "name": "Thermal Depletion"
+                },
+                "zhhant": {
                     "name": "Thermal Depletion"
                 }
             }
@@ -3746,7 +8726,37 @@
             "power": null,
             "text": "Play: Shuffle each friendly card in play into your deck. Draw a card for each card shuffled into your deck this way.\n",
             "locale": {
+                "de": {
+                    "name": "Zeitbeben"
+                },
                 "en": {
+                    "name": "Timequake"
+                },
+                "es": {
+                    "name": "Timequake"
+                },
+                "fr": {
+                    "name": "Tremblement de Temps"
+                },
+                "it": {
+                    "name": "Timequake"
+                },
+                "pl": {
+                    "name": "Timequake"
+                },
+                "pt": {
+                    "name": "Timequake"
+                },
+                "th": {
+                    "name": "Timequake"
+                },
+                "vi": {
+                    "name": "Timequake"
+                },
+                "zhhans": {
+                    "name": "Timequake"
+                },
+                "zhhant": {
                     "name": "Timequake"
                 }
             }
@@ -3769,7 +8779,37 @@
             "power": 5,
             "text": "After Reap: Use an enemy artifact as if it were yours. Put that artifact on the bottom of its owner’s deck.\n",
             "locale": {
+                "de": {
+                    "name": "Voltash Blitzatem"
+                },
                 "en": {
+                    "name": "Voltash Coilbreath"
+                },
+                "es": {
+                    "name": "Voltash Coilbreath"
+                },
+                "fr": {
+                    "name": "Voltach le Fulgurant"
+                },
+                "it": {
+                    "name": "Voltash Coilbreath"
+                },
+                "pl": {
+                    "name": "Voltash Coilbreath"
+                },
+                "pt": {
+                    "name": "Voltash Coilbreath"
+                },
+                "th": {
+                    "name": "Voltash Coilbreath"
+                },
+                "vi": {
+                    "name": "Voltash Coilbreath"
+                },
+                "zhhans": {
+                    "name": "Voltash Coilbreath"
+                },
+                "zhhant": {
                     "name": "Voltash Coilbreath"
                 }
             }
@@ -3792,7 +8832,37 @@
             "power": 5,
             "text": "After Reap: Ready and use a friendly non-Dragon creature.\n",
             "locale": {
+                "de": {
+                    "name": "Zartoo der Flinke"
+                },
                 "en": {
+                    "name": "Zartoo, the Swift"
+                },
+                "es": {
+                    "name": "Zartoo, the Swift"
+                },
+                "fr": {
+                    "name": "Zartou, le Doux"
+                },
+                "it": {
+                    "name": "Zartoo, the Swift"
+                },
+                "pl": {
+                    "name": "Zartoo, the Swift"
+                },
+                "pt": {
+                    "name": "Zartoo, the Swift"
+                },
+                "th": {
+                    "name": "Zartoo, the Swift"
+                },
+                "vi": {
+                    "name": "Zartoo, the Swift"
+                },
+                "zhhans": {
+                    "name": "Zartoo, the Swift"
+                },
+                "zhhant": {
                     "name": "Zartoo, the Swift"
                 }
             }
@@ -3813,7 +8883,37 @@
             "power": null,
             "text": "Play: Choose a friendly exhausted creature. Ready and use that creature.\n",
             "locale": {
+                "de": {
+                    "name": "Arkane Erleichterung"
+                },
                 "en": {
+                    "name": "Arcane Relief"
+                },
+                "es": {
+                    "name": "Arcane Relief"
+                },
+                "fr": {
+                    "name": "Relève Arcanique"
+                },
+                "it": {
+                    "name": "Arcane Relief"
+                },
+                "pl": {
+                    "name": "Arcane Relief"
+                },
+                "pt": {
+                    "name": "Arcane Relief"
+                },
+                "th": {
+                    "name": "Arcane Relief"
+                },
+                "vi": {
+                    "name": "Arcane Relief"
+                },
+                "zhhans": {
+                    "name": "Arcane Relief"
+                },
+                "zhhant": {
                     "name": "Arcane Relief"
                 }
             }
@@ -3834,7 +8934,37 @@
             "power": null,
             "text": "Play: If you are overwhelmed, choose a friendly creature. For each creature your opponent controls in excess of you, the chosen creature captures 1.\n",
             "locale": {
+                "de": {
+                    "name": "Klauenmantelschlag"
+                },
                 "en": {
+                    "name": "Clawcloak Swipe"
+                },
+                "es": {
+                    "name": "Clawcloak Swipe"
+                },
+                "fr": {
+                    "name": "Revers de Fortune"
+                },
+                "it": {
+                    "name": "Clawcloak Swipe"
+                },
+                "pl": {
+                    "name": "Clawcloak Swipe"
+                },
+                "pt": {
+                    "name": "Clawcloak Swipe"
+                },
+                "th": {
+                    "name": "Clawcloak Swipe"
+                },
+                "vi": {
+                    "name": "Clawcloak Swipe"
+                },
+                "zhhans": {
+                    "name": "Clawcloak Swipe"
+                },
+                "zhhant": {
                     "name": "Clawcloak Swipe"
                 }
             }
@@ -3857,7 +8987,37 @@
             "power": 6,
             "text": "After a player readies a creature, deal 1 to it.\n",
             "locale": {
+                "de": {
+                    "name": "Kosmokrax"
+                },
                 "en": {
+                    "name": "Cosmicrux"
+                },
+                "es": {
+                    "name": "Cosmicrux"
+                },
+                "fr": {
+                    "name": "Cosmicrux"
+                },
+                "it": {
+                    "name": "Cosmicrux"
+                },
+                "pl": {
+                    "name": "Cosmicrux"
+                },
+                "pt": {
+                    "name": "Cosmicrux"
+                },
+                "th": {
+                    "name": "Cosmicrux"
+                },
+                "vi": {
+                    "name": "Cosmicrux"
+                },
+                "zhhans": {
+                    "name": "Cosmicrux"
+                },
+                "zhhant": {
                     "name": "Cosmicrux"
                 }
             }
@@ -3880,7 +9040,37 @@
             "power": 4,
             "text": "After Fight: Gain 1 for each ready friendly creature of the active house.\n",
             "locale": {
+                "de": {
+                    "name": "Deltas der Kühne"
+                },
                 "en": {
+                    "name": "Daring Delt"
+                },
+                "es": {
+                    "name": "Daring Delt"
+                },
+                "fr": {
+                    "name": "Delth l’Audacieuse"
+                },
+                "it": {
+                    "name": "Daring Delt"
+                },
+                "pl": {
+                    "name": "Daring Delt"
+                },
+                "pt": {
+                    "name": "Daring Delt"
+                },
+                "th": {
+                    "name": "Daring Delt"
+                },
+                "vi": {
+                    "name": "Daring Delt"
+                },
+                "zhhans": {
+                    "name": "Daring Delt"
+                },
+                "zhhant": {
                     "name": "Daring Delt"
                 }
             }
@@ -3901,7 +9091,37 @@
             "power": null,
             "text": "Play: Each friendly exhausted creature captures 1.\n",
             "locale": {
+                "de": {
+                    "name": "Beute horten"
+                },
                 "en": {
+                    "name": "Hoarding the Goods"
+                },
+                "es": {
+                    "name": "Hoarding the Goods"
+                },
+                "fr": {
+                    "name": "Accaparer les Biens"
+                },
+                "it": {
+                    "name": "Hoarding the Goods"
+                },
+                "pl": {
+                    "name": "Hoarding the Goods"
+                },
+                "pt": {
+                    "name": "Hoarding the Goods"
+                },
+                "th": {
+                    "name": "Hoarding the Goods"
+                },
+                "vi": {
+                    "name": "Hoarding the Goods"
+                },
+                "zhhans": {
+                    "name": "Hoarding the Goods"
+                },
+                "zhhant": {
                     "name": "Hoarding the Goods"
                 }
             }
@@ -3922,7 +9142,37 @@
             "power": null,
             "text": "Play: If you are overwhelmed, exhaust each creature. Otherwise, exhaust a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Leylinien"
+                },
                 "en": {
+                    "name": "Ley Lines"
+                },
+                "es": {
+                    "name": "Ley Lines"
+                },
+                "fr": {
+                    "name": "Lignes Telluriques"
+                },
+                "it": {
+                    "name": "Ley Lines"
+                },
+                "pl": {
+                    "name": "Ley Lines"
+                },
+                "pt": {
+                    "name": "Ley Lines"
+                },
+                "th": {
+                    "name": "Ley Lines"
+                },
+                "vi": {
+                    "name": "Ley Lines"
+                },
+                "zhhans": {
+                    "name": "Ley Lines"
+                },
+                "zhhant": {
                     "name": "Ley Lines"
                 }
             }
@@ -3945,7 +9195,37 @@
             "power": 2,
             "text": "Play: If your opponent has more forged keys than you, steal 2. Otherwise, capture 2.\n",
             "locale": {
+                "de": {
+                    "name": "Pip der Langfinger"
+                },
                 "en": {
+                    "name": "Pip the Pilferer"
+                },
+                "es": {
+                    "name": "Pip the Pilferer"
+                },
+                "fr": {
+                    "name": "Pip le Chapardeur"
+                },
+                "it": {
+                    "name": "Pip the Pilferer"
+                },
+                "pl": {
+                    "name": "Pip the Pilferer"
+                },
+                "pt": {
+                    "name": "Pip the Pilferer"
+                },
+                "th": {
+                    "name": "Pip the Pilferer"
+                },
+                "vi": {
+                    "name": "Pip the Pilferer"
+                },
+                "zhhans": {
+                    "name": "Pip the Pilferer"
+                },
+                "zhhant": {
                     "name": "Pip the Pilferer"
                 }
             }
@@ -3968,7 +9248,37 @@
             "power": 2,
             "text": "Enhance .\nAfter Fight/After Reap: If you are overwhelmed, capture 1 for each +1 power counter on friendly creatures. Otherwise, capture 1.\n",
             "locale": {
+                "de": {
+                    "name": "Ria Schwarmgier"
+                },
                 "en": {
+                    "name": "Ria Bevy Gress"
+                },
+                "es": {
+                    "name": "Ria Bevy Gress"
+                },
+                "fr": {
+                    "name": "Ria Bevy Gress"
+                },
+                "it": {
+                    "name": "Ria Bevy Gress"
+                },
+                "pl": {
+                    "name": "Ria Bevy Gress"
+                },
+                "pt": {
+                    "name": "Ria Bevy Gress"
+                },
+                "th": {
+                    "name": "Ria Bevy Gress"
+                },
+                "vi": {
+                    "name": "Ria Bevy Gress"
+                },
+                "zhhans": {
+                    "name": "Ria Bevy Gress"
+                },
+                "zhhant": {
                     "name": "Ria Bevy Gress"
                 }
             }
@@ -3994,7 +9304,37 @@
             "power": 4,
             "text": "Treachery. Versatile.\nAfter a friendly creature is used, deal 1 to each friendly creature.\n",
             "locale": {
+                "de": {
+                    "name": "Schattenfinstergroll"
+                },
                 "en": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "es": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "fr": {
+                    "name": "Aigrefin des Ombres"
+                },
+                "it": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "pl": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "pt": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "th": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "vi": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "zhhans": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "zhhant": {
                     "name": "Shadow Gloomcoil"
                 }
             }
@@ -4017,7 +9357,37 @@
             "power": 3,
             "text": "Entrench.\nAt the end of your turn, if Snapper Dyn is exhausted, deal 1 to an enemy creature for each  in your opponent’s pool.\n",
             "locale": {
+                "de": {
+                    "name": "Schnapper Dyn"
+                },
                 "en": {
+                    "name": "Snapper Dyn"
+                },
+                "es": {
+                    "name": "Snapper Dyn"
+                },
+                "fr": {
+                    "name": "Dyn le Happeur"
+                },
+                "it": {
+                    "name": "Snapper Dyn"
+                },
+                "pl": {
+                    "name": "Snapper Dyn"
+                },
+                "pt": {
+                    "name": "Snapper Dyn"
+                },
+                "th": {
+                    "name": "Snapper Dyn"
+                },
+                "vi": {
+                    "name": "Snapper Dyn"
+                },
+                "zhhans": {
+                    "name": "Snapper Dyn"
+                },
+                "zhhant": {
                     "name": "Snapper Dyn"
                 }
             }
@@ -4041,7 +9411,37 @@
             "power": 3,
             "text": "Entrench.\nAfter an enemy creature reaps, if Sparkscheme is exhausted, draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Funkenplan"
+                },
                 "en": {
+                    "name": "Sparkscheme"
+                },
+                "es": {
+                    "name": "Sparkscheme"
+                },
+                "fr": {
+                    "name": "Châtaigne"
+                },
+                "it": {
+                    "name": "Sparkscheme"
+                },
+                "pl": {
+                    "name": "Sparkscheme"
+                },
+                "pt": {
+                    "name": "Sparkscheme"
+                },
+                "th": {
+                    "name": "Sparkscheme"
+                },
+                "vi": {
+                    "name": "Sparkscheme"
+                },
+                "zhhans": {
+                    "name": "Sparkscheme"
+                },
+                "zhhant": {
                     "name": "Sparkscheme"
                 }
             }
@@ -4062,7 +9462,37 @@
             "power": null,
             "text": "Play: Deal 3 to a creature. If this damage destroys that creature, draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Wunden der Vorhut"
+                },
                 "en": {
+                    "name": "Vanguard Wounds"
+                },
+                "es": {
+                    "name": "Vanguard Wounds"
+                },
+                "fr": {
+                    "name": "Blessures Préventives"
+                },
+                "it": {
+                    "name": "Vanguard Wounds"
+                },
+                "pl": {
+                    "name": "Vanguard Wounds"
+                },
+                "pt": {
+                    "name": "Vanguard Wounds"
+                },
+                "th": {
+                    "name": "Vanguard Wounds"
+                },
+                "vi": {
+                    "name": "Vanguard Wounds"
+                },
+                "zhhans": {
+                    "name": "Vanguard Wounds"
+                },
+                "zhhant": {
                     "name": "Vanguard Wounds"
                 }
             }
@@ -4085,7 +9515,37 @@
             "power": 7,
             "text": "(Play only with the other half of Boosted B4-RRY.)\nPlay/After Fight/After Reap: Choose one:\nTake control of an enemy artifact. While under your control, it belongs to house Shadows (instead of its original house).\nPlay a random card from your opponent’s archives as if it were yours.\n",
             "locale": {
+                "de": {
+                    "name": "Verstärkter B4-RRY"
+                },
                 "en": {
+                    "name": "Boosted B4-RRY"
+                },
+                "es": {
+                    "name": "Boosted B4-RRY"
+                },
+                "fr": {
+                    "name": "T0-N10 les Bons Pistons"
+                },
+                "it": {
+                    "name": "Boosted B4-RRY"
+                },
+                "pl": {
+                    "name": "Boosted B4-RRY"
+                },
+                "pt": {
+                    "name": "Boosted B4-RRY"
+                },
+                "th": {
+                    "name": "Boosted B4-RRY"
+                },
+                "vi": {
+                    "name": "Boosted B4-RRY"
+                },
+                "zhhans": {
+                    "name": "Boosted B4-RRY"
+                },
+                "zhhant": {
                     "name": "Boosted B4-RRY"
                 }
             }
@@ -4106,7 +9566,37 @@
             "power": null,
             "text": "",
             "locale": {
+                "de": {
+                    "name": "Verstärkter B4-RRY"
+                },
                 "en": {
+                    "name": "Boosted B4-RRY"
+                },
+                "es": {
+                    "name": "Boosted B4-RRY"
+                },
+                "fr": {
+                    "name": "T0-N10 les Bons Pistons"
+                },
+                "it": {
+                    "name": "Boosted B4-RRY"
+                },
+                "pl": {
+                    "name": "Boosted B4-RRY"
+                },
+                "pt": {
+                    "name": "Boosted B4-RRY"
+                },
+                "th": {
+                    "name": "Boosted B4-RRY"
+                },
+                "vi": {
+                    "name": "Boosted B4-RRY"
+                },
+                "zhhans": {
+                    "name": "Boosted B4-RRY"
+                },
+                "zhhant": {
                     "name": "Boosted B4-RRY"
                 }
             }
@@ -4132,7 +9622,37 @@
             "power": 2,
             "text": "Elusive. (The first time this creature is attacked each turn, no damage is dealt.)\nAfter Reap: Destroy a flank creature.",
             "locale": {
+                "de": {
+                    "name": "Scharfauge"
+                },
                 "en": {
+                    "name": "Bulleteye"
+                },
+                "es": {
+                    "name": "Bulleteye"
+                },
+                "fr": {
+                    "name": "Ciblette"
+                },
+                "it": {
+                    "name": "Bulleteye"
+                },
+                "pl": {
+                    "name": "Bulleteye"
+                },
+                "pt": {
+                    "name": "Bulleteye"
+                },
+                "th": {
+                    "name": "Bulleteye"
+                },
+                "vi": {
+                    "name": "Bulleteye"
+                },
+                "zhhans": {
+                    "name": "Bulleteye"
+                },
+                "zhhant": {
                     "name": "Bulleteye"
                 }
             }
@@ -4155,7 +9675,37 @@
             "power": null,
             "text": "Enhance .\nEach friendly Shadows creature gains hazardous 2.\n",
             "locale": {
+                "de": {
+                    "name": "Cheval-de-Frise"
+                },
                 "en": {
+                    "name": "Cheval de Frise"
+                },
+                "es": {
+                    "name": "Cheval de Frise"
+                },
+                "fr": {
+                    "name": "Cheval de Frise"
+                },
+                "it": {
+                    "name": "Cheval de Frise"
+                },
+                "pl": {
+                    "name": "Cheval de Frise"
+                },
+                "pt": {
+                    "name": "Cheval de Frise"
+                },
+                "th": {
+                    "name": "Cheval de Frise"
+                },
+                "vi": {
+                    "name": "Cheval de Frise"
+                },
+                "zhhans": {
+                    "name": "Cheval de Frise"
+                },
+                "zhhant": {
                     "name": "Cheval de Frise"
                 }
             }
@@ -4176,7 +9726,37 @@
             "power": null,
             "text": "Play: Exalt each damaged enemy creature.",
             "locale": {
+                "de": {
+                    "name": "Leichte Opfer"
+                },
                 "en": {
+                    "name": "Easy Marks"
+                },
+                "es": {
+                    "name": "Easy Marks"
+                },
+                "fr": {
+                    "name": "Marques Faciles"
+                },
+                "it": {
+                    "name": "Easy Marks"
+                },
+                "pl": {
+                    "name": "Easy Marks"
+                },
+                "pt": {
+                    "name": "Easy Marks"
+                },
+                "th": {
+                    "name": "Easy Marks"
+                },
+                "vi": {
+                    "name": "Easy Marks"
+                },
+                "zhhans": {
+                    "name": "Easy Marks"
+                },
+                "zhhant": {
                     "name": "Easy Marks"
                 }
             }
@@ -4197,7 +9777,37 @@
             "power": null,
             "text": "Play: Destroy a damaged creature. If you do, steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Todesstoß"
+                },
                 "en": {
+                    "name": "Finishing Blow"
+                },
+                "es": {
+                    "name": "Finishing Blow"
+                },
+                "fr": {
+                    "name": "Coup de Grâce"
+                },
+                "it": {
+                    "name": "Finishing Blow"
+                },
+                "pl": {
+                    "name": "Finishing Blow"
+                },
+                "pt": {
+                    "name": "Finishing Blow"
+                },
+                "th": {
+                    "name": "Finishing Blow"
+                },
+                "vi": {
+                    "name": "Finishing Blow"
+                },
+                "zhhans": {
+                    "name": "Finishing Blow"
+                },
+                "zhhant": {
                     "name": "Finishing Blow"
                 }
             }
@@ -4223,7 +9833,37 @@
             "power": 2,
             "text": "Elusive.\nYou may spend up to 3 from your opponent’s pool when forging keys.\n",
             "locale": {
+                "de": {
+                    "name": "Ehrenwerter Abagnale"
+                },
                 "en": {
+                    "name": "Honorable Abagnale"
+                },
+                "es": {
+                    "name": "Honorable Abagnale"
+                },
+                "fr": {
+                    "name": "Abagnale l’Honorable"
+                },
+                "it": {
+                    "name": "Honorable Abagnale"
+                },
+                "pl": {
+                    "name": "Honorable Abagnale"
+                },
+                "pt": {
+                    "name": "Honorable Abagnale"
+                },
+                "th": {
+                    "name": "Honorable Abagnale"
+                },
+                "vi": {
+                    "name": "Honorable Abagnale"
+                },
+                "zhhans": {
+                    "name": "Honorable Abagnale"
+                },
+                "zhhant": {
                     "name": "Honorable Abagnale"
                 }
             }
@@ -4244,7 +9884,37 @@
             "power": null,
             "text": "Play: Pay your opponent up to 6. For each  paid this way, draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Der Rest ist für dich"
+                },
                 "en": {
+                    "name": "Keep the Change"
+                },
+                "es": {
+                    "name": "Keep the Change"
+                },
+                "fr": {
+                    "name": "Garde la Monnaie"
+                },
+                "it": {
+                    "name": "Keep the Change"
+                },
+                "pl": {
+                    "name": "Keep the Change"
+                },
+                "pt": {
+                    "name": "Keep the Change"
+                },
+                "th": {
+                    "name": "Keep the Change"
+                },
+                "vi": {
+                    "name": "Keep the Change"
+                },
+                "zhhans": {
+                    "name": "Keep the Change"
+                },
+                "zhhant": {
                     "name": "Keep the Change"
                 }
             }
@@ -4270,7 +9940,37 @@
             "power": 4,
             "text": "Elusive.\nAt the end of your opponent's turn, if they drew 2 or more cards during their “draw cards” step, steal 2.\n",
             "locale": {
+                "de": {
+                    "name": "Luis Compère"
+                },
                 "en": {
+                    "name": "Luis Compère"
+                },
+                "es": {
+                    "name": "Luis Compère"
+                },
+                "fr": {
+                    "name": "Compère Louis"
+                },
+                "it": {
+                    "name": "Luis Compère"
+                },
+                "pl": {
+                    "name": "Luis Compère"
+                },
+                "pt": {
+                    "name": "Luis Compère"
+                },
+                "th": {
+                    "name": "Luis Compère"
+                },
+                "vi": {
+                    "name": "Luis Compère"
+                },
+                "zhhans": {
+                    "name": "Luis Compère"
+                },
+                "zhhant": {
                     "name": "Luis Compère"
                 }
             }
@@ -4291,7 +9991,37 @@
             "power": null,
             "text": "This creature cannot be used and gains, “At the start of your turn, you may pay your opponent 2. If you do, destroy Ransom.”\n",
             "locale": {
+                "de": {
+                    "name": "Lösegeld"
+                },
                 "en": {
+                    "name": "Ransom"
+                },
+                "es": {
+                    "name": "Ransom"
+                },
+                "fr": {
+                    "name": "Rançon"
+                },
+                "it": {
+                    "name": "Ransom"
+                },
+                "pl": {
+                    "name": "Ransom"
+                },
+                "pt": {
+                    "name": "Ransom"
+                },
+                "th": {
+                    "name": "Ransom"
+                },
+                "vi": {
+                    "name": "Ransom"
+                },
+                "zhhans": {
+                    "name": "Ransom"
+                },
+                "zhhant": {
                     "name": "Ransom"
                 }
             }
@@ -4312,7 +10042,37 @@
             "power": null,
             "text": "Play: Pay your opponent 1. If you do, take control of an enemy creature or artifact.\n",
             "locale": {
+                "de": {
+                    "name": "Gas geben und greifen"
+                },
                 "en": {
+                    "name": "Rein and Cycle"
+                },
+                "es": {
+                    "name": "Rein and Cycle"
+                },
+                "fr": {
+                    "name": "Gagner au Change"
+                },
+                "it": {
+                    "name": "Rein and Cycle"
+                },
+                "pl": {
+                    "name": "Rein and Cycle"
+                },
+                "pt": {
+                    "name": "Rein and Cycle"
+                },
+                "th": {
+                    "name": "Rein and Cycle"
+                },
+                "vi": {
+                    "name": "Rein and Cycle"
+                },
+                "zhhans": {
+                    "name": "Rein and Cycle"
+                },
+                "zhhant": {
                     "name": "Rein and Cycle"
                 }
             }
@@ -4333,7 +10093,37 @@
             "power": null,
             "text": "Play: Each player discards the top 5 cards of their deck. For each Shadows card discarded, its owner gains 1.\n",
             "locale": {
+                "de": {
+                    "name": "Manipulierte Lotterie"
+                },
                 "en": {
+                    "name": "Rigged Lottery"
+                },
+                "es": {
+                    "name": "Rigged Lottery"
+                },
+                "fr": {
+                    "name": "Loterie Truquée"
+                },
+                "it": {
+                    "name": "Rigged Lottery"
+                },
+                "pl": {
+                    "name": "Rigged Lottery"
+                },
+                "pt": {
+                    "name": "Rigged Lottery"
+                },
+                "th": {
+                    "name": "Rigged Lottery"
+                },
+                "vi": {
+                    "name": "Rigged Lottery"
+                },
+                "zhhans": {
+                    "name": "Rigged Lottery"
+                },
+                "zhhant": {
                     "name": "Rigged Lottery"
                 }
             }
@@ -4354,7 +10144,37 @@
             "power": null,
             "text": "Play: Steal 1. Then, steal 1 for each copy of Routine Job in your discard pile.",
             "locale": {
+                "de": {
+                    "name": "Routinearbeit"
+                },
                 "en": {
+                    "name": "Routine Job"
+                },
+                "es": {
+                    "name": "Routine Job"
+                },
+                "fr": {
+                    "name": "Travail de Routine"
+                },
+                "it": {
+                    "name": "Routine Job"
+                },
+                "pl": {
+                    "name": "Routine Job"
+                },
+                "pt": {
+                    "name": "Routine Job"
+                },
+                "th": {
+                    "name": "Routine Job"
+                },
+                "vi": {
+                    "name": "Routine Job"
+                },
+                "zhhans": {
+                    "name": "Routine Job"
+                },
+                "zhhant": {
                     "name": "Routine Job"
                 }
             }
@@ -4378,7 +10198,37 @@
             "power": 3,
             "text": "After Fight/After Reap: Move 1 from a friendly card to your pool.",
             "locale": {
+                "de": {
+                    "name": "Selwyn die Hehlerin"
+                },
                 "en": {
+                    "name": "Selwyn the Fence"
+                },
+                "es": {
+                    "name": "Selwyn the Fence"
+                },
+                "fr": {
+                    "name": "Selwyn la Receleuse"
+                },
+                "it": {
+                    "name": "Selwyn the Fence"
+                },
+                "pl": {
+                    "name": "Selwyn the Fence"
+                },
+                "pt": {
+                    "name": "Selwyn the Fence"
+                },
+                "th": {
+                    "name": "Selwyn the Fence"
+                },
+                "vi": {
+                    "name": "Selwyn the Fence"
+                },
+                "zhhans": {
+                    "name": "Selwyn the Fence"
+                },
+                "zhhant": {
                     "name": "Selwyn the Fence"
                 }
             }
@@ -4402,7 +10252,37 @@
             "power": 2,
             "text": "Play: Take control of an enemy artifact. While under your control, if it does not belong to one of your three houses, it belongs to house Shadows.",
             "locale": {
+                "de": {
+                    "name": "Schlangenstehler"
+                },
                 "en": {
+                    "name": "Sneklifter"
+                },
+                "es": {
+                    "name": "Sneklifter"
+                },
+                "fr": {
+                    "name": "Crotale la Détale"
+                },
+                "it": {
+                    "name": "Sneklifter"
+                },
+                "pl": {
+                    "name": "Sneklifter"
+                },
+                "pt": {
+                    "name": "Sneklifter"
+                },
+                "th": {
+                    "name": "Sneklifter"
+                },
+                "vi": {
+                    "name": "Sneklifter"
+                },
+                "zhhans": {
+                    "name": "Sneklifter"
+                },
+                "zhhant": {
                     "name": "Sneklifter"
                 }
             }
@@ -4425,7 +10305,37 @@
             "power": null,
             "text": "After a player gains  by reaping, a creature they do not control captures that .\n",
             "locale": {
+                "de": {
+                    "name": "Weitverbreitete Korruption"
+                },
                 "en": {
+                    "name": "Widespread Corruption"
+                },
+                "es": {
+                    "name": "Widespread Corruption"
+                },
+                "fr": {
+                    "name": "Corruption Généralisée"
+                },
+                "it": {
+                    "name": "Widespread Corruption"
+                },
+                "pl": {
+                    "name": "Widespread Corruption"
+                },
+                "pt": {
+                    "name": "Widespread Corruption"
+                },
+                "th": {
+                    "name": "Widespread Corruption"
+                },
+                "vi": {
+                    "name": "Widespread Corruption"
+                },
+                "zhhans": {
+                    "name": "Widespread Corruption"
+                },
+                "zhhant": {
                     "name": "Widespread Corruption"
                 }
             }
@@ -4446,7 +10356,37 @@
             "power": null,
             "text": "Play: Each player shuffles their archives and discard pile into their deck. Discard the top 5 cards of your opponent’s deck. Play the top card of their deck as if it were yours.\n",
             "locale": {
+                "de": {
+                    "name": "Blankoscheck"
+                },
                 "en": {
+                    "name": "Blank Check"
+                },
+                "es": {
+                    "name": "Blank Check"
+                },
+                "fr": {
+                    "name": "Chèque en Blanc"
+                },
+                "it": {
+                    "name": "Blank Check"
+                },
+                "pl": {
+                    "name": "Blank Check"
+                },
+                "pt": {
+                    "name": "Blank Check"
+                },
+                "th": {
+                    "name": "Blank Check"
+                },
+                "vi": {
+                    "name": "Blank Check"
+                },
+                "zhhans": {
+                    "name": "Blank Check"
+                },
+                "zhhant": {
                     "name": "Blank Check"
                 }
             }
@@ -4467,7 +10407,37 @@
             "power": null,
             "text": "Play: Enrage an enemy creature. Move all  from that creature to your pool.\n",
             "locale": {
+                "de": {
+                    "name": "Dreister Diebstahl"
+                },
                 "en": {
+                    "name": "Blatant Thievery"
+                },
+                "es": {
+                    "name": "Blatant Thievery"
+                },
+                "fr": {
+                    "name": "Flagrant Délit"
+                },
+                "it": {
+                    "name": "Blatant Thievery"
+                },
+                "pl": {
+                    "name": "Blatant Thievery"
+                },
+                "pt": {
+                    "name": "Blatant Thievery"
+                },
+                "th": {
+                    "name": "Blatant Thievery"
+                },
+                "vi": {
+                    "name": "Blatant Thievery"
+                },
+                "zhhans": {
+                    "name": "Blatant Thievery"
+                },
+                "zhhant": {
                     "name": "Blatant Thievery"
                 }
             }
@@ -4491,7 +10461,37 @@
             "power": 3,
             "text": "After you play Subtle Chain, ready Chain Gang. \nAction: Steal 1. Shuffle a Subtle Chain from your discard pile into your deck.\n",
             "locale": {
+                "de": {
+                    "name": "Ketten-Bande"
+                },
                 "en": {
+                    "name": "Chain Gang"
+                },
+                "es": {
+                    "name": "Chain Gang"
+                },
+                "fr": {
+                    "name": "Récidivistes en Chaîne"
+                },
+                "it": {
+                    "name": "Chain Gang"
+                },
+                "pl": {
+                    "name": "Chain Gang"
+                },
+                "pt": {
+                    "name": "Chain Gang"
+                },
+                "th": {
+                    "name": "Chain Gang"
+                },
+                "vi": {
+                    "name": "Chain Gang"
+                },
+                "zhhans": {
+                    "name": "Chain Gang"
+                },
+                "zhhant": {
                     "name": "Chain Gang"
                 }
             }
@@ -4512,7 +10512,37 @@
             "power": null,
             "text": "Play: If your opponent has more  than you, they lose half of their  (rounding down the loss).\n",
             "locale": {
+                "de": {
+                    "name": "Falschgeld-Affäre"
+                },
                 "en": {
+                    "name": "Counterfeit Controversy"
+                },
+                "es": {
+                    "name": "Counterfeit Controversy"
+                },
+                "fr": {
+                    "name": "Contrefaçon Controversée"
+                },
+                "it": {
+                    "name": "Counterfeit Controversy"
+                },
+                "pl": {
+                    "name": "Counterfeit Controversy"
+                },
+                "pt": {
+                    "name": "Counterfeit Controversy"
+                },
+                "th": {
+                    "name": "Counterfeit Controversy"
+                },
+                "vi": {
+                    "name": "Counterfeit Controversy"
+                },
+                "zhhans": {
+                    "name": "Counterfeit Controversy"
+                },
+                "zhhant": {
                     "name": "Counterfeit Controversy"
                 }
             }
@@ -4533,7 +10563,37 @@
             "power": null,
             "text": "Enhance .\nPlay: Move all  from one creature to another creature.\n",
             "locale": {
+                "de": {
+                    "name": "Beute loswerden"
+                },
                 "en": {
+                    "name": "Ditch the Loot"
+                },
+                "es": {
+                    "name": "Ditch the Loot"
+                },
+                "fr": {
+                    "name": "Bazarder le Butin"
+                },
+                "it": {
+                    "name": "Ditch the Loot"
+                },
+                "pl": {
+                    "name": "Ditch the Loot"
+                },
+                "pt": {
+                    "name": "Ditch the Loot"
+                },
+                "th": {
+                    "name": "Ditch the Loot"
+                },
+                "vi": {
+                    "name": "Ditch the Loot"
+                },
+                "zhhans": {
+                    "name": "Ditch the Loot"
+                },
+                "zhhant": {
                     "name": "Ditch the Loot"
                 }
             }
@@ -4557,7 +10617,37 @@
             "power": 2,
             "text": "Each enemy creature gains, “After Fight/After Reap: Exhaust each friendly creature that shares a house with this creature.”\n",
             "locale": {
+                "de": {
+                    "name": "Ox Sarbane"
+                },
                 "en": {
+                    "name": "Ox Sarbane"
+                },
+                "es": {
+                    "name": "Ox Sarbane"
+                },
+                "fr": {
+                    "name": "Ox Sarbane"
+                },
+                "it": {
+                    "name": "Ox Sarbane"
+                },
+                "pl": {
+                    "name": "Ox Sarbane"
+                },
+                "pt": {
+                    "name": "Ox Sarbane"
+                },
+                "th": {
+                    "name": "Ox Sarbane"
+                },
+                "vi": {
+                    "name": "Ox Sarbane"
+                },
+                "zhhans": {
+                    "name": "Ox Sarbane"
+                },
+                "zhhant": {
                     "name": "Ox Sarbane"
                 }
             }
@@ -4578,7 +10668,37 @@
             "power": null,
             "text": "Play: If you have more  than your opponent, they discard a random card from their hand and you draw a card.",
             "locale": {
+                "de": {
+                    "name": "Verwirrende Klügelei"
+                },
                 "en": {
+                    "name": "Perplexing Sophistry"
+                },
+                "es": {
+                    "name": "Perplexing Sophistry"
+                },
+                "fr": {
+                    "name": "Sophisme Troublant"
+                },
+                "it": {
+                    "name": "Perplexing Sophistry"
+                },
+                "pl": {
+                    "name": "Perplexing Sophistry"
+                },
+                "pt": {
+                    "name": "Perplexing Sophistry"
+                },
+                "th": {
+                    "name": "Perplexing Sophistry"
+                },
+                "vi": {
+                    "name": "Perplexing Sophistry"
+                },
+                "zhhans": {
+                    "name": "Perplexing Sophistry"
+                },
+                "zhhant": {
                     "name": "Perplexing Sophistry"
                 }
             }
@@ -4604,7 +10724,37 @@
             "power": 1,
             "text": "Elusive. (The first time this creature is attacked each turn, no damage is dealt.)\nAction: Steal 2. Until the start of your next turn, Reckless Rizzo loses elusive.",
             "locale": {
+                "de": {
+                    "name": "Waghalsige Rizzo"
+                },
                 "en": {
+                    "name": "Reckless Rizzo"
+                },
+                "es": {
+                    "name": "Reckless Rizzo"
+                },
+                "fr": {
+                    "name": "Rizzo Sans Repos"
+                },
+                "it": {
+                    "name": "Reckless Rizzo"
+                },
+                "pl": {
+                    "name": "Reckless Rizzo"
+                },
+                "pt": {
+                    "name": "Reckless Rizzo"
+                },
+                "th": {
+                    "name": "Reckless Rizzo"
+                },
+                "vi": {
+                    "name": "Reckless Rizzo"
+                },
+                "zhhans": {
+                    "name": "Reckless Rizzo"
+                },
+                "zhhant": {
                     "name": "Reckless Rizzo"
                 }
             }
@@ -4625,7 +10775,37 @@
             "power": null,
             "text": "Play: Your opponent discards a random card from their hand. \n",
             "locale": {
+                "de": {
+                    "name": "Subtile Kette"
+                },
                 "en": {
+                    "name": "Subtle Chain"
+                },
+                "es": {
+                    "name": "Subtle Chain"
+                },
+                "fr": {
+                    "name": "Chaîne Subtile"
+                },
+                "it": {
+                    "name": "Subtle Chain"
+                },
+                "pl": {
+                    "name": "Subtle Chain"
+                },
+                "pt": {
+                    "name": "Subtle Chain"
+                },
+                "th": {
+                    "name": "Subtle Chain"
+                },
+                "vi": {
+                    "name": "Subtle Chain"
+                },
+                "zhhans": {
+                    "name": "Subtle Chain"
+                },
+                "zhhant": {
                     "name": "Subtle Chain"
                 }
             }
@@ -4651,7 +10831,37 @@
             "power": 2,
             "text": "Elusive. Entrench.\nWhile The Watch is exhausted, your  cannot be stolen.\n",
             "locale": {
+                "de": {
+                    "name": "Die Wache"
+                },
                 "en": {
+                    "name": "The Watch"
+                },
+                "es": {
+                    "name": "The Watch"
+                },
+                "fr": {
+                    "name": "Le Veilleur"
+                },
+                "it": {
+                    "name": "The Watch"
+                },
+                "pl": {
+                    "name": "The Watch"
+                },
+                "pt": {
+                    "name": "The Watch"
+                },
+                "th": {
+                    "name": "The Watch"
+                },
+                "vi": {
+                    "name": "The Watch"
+                },
+                "zhhans": {
+                    "name": "The Watch"
+                },
+                "zhhant": {
                     "name": "The Watch"
                 }
             }
@@ -4672,7 +10882,37 @@
             "power": null,
             "text": "Play: Steal all but 6 of your\nopponent’s .\n",
             "locale": {
+                "de": {
+                    "name": "Zu viel zu bewachen"
+                },
                 "en": {
+                    "name": "Too Much to Protect"
+                },
+                "es": {
+                    "name": "Too Much to Protect"
+                },
+                "fr": {
+                    "name": "Trop à Protéger"
+                },
+                "it": {
+                    "name": "Too Much to Protect"
+                },
+                "pl": {
+                    "name": "Too Much to Protect"
+                },
+                "pt": {
+                    "name": "Too Much to Protect"
+                },
+                "th": {
+                    "name": "Too Much to Protect"
+                },
+                "vi": {
+                    "name": "Too Much to Protect"
+                },
+                "zhhans": {
+                    "name": "Too Much to Protect"
+                },
+                "zhhant": {
                     "name": "Too Much to Protect"
                 }
             }
@@ -4696,7 +10936,37 @@
             "power": 3,
             "text": "After your opponent plays a creature, deal 2 to it.\n",
             "locale": {
+                "de": {
+                    "name": "Vaelra Flüsterfang"
+                },
                 "en": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "es": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "fr": {
+                    "name": "Vaelra Quenottes"
+                },
+                "it": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "pl": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "pt": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "th": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "vi": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "zhhans": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "zhhant": {
                     "name": "Vaelra Whisperfang"
                 }
             }
@@ -4720,7 +10990,37 @@
             "power": 3,
             "text": "After Reap: Purge a card from your discard pile. If you do, until the start of your next turn, your opponent cannot play cards of the purged card’s type.\n",
             "locale": {
+                "de": {
+                    "name": "Victor Flux"
+                },
                 "en": {
+                    "name": "Victor Flux"
+                },
+                "es": {
+                    "name": "Victor Flux"
+                },
+                "fr": {
+                    "name": "Victor Flux"
+                },
+                "it": {
+                    "name": "Victor Flux"
+                },
+                "pl": {
+                    "name": "Victor Flux"
+                },
+                "pt": {
+                    "name": "Victor Flux"
+                },
+                "th": {
+                    "name": "Victor Flux"
+                },
+                "vi": {
+                    "name": "Victor Flux"
+                },
+                "zhhans": {
+                    "name": "Victor Flux"
+                },
+                "zhhant": {
                     "name": "Victor Flux"
                 }
             }
@@ -4745,7 +11045,37 @@
             "power": 2,
             "text": "Skirmish.\nAfter Fight: Exhaust an enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Achromatischer Basilisk"
+                },
                 "en": {
+                    "name": "Achromatic Basilisk"
+                },
+                "es": {
+                    "name": "Achromatic Basilisk"
+                },
+                "fr": {
+                    "name": "Basilic Achromatique"
+                },
+                "it": {
+                    "name": "Achromatic Basilisk"
+                },
+                "pl": {
+                    "name": "Achromatic Basilisk"
+                },
+                "pt": {
+                    "name": "Achromatic Basilisk"
+                },
+                "th": {
+                    "name": "Achromatic Basilisk"
+                },
+                "vi": {
+                    "name": "Achromatic Basilisk"
+                },
+                "zhhans": {
+                    "name": "Achromatic Basilisk"
+                },
+                "zhhant": {
                     "name": "Achromatic Basilisk"
                 }
             }
@@ -4766,7 +11096,37 @@
             "power": null,
             "text": "Play: If you are overwhelmed, exhaust an enemy creature. Steal 1 for each exhausted enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Kalt erwischt"
+                },
                 "en": {
+                    "name": "Caught You Napping"
+                },
+                "es": {
+                    "name": "Caught You Napping"
+                },
+                "fr": {
+                    "name": "Choppé à Roupiller"
+                },
+                "it": {
+                    "name": "Caught You Napping"
+                },
+                "pl": {
+                    "name": "Caught You Napping"
+                },
+                "pt": {
+                    "name": "Caught You Napping"
+                },
+                "th": {
+                    "name": "Caught You Napping"
+                },
+                "vi": {
+                    "name": "Caught You Napping"
+                },
+                "zhhans": {
+                    "name": "Caught You Napping"
+                },
+                "zhhant": {
                     "name": "Caught You Napping"
                 }
             }
@@ -4790,7 +11150,37 @@
             "power": 1,
             "text": "Enhance .\nDestroyed: Deal 2 to each enemy flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Knall E. More"
+                },
                 "en": {
+                    "name": "Clay More"
+                },
+                "es": {
+                    "name": "Clay More"
+                },
+                "fr": {
+                    "name": "Bonne Mine"
+                },
+                "it": {
+                    "name": "Clay More"
+                },
+                "pl": {
+                    "name": "Clay More"
+                },
+                "pt": {
+                    "name": "Clay More"
+                },
+                "th": {
+                    "name": "Clay More"
+                },
+                "vi": {
+                    "name": "Clay More"
+                },
+                "zhhans": {
+                    "name": "Clay More"
+                },
+                "zhhant": {
                     "name": "Clay More"
                 }
             }
@@ -4814,7 +11204,37 @@
             "power": 2,
             "text": "Enhance .\nPlay: For each +1 power counter on each creature, deal 1 to a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Colt Slevin"
+                },
                 "en": {
+                    "name": "Colt Sleven"
+                },
+                "es": {
+                    "name": "Colt Sleven"
+                },
+                "fr": {
+                    "name": "Colt Sleven"
+                },
+                "it": {
+                    "name": "Colt Sleven"
+                },
+                "pl": {
+                    "name": "Colt Sleven"
+                },
+                "pt": {
+                    "name": "Colt Sleven"
+                },
+                "th": {
+                    "name": "Colt Sleven"
+                },
+                "vi": {
+                    "name": "Colt Sleven"
+                },
+                "zhhans": {
+                    "name": "Colt Sleven"
+                },
+                "zhhant": {
                     "name": "Colt Sleven"
                 }
             }
@@ -4839,7 +11259,37 @@
             "power": 2,
             "text": "Taunt.\nDestroyed: Steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Sündenbock"
+                },
                 "en": {
+                    "name": "Fallguy"
+                },
+                "es": {
+                    "name": "Fallguy"
+                },
+                "fr": {
+                    "name": "Bouc Émissaire"
+                },
+                "it": {
+                    "name": "Fallguy"
+                },
+                "pl": {
+                    "name": "Fallguy"
+                },
+                "pt": {
+                    "name": "Fallguy"
+                },
+                "th": {
+                    "name": "Fallguy"
+                },
+                "vi": {
+                    "name": "Fallguy"
+                },
+                "zhhans": {
+                    "name": "Fallguy"
+                },
+                "zhhant": {
                     "name": "Fallguy"
                 }
             }
@@ -4865,7 +11315,37 @@
             "power": 2,
             "text": "Elusive. Entrench.\nWhile Grammy Taps is exhausted, each of its neighbors gains elusive.\n",
             "locale": {
+                "de": {
+                    "name": "Omi Taps"
+                },
                 "en": {
+                    "name": "Grammy Taps"
+                },
+                "es": {
+                    "name": "Grammy Taps"
+                },
+                "fr": {
+                    "name": "Mamy Blue"
+                },
+                "it": {
+                    "name": "Grammy Taps"
+                },
+                "pl": {
+                    "name": "Grammy Taps"
+                },
+                "pt": {
+                    "name": "Grammy Taps"
+                },
+                "th": {
+                    "name": "Grammy Taps"
+                },
+                "vi": {
+                    "name": "Grammy Taps"
+                },
+                "zhhans": {
+                    "name": "Grammy Taps"
+                },
+                "zhhant": {
                     "name": "Grammy Taps"
                 }
             }
@@ -4886,7 +11366,37 @@
             "power": null,
             "text": "Play: Destroy a friendly creature. If you do, deal 6 to a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Ein Leben für ein Leben"
+                },
                 "en": {
+                    "name": "Life for a Life"
+                },
+                "es": {
+                    "name": "Life for a Life"
+                },
+                "fr": {
+                    "name": "Une Vie contre une Vie"
+                },
+                "it": {
+                    "name": "Life for a Life"
+                },
+                "pl": {
+                    "name": "Life for a Life"
+                },
+                "pt": {
+                    "name": "Life for a Life"
+                },
+                "th": {
+                    "name": "Life for a Life"
+                },
+                "vi": {
+                    "name": "Life for a Life"
+                },
+                "zhhans": {
+                    "name": "Life for a Life"
+                },
+                "zhhant": {
                     "name": "Life for a Life"
                 }
             }
@@ -4910,7 +11420,37 @@
             "power": 2,
             "text": "After Reap: If you are overwhelmed, steal 2. Otherwise, steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Albtraum-Straßenkind"
+                },
                 "en": {
+                    "name": "Nightmare Urchin"
+                },
+                "es": {
+                    "name": "Nightmare Urchin"
+                },
+                "fr": {
+                    "name": "Orphelin Endiablé"
+                },
+                "it": {
+                    "name": "Nightmare Urchin"
+                },
+                "pl": {
+                    "name": "Nightmare Urchin"
+                },
+                "pt": {
+                    "name": "Nightmare Urchin"
+                },
+                "th": {
+                    "name": "Nightmare Urchin"
+                },
+                "vi": {
+                    "name": "Nightmare Urchin"
+                },
+                "zhhans": {
+                    "name": "Nightmare Urchin"
+                },
+                "zhhant": {
                     "name": "Nightmare Urchin"
                 }
             }
@@ -4934,7 +11474,37 @@
             "power": 2,
             "text": "Play: If your opponent has more  than you, steal 2.\n",
             "locale": {
+                "de": {
+                    "name": "Buchhalter Malloy"
+                },
                 "en": {
+                    "name": "Pincher Malloy"
+                },
+                "es": {
+                    "name": "Pincher Malloy"
+                },
+                "fr": {
+                    "name": "Malo le Faussaire"
+                },
+                "it": {
+                    "name": "Pincher Malloy"
+                },
+                "pl": {
+                    "name": "Pincher Malloy"
+                },
+                "pt": {
+                    "name": "Pincher Malloy"
+                },
+                "th": {
+                    "name": "Pincher Malloy"
+                },
+                "vi": {
+                    "name": "Pincher Malloy"
+                },
+                "zhhans": {
+                    "name": "Pincher Malloy"
+                },
+                "zhhant": {
                     "name": "Pincher Malloy"
                 }
             }
@@ -4955,7 +11525,37 @@
             "power": null,
             "text": "Play: Deal 2 to a creature, with 1 splash. If this damage destroys 2 or more creatures, steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Pyrotechnischer Blitz"
+                },
                 "en": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "es": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "fr": {
+                    "name": "Éclair Pyrotechnique"
+                },
+                "it": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "pl": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "pt": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "th": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "vi": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "zhhans": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "zhhant": {
                     "name": "Pyrotechnic Flash"
                 }
             }
@@ -4976,7 +11576,37 @@
             "power": null,
             "text": "Play: Exhaust the least powerful enemy creature and each of its neighbors.\n",
             "locale": {
+                "de": {
+                    "name": "Mach mal Pause"
+                },
                 "en": {
+                    "name": "Take a Break"
+                },
+                "es": {
+                    "name": "Take a Break"
+                },
+                "fr": {
+                    "name": "Prends une Pause"
+                },
+                "it": {
+                    "name": "Take a Break"
+                },
+                "pl": {
+                    "name": "Take a Break"
+                },
+                "pt": {
+                    "name": "Take a Break"
+                },
+                "th": {
+                    "name": "Take a Break"
+                },
+                "vi": {
+                    "name": "Take a Break"
+                },
+                "zhhans": {
+                    "name": "Take a Break"
+                },
+                "zhhant": {
                     "name": "Take a Break"
                 }
             }
@@ -4997,7 +11627,37 @@
             "power": null,
             "text": "Play: Deal 1 to up to three creatures. Gain 1 for each creature destroyed this way.",
             "locale": {
+                "de": {
+                    "name": "Wurfsterne"
+                },
                 "en": {
+                    "name": "Throwing Stars"
+                },
+                "es": {
+                    "name": "Throwing Stars"
+                },
+                "fr": {
+                    "name": "Étoiles de Lancer"
+                },
+                "it": {
+                    "name": "Throwing Stars"
+                },
+                "pl": {
+                    "name": "Throwing Stars"
+                },
+                "pt": {
+                    "name": "Throwing Stars"
+                },
+                "th": {
+                    "name": "Throwing Stars"
+                },
+                "vi": {
+                    "name": "Throwing Stars"
+                },
+                "zhhans": {
+                    "name": "Throwing Stars"
+                },
+                "zhhant": {
                     "name": "Throwing Stars"
                 }
             }
@@ -5023,7 +11683,37 @@
             "power": 3,
             "text": "Deploy.\nPlay: Exhaust each non-flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Aviatrix Virtuosa"
+                },
                 "en": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "es": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "fr": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "it": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "pl": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "pt": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "th": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "vi": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "zhhans": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "zhhant": {
                     "name": "Aviatrix Virtuosa"
                 }
             }
@@ -5046,7 +11736,37 @@
             "power": null,
             "text": "Your opponent’s keys cost +1 for each Skyborn creature on a flank.\n",
             "locale": {
+                "de": {
+                    "name": "Wolkenbruch-Befehl"
+                },
                 "en": {
+                    "name": "Cloudburst Command"
+                },
+                "es": {
+                    "name": "Cloudburst Command"
+                },
+                "fr": {
+                    "name": "Régie Cumulo-Blastus"
+                },
+                "it": {
+                    "name": "Cloudburst Command"
+                },
+                "pl": {
+                    "name": "Cloudburst Command"
+                },
+                "pt": {
+                    "name": "Cloudburst Command"
+                },
+                "th": {
+                    "name": "Cloudburst Command"
+                },
+                "vi": {
+                    "name": "Cloudburst Command"
+                },
+                "zhhans": {
+                    "name": "Cloudburst Command"
+                },
+                "zhhant": {
                     "name": "Cloudburst Command"
                 }
             }
@@ -5069,7 +11789,37 @@
             "power": 4,
             "text": "Each enemy creature loses each of its destroyed abilities.\n",
             "locale": {
+                "de": {
+                    "name": "Flipp Stahl­hart"
+                },
                 "en": {
+                    "name": "Flip Stallard"
+                },
+                "es": {
+                    "name": "Flip Stallard"
+                },
+                "fr": {
+                    "name": "Flip Stallard"
+                },
+                "it": {
+                    "name": "Flip Stallard"
+                },
+                "pl": {
+                    "name": "Flip Stallard"
+                },
+                "pt": {
+                    "name": "Flip Stallard"
+                },
+                "th": {
+                    "name": "Flip Stallard"
+                },
+                "vi": {
+                    "name": "Flip Stallard"
+                },
+                "zhhans": {
+                    "name": "Flip Stallard"
+                },
+                "zhhant": {
                     "name": "Flip Stallard"
                 }
             }
@@ -5090,7 +11840,37 @@
             "power": null,
             "text": "Play: Deal 1 to each creature for each forged key.\n",
             "locale": {
+                "de": {
+                    "name": "Geschmiedeter Blitz"
+                },
                 "en": {
+                    "name": "Forged Bolt"
+                },
+                "es": {
+                    "name": "Forged Bolt"
+                },
+                "fr": {
+                    "name": "Forgedroyer"
+                },
+                "it": {
+                    "name": "Forged Bolt"
+                },
+                "pl": {
+                    "name": "Forged Bolt"
+                },
+                "pt": {
+                    "name": "Forged Bolt"
+                },
+                "th": {
+                    "name": "Forged Bolt"
+                },
+                "vi": {
+                    "name": "Forged Bolt"
+                },
+                "zhhans": {
+                    "name": "Forged Bolt"
+                },
+                "zhhant": {
                     "name": "Forged Bolt"
                 }
             }
@@ -5114,7 +11894,37 @@
             "power": 6,
             "text": "After Fight/After Reap: You may exalt Han Peregrine. If you do, fully heal a damaged creature and move it to either flank of its controller's battleline.\n",
             "locale": {
+                "de": {
+                    "name": "Han der Wanderer"
+                },
                 "en": {
+                    "name": "Han Peregrine"
+                },
+                "es": {
+                    "name": "Han Peregrine"
+                },
+                "fr": {
+                    "name": "Han Peregrine"
+                },
+                "it": {
+                    "name": "Han Peregrine"
+                },
+                "pl": {
+                    "name": "Han Peregrine"
+                },
+                "pt": {
+                    "name": "Han Peregrine"
+                },
+                "th": {
+                    "name": "Han Peregrine"
+                },
+                "vi": {
+                    "name": "Han Peregrine"
+                },
+                "zhhans": {
+                    "name": "Han Peregrine"
+                },
+                "zhhant": {
                     "name": "Han Peregrine"
                 }
             }
@@ -5135,7 +11945,37 @@
             "power": null,
             "text": "Play: Put each friendly Skyborn creature into its owner’s archives.\n",
             "locale": {
+                "de": {
+                    "name": "Ein langer Weg nach Hause"
+                },
                 "en": {
+                    "name": "Long Way Home"
+                },
+                "es": {
+                    "name": "Long Way Home"
+                },
+                "fr": {
+                    "name": "Long Détour"
+                },
+                "it": {
+                    "name": "Long Way Home"
+                },
+                "pl": {
+                    "name": "Long Way Home"
+                },
+                "pt": {
+                    "name": "Long Way Home"
+                },
+                "th": {
+                    "name": "Long Way Home"
+                },
+                "vi": {
+                    "name": "Long Way Home"
+                },
+                "zhhans": {
+                    "name": "Long Way Home"
+                },
+                "zhhant": {
                     "name": "Long Way Home"
                 }
             }
@@ -5162,7 +12002,37 @@
             "power": 5,
             "text": "Treachery. Versatile.\nYou cannot forge keys.\nAt the end of your turn, deal 2 to Malforge.\n",
             "locale": {
+                "de": {
+                    "name": "Fehlschmiede"
+                },
                 "en": {
+                    "name": "Malforge"
+                },
+                "es": {
+                    "name": "Malforge"
+                },
+                "fr": {
+                    "name": "Malforge"
+                },
+                "it": {
+                    "name": "Malforge"
+                },
+                "pl": {
+                    "name": "Malforge"
+                },
+                "pt": {
+                    "name": "Malforge"
+                },
+                "th": {
+                    "name": "Malforge"
+                },
+                "vi": {
+                    "name": "Malforge"
+                },
+                "zhhans": {
+                    "name": "Malforge"
+                },
+                "zhhant": {
                     "name": "Malforge"
                 }
             }
@@ -5183,7 +12053,37 @@
             "power": null,
             "text": "Play: Gain control of an enemy flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Maqui-Expedition"
+                },
                 "en": {
+                    "name": "Maqui Expedition"
+                },
+                "es": {
+                    "name": "Maqui Expedition"
+                },
+                "fr": {
+                    "name": "Expédition Maquis"
+                },
+                "it": {
+                    "name": "Maqui Expedition"
+                },
+                "pl": {
+                    "name": "Maqui Expedition"
+                },
+                "pt": {
+                    "name": "Maqui Expedition"
+                },
+                "th": {
+                    "name": "Maqui Expedition"
+                },
+                "vi": {
+                    "name": "Maqui Expedition"
+                },
+                "zhhans": {
+                    "name": "Maqui Expedition"
+                },
+                "zhhant": {
                     "name": "Maqui Expedition"
                 }
             }
@@ -5206,7 +12106,37 @@
             "power": null,
             "text": "Enhance  . (These icons have already been added to cards in your deck.)\nAction: Ready and fight with a friendly Skyborn creature. If your blue key is forged, repeat the preceding effect.\n",
             "locale": {
+                "de": {
+                    "name": "Rasierer-Gambit"
+                },
                 "en": {
+                    "name": "Razor’s Gambit"
+                },
+                "es": {
+                    "name": "Razor’s Gambit"
+                },
+                "fr": {
+                    "name": "Stratagème du Rasoir"
+                },
+                "it": {
+                    "name": "Razor’s Gambit"
+                },
+                "pl": {
+                    "name": "Razor’s Gambit"
+                },
+                "pt": {
+                    "name": "Razor’s Gambit"
+                },
+                "th": {
+                    "name": "Razor’s Gambit"
+                },
+                "vi": {
+                    "name": "Razor’s Gambit"
+                },
+                "zhhans": {
+                    "name": "Razor’s Gambit"
+                },
+                "zhhant": {
                     "name": "Razor’s Gambit"
                 }
             }
@@ -5227,7 +12157,37 @@
             "power": null,
             "text": "Play: Discard a card. Resolve its bonus icons as if you had played it. If a yellow key is forged, repeat the preceding effect.\n",
             "locale": {
+                "de": {
+                    "name": "Fröhliches Überbordwerfen"
+                },
                 "en": {
+                    "name": "Recreational Jettison"
+                },
+                "es": {
+                    "name": "Recreational Jettison"
+                },
+                "fr": {
+                    "name": "Délestage Récréatif"
+                },
+                "it": {
+                    "name": "Recreational Jettison"
+                },
+                "pl": {
+                    "name": "Recreational Jettison"
+                },
+                "pt": {
+                    "name": "Recreational Jettison"
+                },
+                "th": {
+                    "name": "Recreational Jettison"
+                },
+                "vi": {
+                    "name": "Recreational Jettison"
+                },
+                "zhhans": {
+                    "name": "Recreational Jettison"
+                },
+                "zhhant": {
                     "name": "Recreational Jettison"
                 }
             }
@@ -5248,7 +12208,37 @@
             "power": null,
             "text": "Each time a card would be discarded from a player's hand, reveal the card and put it facedown under this creature instead.\n",
             "locale": {
+                "de": {
+                    "name": "Hochwertiger Klebstoff"
+                },
                 "en": {
+                    "name": "Refined Adhesive"
+                },
+                "es": {
+                    "name": "Refined Adhesive"
+                },
+                "fr": {
+                    "name": "Adhésif Raffiné"
+                },
+                "it": {
+                    "name": "Refined Adhesive"
+                },
+                "pl": {
+                    "name": "Refined Adhesive"
+                },
+                "pt": {
+                    "name": "Refined Adhesive"
+                },
+                "th": {
+                    "name": "Refined Adhesive"
+                },
+                "vi": {
+                    "name": "Refined Adhesive"
+                },
+                "zhhans": {
+                    "name": "Refined Adhesive"
+                },
+                "zhhant": {
                     "name": "Refined Adhesive"
                 }
             }
@@ -5269,7 +12259,37 @@
             "power": null,
             "text": "Play: Take control of the enemy creature in the center of your opponent’s battleline.\n",
             "locale": {
+                "de": {
+                    "name": "Willkommenskultur"
+                },
                 "en": {
+                    "name": "Universal Welcome"
+                },
+                "es": {
+                    "name": "Universal Welcome"
+                },
+                "fr": {
+                    "name": "Accueil Universel"
+                },
+                "it": {
+                    "name": "Universal Welcome"
+                },
+                "pl": {
+                    "name": "Universal Welcome"
+                },
+                "pt": {
+                    "name": "Universal Welcome"
+                },
+                "th": {
+                    "name": "Universal Welcome"
+                },
+                "vi": {
+                    "name": "Universal Welcome"
+                },
+                "zhhans": {
+                    "name": "Universal Welcome"
+                },
+                "zhhant": {
                     "name": "Universal Welcome"
                 }
             }
@@ -5293,7 +12313,37 @@
             "power": 2,
             "text": "While your yellow key is forged, each enemy creature enters play stunned. \nPlay: If your yellow key is forged, stun each enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Vicomte von Aerys"
+                },
                 "en": {
+                    "name": "Viscount of Aerys"
+                },
+                "es": {
+                    "name": "Viscount of Aerys"
+                },
+                "fr": {
+                    "name": "Vicomte d’Aerys"
+                },
+                "it": {
+                    "name": "Viscount of Aerys"
+                },
+                "pl": {
+                    "name": "Viscount of Aerys"
+                },
+                "pt": {
+                    "name": "Viscount of Aerys"
+                },
+                "th": {
+                    "name": "Viscount of Aerys"
+                },
+                "vi": {
+                    "name": "Viscount of Aerys"
+                },
+                "zhhans": {
+                    "name": "Viscount of Aerys"
+                },
+                "zhhant": {
                     "name": "Viscount of Aerys"
                 }
             }
@@ -5314,7 +12364,37 @@
             "power": null,
             "text": "",
             "locale": {
+                "de": {
+                    "name": "Zomok"
+                },
                 "en": {
+                    "name": "Zomok"
+                },
+                "es": {
+                    "name": "Zomok"
+                },
+                "fr": {
+                    "name": "Zomok"
+                },
+                "it": {
+                    "name": "Zomok"
+                },
+                "pl": {
+                    "name": "Zomok"
+                },
+                "pt": {
+                    "name": "Zomok"
+                },
+                "th": {
+                    "name": "Zomok"
+                },
+                "vi": {
+                    "name": "Zomok"
+                },
+                "zhhans": {
+                    "name": "Zomok"
+                },
+                "zhhant": {
                     "name": "Zomok"
                 }
             }
@@ -5338,7 +12418,37 @@
             "power": 16,
             "text": "(Play only with the other half of Zomok.)\nWhile Zomok is attacking, ignore taunt, elusive, poison, hazardous, and invulnerable.\nAfter Fight: Deal 2 to a creature for each forged key.\n",
             "locale": {
+                "de": {
+                    "name": "Zomok"
+                },
                 "en": {
+                    "name": "Zomok"
+                },
+                "es": {
+                    "name": "Zomok"
+                },
+                "fr": {
+                    "name": "Zomok"
+                },
+                "it": {
+                    "name": "Zomok"
+                },
+                "pl": {
+                    "name": "Zomok"
+                },
+                "pt": {
+                    "name": "Zomok"
+                },
+                "th": {
+                    "name": "Zomok"
+                },
+                "vi": {
+                    "name": "Zomok"
+                },
+                "zhhans": {
+                    "name": "Zomok"
+                },
+                "zhhant": {
                     "name": "Zomok"
                 }
             }
@@ -5362,7 +12472,37 @@
             "power": 2,
             "text": "After Fight/After Reap: Shuffle Æmber Airhart into its owner’s deck.\n",
             "locale": {
+                "de": {
+                    "name": "Æmber-Flughart"
+                },
                 "en": {
+                    "name": "Æmber Airhart"
+                },
+                "es": {
+                    "name": "Æmber Airhart"
+                },
+                "fr": {
+                    "name": "Amelia Aombrehart"
+                },
+                "it": {
+                    "name": "Æmber Airhart"
+                },
+                "pl": {
+                    "name": "Æmber Airhart"
+                },
+                "pt": {
+                    "name": "Æmber Airhart"
+                },
+                "th": {
+                    "name": "Æmber Airhart"
+                },
+                "vi": {
+                    "name": "Æmber Airhart"
+                },
+                "zhhans": {
+                    "name": "Æmber Airhart"
+                },
+                "zhhant": {
                     "name": "Æmber Airhart"
                 }
             }
@@ -5386,7 +12526,37 @@
             "power": 3,
             "text": "Entrench.\nAt the start of your turn, if Cabochon is exhausted, gain 1 for each friendly Skyborn flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Cabochon"
+                },
                 "en": {
+                    "name": "Cabochon"
+                },
+                "es": {
+                    "name": "Cabochon"
+                },
+                "fr": {
+                    "name": "Cabochon"
+                },
+                "it": {
+                    "name": "Cabochon"
+                },
+                "pl": {
+                    "name": "Cabochon"
+                },
+                "pt": {
+                    "name": "Cabochon"
+                },
+                "th": {
+                    "name": "Cabochon"
+                },
+                "vi": {
+                    "name": "Cabochon"
+                },
+                "zhhans": {
+                    "name": "Cabochon"
+                },
+                "zhhant": {
                     "name": "Cabochon"
                 }
             }
@@ -5407,7 +12577,37 @@
             "power": null,
             "text": "Play: Move a creature to a flank of its controller’s battleline. Steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Rand der Welt"
+                },
                 "en": {
+                    "name": "Edge of the World"
+                },
+                "es": {
+                    "name": "Edge of the World"
+                },
+                "fr": {
+                    "name": "Bout du Monde"
+                },
+                "it": {
+                    "name": "Edge of the World"
+                },
+                "pl": {
+                    "name": "Edge of the World"
+                },
+                "pt": {
+                    "name": "Edge of the World"
+                },
+                "th": {
+                    "name": "Edge of the World"
+                },
+                "vi": {
+                    "name": "Edge of the World"
+                },
+                "zhhans": {
+                    "name": "Edge of the World"
+                },
+                "zhhant": {
                     "name": "Edge of the World"
                 }
             }
@@ -5428,7 +12628,37 @@
             "power": null,
             "text": "Play: Steal 1 for each ready Skyborn creature in play.\n",
             "locale": {
+                "de": {
+                    "name": "Glutbeutel"
+                },
                 "en": {
+                    "name": "Embered Purse"
+                },
+                "es": {
+                    "name": "Embered Purse"
+                },
+                "fr": {
+                    "name": "Bourse Embrasée"
+                },
+                "it": {
+                    "name": "Embered Purse"
+                },
+                "pl": {
+                    "name": "Embered Purse"
+                },
+                "pt": {
+                    "name": "Embered Purse"
+                },
+                "th": {
+                    "name": "Embered Purse"
+                },
+                "vi": {
+                    "name": "Embered Purse"
+                },
+                "zhhans": {
+                    "name": "Embered Purse"
+                },
+                "zhhant": {
                     "name": "Embered Purse"
                 }
             }
@@ -5449,7 +12679,37 @@
             "power": null,
             "text": "Play: Each friendly flank creature captures 1. If a yellow key is forged, repeat the preceding effect.\n",
             "locale": {
+                "de": {
+                    "name": "Vergoldet sie!"
+                },
                 "en": {
+                    "name": "Gilt ’Em Good"
+                },
+                "es": {
+                    "name": "Gilt ’Em Good"
+                },
+                "fr": {
+                    "name": "Couverts d'Or"
+                },
+                "it": {
+                    "name": "Gilt ’Em Good"
+                },
+                "pl": {
+                    "name": "Gilt ’Em Good"
+                },
+                "pt": {
+                    "name": "Gilt ’Em Good"
+                },
+                "th": {
+                    "name": "Gilt ’Em Good"
+                },
+                "vi": {
+                    "name": "Gilt ’Em Good"
+                },
+                "zhhans": {
+                    "name": "Gilt ’Em Good"
+                },
+                "zhhant": {
                     "name": "Gilt ’Em Good"
                 }
             }
@@ -5470,7 +12730,37 @@
             "power": null,
             "text": "Play: Take control of an enemy flank creature and give it three +1 power counters. While under your control, it belongs to house Skyborn. (Instead of its original house.)\n",
             "locale": {
+                "de": {
+                    "name": "Hannibals Mal"
+                },
                 "en": {
+                    "name": "Hannibal’s Mark"
+                },
+                "es": {
+                    "name": "Hannibal’s Mark"
+                },
+                "fr": {
+                    "name": "Marque d’Hannibal"
+                },
+                "it": {
+                    "name": "Hannibal’s Mark"
+                },
+                "pl": {
+                    "name": "Hannibal’s Mark"
+                },
+                "pt": {
+                    "name": "Hannibal’s Mark"
+                },
+                "th": {
+                    "name": "Hannibal’s Mark"
+                },
+                "vi": {
+                    "name": "Hannibal’s Mark"
+                },
+                "zhhans": {
+                    "name": "Hannibal’s Mark"
+                },
+                "zhhant": {
                     "name": "Hannibal’s Mark"
                 }
             }
@@ -5493,7 +12783,37 @@
             "power": 3,
             "text": "After Reap: If Navigator Ketarr is on a flank, draw 2 cards and archive a card.\n",
             "locale": {
+                "de": {
+                    "name": "Navigator Ketarr"
+                },
                 "en": {
+                    "name": "Navigator Ketarr"
+                },
+                "es": {
+                    "name": "Navigator Ketarr"
+                },
+                "fr": {
+                    "name": "Navigateur Ketarr"
+                },
+                "it": {
+                    "name": "Navigator Ketarr"
+                },
+                "pl": {
+                    "name": "Navigator Ketarr"
+                },
+                "pt": {
+                    "name": "Navigator Ketarr"
+                },
+                "th": {
+                    "name": "Navigator Ketarr"
+                },
+                "vi": {
+                    "name": "Navigator Ketarr"
+                },
+                "zhhans": {
+                    "name": "Navigator Ketarr"
+                },
+                "zhhant": {
                     "name": "Navigator Ketarr"
                 }
             }
@@ -5518,7 +12838,37 @@
             "power": 6,
             "text": "Taunt.\nAfter Fight: You may move Pirate Champion to a flank.\n",
             "locale": {
+                "de": {
+                    "name": "Piratenmeister"
+                },
                 "en": {
+                    "name": "Pirate Champion"
+                },
+                "es": {
+                    "name": "Pirate Champion"
+                },
+                "fr": {
+                    "name": "Champion Pirate"
+                },
+                "it": {
+                    "name": "Pirate Champion"
+                },
+                "pl": {
+                    "name": "Pirate Champion"
+                },
+                "pt": {
+                    "name": "Pirate Champion"
+                },
+                "th": {
+                    "name": "Pirate Champion"
+                },
+                "vi": {
+                    "name": "Pirate Champion"
+                },
+                "zhhans": {
+                    "name": "Pirate Champion"
+                },
+                "zhhant": {
                     "name": "Pirate Champion"
                 }
             }
@@ -5539,7 +12889,37 @@
             "power": null,
             "text": "Play: Move a friendly Skyborn creature to a flank and ready it. If a red key is forged, repeat the preceding effect.\n",
             "locale": {
+                "de": {
+                    "name": "Abendrot"
+                },
                 "en": {
+                    "name": "Red Skies"
+                },
+                "es": {
+                    "name": "Red Skies"
+                },
+                "fr": {
+                    "name": "Ciels Rouges"
+                },
+                "it": {
+                    "name": "Red Skies"
+                },
+                "pl": {
+                    "name": "Red Skies"
+                },
+                "pt": {
+                    "name": "Red Skies"
+                },
+                "th": {
+                    "name": "Red Skies"
+                },
+                "vi": {
+                    "name": "Red Skies"
+                },
+                "zhhans": {
+                    "name": "Red Skies"
+                },
+                "zhhant": {
                     "name": "Red Skies"
                 }
             }
@@ -5560,7 +12940,37 @@
             "power": null,
             "text": "Play: Gain 1 for each house represented among friendly flank creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Silberstreifen"
+                },
                 "en": {
+                    "name": "Silver Linings"
+                },
+                "es": {
+                    "name": "Silver Linings"
+                },
+                "fr": {
+                    "name": "Lueur d’Espoir"
+                },
+                "it": {
+                    "name": "Silver Linings"
+                },
+                "pl": {
+                    "name": "Silver Linings"
+                },
+                "pt": {
+                    "name": "Silver Linings"
+                },
+                "th": {
+                    "name": "Silver Linings"
+                },
+                "vi": {
+                    "name": "Silver Linings"
+                },
+                "zhhans": {
+                    "name": "Silver Linings"
+                },
+                "zhhant": {
                     "name": "Silver Linings"
                 }
             }
@@ -5584,7 +12994,37 @@
             "power": 5,
             "text": "If your red key is forged, Sir Lorcas gains skirmish. \nIf your yellow key is forged, Sir Lorcas gains elusive. \nIf your blue key is forged, Sir Lorcas gains taunt.\n",
             "locale": {
+                "de": {
+                    "name": "Sir Lorcas"
+                },
                 "en": {
+                    "name": "Sir Lorcas"
+                },
+                "es": {
+                    "name": "Sir Lorcas"
+                },
+                "fr": {
+                    "name": "Sire Lorcas"
+                },
+                "it": {
+                    "name": "Sir Lorcas"
+                },
+                "pl": {
+                    "name": "Sir Lorcas"
+                },
+                "pt": {
+                    "name": "Sir Lorcas"
+                },
+                "th": {
+                    "name": "Sir Lorcas"
+                },
+                "vi": {
+                    "name": "Sir Lorcas"
+                },
+                "zhhans": {
+                    "name": "Sir Lorcas"
+                },
+                "zhhant": {
                     "name": "Sir Lorcas"
                 }
             }
@@ -5608,7 +13048,37 @@
             "power": 4,
             "text": "After Reap: If a blue key is forged, draw 2 cards. Otherwise, draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Tur-bo-prop"
+                },
                 "en": {
+                    "name": "Tur-bo-prop"
+                },
+                "es": {
+                    "name": "Tur-bo-prop"
+                },
+                "fr": {
+                    "name": "Tur-bo-prop"
+                },
+                "it": {
+                    "name": "Tur-bo-prop"
+                },
+                "pl": {
+                    "name": "Tur-bo-prop"
+                },
+                "pt": {
+                    "name": "Tur-bo-prop"
+                },
+                "th": {
+                    "name": "Tur-bo-prop"
+                },
+                "vi": {
+                    "name": "Tur-bo-prop"
+                },
+                "zhhans": {
+                    "name": "Tur-bo-prop"
+                },
+                "zhhant": {
                     "name": "Tur-bo-prop"
                 }
             }
@@ -5632,7 +13102,37 @@
             "power": 3,
             "text": "After your opponent discards a card from their hand, gain 1.\n",
             "locale": {
+                "de": {
+                    "name": "Ty Lourd"
+                },
                 "en": {
+                    "name": "Ty Lourd"
+                },
+                "es": {
+                    "name": "Ty Lourd"
+                },
+                "fr": {
+                    "name": "Ty Lourd"
+                },
+                "it": {
+                    "name": "Ty Lourd"
+                },
+                "pl": {
+                    "name": "Ty Lourd"
+                },
+                "pt": {
+                    "name": "Ty Lourd"
+                },
+                "th": {
+                    "name": "Ty Lourd"
+                },
+                "vi": {
+                    "name": "Ty Lourd"
+                },
+                "zhhans": {
+                    "name": "Ty Lourd"
+                },
+                "zhhant": {
                     "name": "Ty Lourd"
                 }
             }
@@ -5653,7 +13153,37 @@
             "power": null,
             "text": "Play: Steal 2 if any flank creature shares a house with another flank creature. Otherwise, steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Gegen alle Flaggen"
+                },
                 "en": {
+                    "name": "Against All Flags"
+                },
+                "es": {
+                    "name": "Against All Flags"
+                },
+                "fr": {
+                    "name": "À l’Abordage !"
+                },
+                "it": {
+                    "name": "Against All Flags"
+                },
+                "pl": {
+                    "name": "Against All Flags"
+                },
+                "pt": {
+                    "name": "Against All Flags"
+                },
+                "th": {
+                    "name": "Against All Flags"
+                },
+                "vi": {
+                    "name": "Against All Flags"
+                },
+                "zhhans": {
+                    "name": "Against All Flags"
+                },
+                "zhhant": {
                     "name": "Against All Flags"
                 }
             }
@@ -5674,7 +13204,37 @@
             "power": null,
             "text": "Play: Move a creature to a flank of its controller’s battleline and exhaust it.\n",
             "locale": {
+                "de": {
+                    "name": "Fassrolle"
+                },
                 "en": {
+                    "name": "Barrel Roll"
+                },
+                "es": {
+                    "name": "Barrel Roll"
+                },
+                "fr": {
+                    "name": "Tonneau"
+                },
+                "it": {
+                    "name": "Barrel Roll"
+                },
+                "pl": {
+                    "name": "Barrel Roll"
+                },
+                "pt": {
+                    "name": "Barrel Roll"
+                },
+                "th": {
+                    "name": "Barrel Roll"
+                },
+                "vi": {
+                    "name": "Barrel Roll"
+                },
+                "zhhans": {
+                    "name": "Barrel Roll"
+                },
+                "zhhant": {
                     "name": "Barrel Roll"
                 }
             }
@@ -5697,7 +13257,37 @@
             "power": 2,
             "text": "Enhance .\nAfter Fight/After Reap: Put a +1 power counter on each friendly flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Blutschwinge"
+                },
                 "en": {
+                    "name": "Bloodwing"
+                },
+                "es": {
+                    "name": "Bloodwing"
+                },
+                "fr": {
+                    "name": "Piruche"
+                },
+                "it": {
+                    "name": "Bloodwing"
+                },
+                "pl": {
+                    "name": "Bloodwing"
+                },
+                "pt": {
+                    "name": "Bloodwing"
+                },
+                "th": {
+                    "name": "Bloodwing"
+                },
+                "vi": {
+                    "name": "Bloodwing"
+                },
+                "zhhans": {
+                    "name": "Bloodwing"
+                },
+                "zhhant": {
                     "name": "Bloodwing"
                 }
             }
@@ -5718,7 +13308,37 @@
             "power": null,
             "text": "Play: If you are overwhelmed, put an enemy creature on the bottom of its owner’s deck. Otherwise, move an enemy creature to a flank of its controller’s battleline and exhaust it.\n",
             "locale": {
+                "de": {
+                    "name": "Eiskalte Fesseln"
+                },
                 "en": {
+                    "name": "Cold Ropes"
+                },
+                "es": {
+                    "name": "Cold Ropes"
+                },
+                "fr": {
+                    "name": "Coup de Froid"
+                },
+                "it": {
+                    "name": "Cold Ropes"
+                },
+                "pl": {
+                    "name": "Cold Ropes"
+                },
+                "pt": {
+                    "name": "Cold Ropes"
+                },
+                "th": {
+                    "name": "Cold Ropes"
+                },
+                "vi": {
+                    "name": "Cold Ropes"
+                },
+                "zhhans": {
+                    "name": "Cold Ropes"
+                },
+                "zhhant": {
                     "name": "Cold Ropes"
                 }
             }
@@ -5742,7 +13362,37 @@
             "power": 4,
             "text": "After Fight: Steal 1. If a blue key is forged, ward Deep Blue Bryn.\n",
             "locale": {
+                "de": {
+                    "name": "Tief Blauer Bryn"
+                },
                 "en": {
+                    "name": "Deep Blue Bryn"
+                },
+                "es": {
+                    "name": "Deep Blue Bryn"
+                },
+                "fr": {
+                    "name": "Bryn Barbacier"
+                },
+                "it": {
+                    "name": "Deep Blue Bryn"
+                },
+                "pl": {
+                    "name": "Deep Blue Bryn"
+                },
+                "pt": {
+                    "name": "Deep Blue Bryn"
+                },
+                "th": {
+                    "name": "Deep Blue Bryn"
+                },
+                "vi": {
+                    "name": "Deep Blue Bryn"
+                },
+                "zhhans": {
+                    "name": "Deep Blue Bryn"
+                },
+                "zhhant": {
                     "name": "Deep Blue Bryn"
                 }
             }
@@ -5766,7 +13416,37 @@
             "power": 4,
             "text": "After Reap: If Jeen Peary is on a flank, steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Jeen Peary"
+                },
                 "en": {
+                    "name": "Jeen Peary"
+                },
+                "es": {
+                    "name": "Jeen Peary"
+                },
+                "fr": {
+                    "name": "Jeanne Peary"
+                },
+                "it": {
+                    "name": "Jeen Peary"
+                },
+                "pl": {
+                    "name": "Jeen Peary"
+                },
+                "pt": {
+                    "name": "Jeen Peary"
+                },
+                "th": {
+                    "name": "Jeen Peary"
+                },
+                "vi": {
+                    "name": "Jeen Peary"
+                },
+                "zhhans": {
+                    "name": "Jeen Peary"
+                },
+                "zhhant": {
                     "name": "Jeen Peary"
                 }
             }
@@ -5787,7 +13467,37 @@
             "power": null,
             "text": "Play: Ready and use a friendly flank creature. If you are overwhelmed, repeat the preceding effect.\n",
             "locale": {
+                "de": {
+                    "name": "Starthilfe"
+                },
                 "en": {
+                    "name": "Jump Start"
+                },
+                "es": {
+                    "name": "Jump Start"
+                },
+                "fr": {
+                    "name": "Catapultage"
+                },
+                "it": {
+                    "name": "Jump Start"
+                },
+                "pl": {
+                    "name": "Jump Start"
+                },
+                "pt": {
+                    "name": "Jump Start"
+                },
+                "th": {
+                    "name": "Jump Start"
+                },
+                "vi": {
+                    "name": "Jump Start"
+                },
+                "zhhans": {
+                    "name": "Jump Start"
+                },
+                "zhhant": {
                     "name": "Jump Start"
                 }
             }
@@ -5811,7 +13521,37 @@
             "power": 5,
             "text": "After Fight: If you are overwhelmed, steal 2. Otherwise capture 1.\n",
             "locale": {
+                "de": {
+                    "name": "Leutnant Chars"
+                },
                 "en": {
+                    "name": "Leftenant Chars"
+                },
+                "es": {
+                    "name": "Leftenant Chars"
+                },
+                "fr": {
+                    "name": "Lieutenant Charles"
+                },
+                "it": {
+                    "name": "Leftenant Chars"
+                },
+                "pl": {
+                    "name": "Leftenant Chars"
+                },
+                "pt": {
+                    "name": "Leftenant Chars"
+                },
+                "th": {
+                    "name": "Leftenant Chars"
+                },
+                "vi": {
+                    "name": "Leftenant Chars"
+                },
+                "zhhans": {
+                    "name": "Leftenant Chars"
+                },
+                "zhhant": {
                     "name": "Leftenant Chars"
                 }
             }
@@ -5832,7 +13572,37 @@
             "power": null,
             "text": "Play: Destroy an enemy flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Die Propeller abstauben"
+                },
                 "en": {
+                    "name": "Prop Dusting"
+                },
+                "es": {
+                    "name": "Prop Dusting"
+                },
+                "fr": {
+                    "name": "Dépoussiérer les Hélices"
+                },
+                "it": {
+                    "name": "Prop Dusting"
+                },
+                "pl": {
+                    "name": "Prop Dusting"
+                },
+                "pt": {
+                    "name": "Prop Dusting"
+                },
+                "th": {
+                    "name": "Prop Dusting"
+                },
+                "vi": {
+                    "name": "Prop Dusting"
+                },
+                "zhhans": {
+                    "name": "Prop Dusting"
+                },
+                "zhhant": {
                     "name": "Prop Dusting"
                 }
             }
@@ -5856,7 +13626,37 @@
             "power": 3,
             "text": "Entrench.\nWhile Remmi Hound is exhausted, each friendly flank creature gets +4 power.\n\n",
             "locale": {
+                "de": {
+                    "name": "Remmi-Hund"
+                },
                 "en": {
+                    "name": "Remmi Hound"
+                },
+                "es": {
+                    "name": "Remmi Hound"
+                },
+                "fr": {
+                    "name": "Rémi le Limier"
+                },
+                "it": {
+                    "name": "Remmi Hound"
+                },
+                "pl": {
+                    "name": "Remmi Hound"
+                },
+                "pt": {
+                    "name": "Remmi Hound"
+                },
+                "th": {
+                    "name": "Remmi Hound"
+                },
+                "vi": {
+                    "name": "Remmi Hound"
+                },
+                "zhhans": {
+                    "name": "Remmi Hound"
+                },
+                "zhhant": {
                     "name": "Remmi Hound"
                 }
             }
@@ -5880,7 +13680,37 @@
             "power": 3,
             "text": "After Fight: If a red key is forged, deal 4 to each enemy flank creature. Otherwise, deal 1 to each enemy flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Ruby Rackham"
+                },
                 "en": {
+                    "name": "Ruby Rackham"
+                },
+                "es": {
+                    "name": "Ruby Rackham"
+                },
+                "fr": {
+                    "name": "Rackham la Rouge"
+                },
+                "it": {
+                    "name": "Ruby Rackham"
+                },
+                "pl": {
+                    "name": "Ruby Rackham"
+                },
+                "pt": {
+                    "name": "Ruby Rackham"
+                },
+                "th": {
+                    "name": "Ruby Rackham"
+                },
+                "vi": {
+                    "name": "Ruby Rackham"
+                },
+                "zhhans": {
+                    "name": "Ruby Rackham"
+                },
+                "zhhant": {
                     "name": "Ruby Rackham"
                 }
             }
@@ -5905,7 +13735,37 @@
             "power": 2,
             "text": "Elusive.\nAfter Reap: If your red key is forged, destroy an enemy creature. If your yellow key is forged, destroy an enemy artifact. If your blue key is forged, destroy an enemy upgrade.\n",
             "locale": {
+                "de": {
+                    "name": "Schleichende Saboteure"
+                },
                 "en": {
+                    "name": "Skulking Saboteurs"
+                },
+                "es": {
+                    "name": "Skulking Saboteurs"
+                },
+                "fr": {
+                    "name": "Saboteurs Inventifs"
+                },
+                "it": {
+                    "name": "Skulking Saboteurs"
+                },
+                "pl": {
+                    "name": "Skulking Saboteurs"
+                },
+                "pt": {
+                    "name": "Skulking Saboteurs"
+                },
+                "th": {
+                    "name": "Skulking Saboteurs"
+                },
+                "vi": {
+                    "name": "Skulking Saboteurs"
+                },
+                "zhhans": {
+                    "name": "Skulking Saboteurs"
+                },
+                "zhhant": {
                     "name": "Skulking Saboteurs"
                 }
             }
@@ -5928,7 +13788,37 @@
             "power": null,
             "text": "After a creature fights, it doesn’t ready during the “ready cards” step this turn.\n",
             "locale": {
+                "de": {
+                    "name": "Brackwasserküste"
+                },
                 "en": {
+                    "name": "Brackish Shoreline"
+                },
+                "es": {
+                    "name": "Brackish Shoreline"
+                },
+                "fr": {
+                    "name": "Rivage Saumâtre"
+                },
+                "it": {
+                    "name": "Brackish Shoreline"
+                },
+                "pl": {
+                    "name": "Brackish Shoreline"
+                },
+                "pt": {
+                    "name": "Brackish Shoreline"
+                },
+                "th": {
+                    "name": "Brackish Shoreline"
+                },
+                "vi": {
+                    "name": "Brackish Shoreline"
+                },
+                "zhhans": {
+                    "name": "Brackish Shoreline"
+                },
+                "zhhant": {
                     "name": "Brackish Shoreline"
                 }
             }
@@ -5949,7 +13839,37 @@
             "power": null,
             "text": "Play: Choose one:\nDestroy an artifact.\nDestroy an upgrade.\nDestroy a creature with armor.\n",
             "locale": {
+                "de": {
+                    "name": "Rosten"
+                },
                 "en": {
+                    "name": "Corrode"
+                },
+                "es": {
+                    "name": "Corrode"
+                },
+                "fr": {
+                    "name": "Corroder"
+                },
+                "it": {
+                    "name": "Corrode"
+                },
+                "pl": {
+                    "name": "Corrode"
+                },
+                "pt": {
+                    "name": "Corrode"
+                },
+                "th": {
+                    "name": "Corrode"
+                },
+                "vi": {
+                    "name": "Corrode"
+                },
+                "zhhans": {
+                    "name": "Corrode"
+                },
+                "zhhant": {
                     "name": "Corrode"
                 }
             }
@@ -5970,7 +13890,37 @@
             "power": null,
             "text": "Play: Exhaust a creature and each of its neighbors. Stun 2 exhausted creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Benommen und verwirrt"
+                },
                 "en": {
+                    "name": "Dazed and Confused"
+                },
+                "es": {
+                    "name": "Dazed and Confused"
+                },
+                "fr": {
+                    "name": "Confus et Perdus"
+                },
+                "it": {
+                    "name": "Dazed and Confused"
+                },
+                "pl": {
+                    "name": "Dazed and Confused"
+                },
+                "pt": {
+                    "name": "Dazed and Confused"
+                },
+                "th": {
+                    "name": "Dazed and Confused"
+                },
+                "vi": {
+                    "name": "Dazed and Confused"
+                },
+                "zhhans": {
+                    "name": "Dazed and Confused"
+                },
+                "zhhant": {
                     "name": "Dazed and Confused"
                 }
             }
@@ -5993,7 +13943,37 @@
             "power": 5,
             "text": "After you play an Aquan creature, exhaust an enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Tiefenpriester Glebe"
+                },
                 "en": {
+                    "name": "Deep Priest Glebe"
+                },
+                "es": {
+                    "name": "Deep Priest Glebe"
+                },
+                "fr": {
+                    "name": "Prêtre des Profondeurs Glebe"
+                },
+                "it": {
+                    "name": "Deep Priest Glebe"
+                },
+                "pl": {
+                    "name": "Deep Priest Glebe"
+                },
+                "pt": {
+                    "name": "Deep Priest Glebe"
+                },
+                "th": {
+                    "name": "Deep Priest Glebe"
+                },
+                "vi": {
+                    "name": "Deep Priest Glebe"
+                },
+                "zhhans": {
+                    "name": "Deep Priest Glebe"
+                },
+                "zhhant": {
                     "name": "Deep Priest Glebe"
                 }
             }
@@ -6014,7 +13994,37 @@
             "power": null,
             "text": "Play: For the remainder of the turn, after you play another card, exhaust a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Blitzeis"
+                },
                 "en": {
+                    "name": "Flash Freeze"
+                },
+                "es": {
+                    "name": "Flash Freeze"
+                },
+                "fr": {
+                    "name": "Gel Éclair"
+                },
+                "it": {
+                    "name": "Flash Freeze"
+                },
+                "pl": {
+                    "name": "Flash Freeze"
+                },
+                "pt": {
+                    "name": "Flash Freeze"
+                },
+                "th": {
+                    "name": "Flash Freeze"
+                },
+                "vi": {
+                    "name": "Flash Freeze"
+                },
+                "zhhans": {
+                    "name": "Flash Freeze"
+                },
+                "zhhant": {
                     "name": "Flash Freeze"
                 }
             }
@@ -6035,7 +14045,37 @@
             "power": null,
             "text": "",
             "locale": {
+                "de": {
+                    "name": "Hydrogan"
+                },
                 "en": {
+                    "name": "Hydrogan"
+                },
+                "es": {
+                    "name": "Hydrogan"
+                },
+                "fr": {
+                    "name": "Hydrogand"
+                },
+                "it": {
+                    "name": "Hydrogan"
+                },
+                "pl": {
+                    "name": "Hydrogan"
+                },
+                "pt": {
+                    "name": "Hydrogan"
+                },
+                "th": {
+                    "name": "Hydrogan"
+                },
+                "vi": {
+                    "name": "Hydrogan"
+                },
+                "zhhans": {
+                    "name": "Hydrogan"
+                },
+                "zhhant": {
                     "name": "Hydrogan"
                 }
             }
@@ -6059,7 +14099,37 @@
             "power": 10,
             "text": "(Play only with the other half of Hydrogan.)\nPlay: Put each other creature faceup under Hydrogan.\nAfter Fight/After Reap: Put a creature from under Hydrogan into play under your control.\nDestroyed: Purge each card under Hydrogan.\n",
             "locale": {
+                "de": {
+                    "name": "Hydrogan"
+                },
                 "en": {
+                    "name": "Hydrogan"
+                },
+                "es": {
+                    "name": "Hydrogan"
+                },
+                "fr": {
+                    "name": "Hydrogand"
+                },
+                "it": {
+                    "name": "Hydrogan"
+                },
+                "pl": {
+                    "name": "Hydrogan"
+                },
+                "pt": {
+                    "name": "Hydrogan"
+                },
+                "th": {
+                    "name": "Hydrogan"
+                },
+                "vi": {
+                    "name": "Hydrogan"
+                },
+                "zhhans": {
+                    "name": "Hydrogan"
+                },
+                "zhhant": {
                     "name": "Hydrogan"
                 }
             }
@@ -6080,7 +14150,37 @@
             "power": null,
             "text": "Play: Look at your opponent’s hand. Play a card from that hand as if it were yours.\n",
             "locale": {
+                "de": {
+                    "name": "Lateralverschiebung"
+                },
                 "en": {
+                    "name": "Lateral Shift"
+                },
+                "es": {
+                    "name": "Lateral Shift"
+                },
+                "fr": {
+                    "name": "Décalage Latéral"
+                },
+                "it": {
+                    "name": "Lateral Shift"
+                },
+                "pl": {
+                    "name": "Lateral Shift"
+                },
+                "pt": {
+                    "name": "Lateral Shift"
+                },
+                "th": {
+                    "name": "Lateral Shift"
+                },
+                "vi": {
+                    "name": "Lateral Shift"
+                },
+                "zhhans": {
+                    "name": "Lateral Shift"
+                },
+                "zhhant": {
                     "name": "Lateral Shift"
                 }
             }
@@ -6101,7 +14201,37 @@
             "power": null,
             "text": "Play: Reveal a random unrevealed card from your opponent’s hand. Then, you may either repeat this effect or your opponent discards the last revealed card.",
             "locale": {
+                "de": {
+                    "name": "Plünderung"
+                },
                 "en": {
+                    "name": "Plunder"
+                },
+                "es": {
+                    "name": "Plunder"
+                },
+                "fr": {
+                    "name": "Pillage"
+                },
+                "it": {
+                    "name": "Plunder"
+                },
+                "pl": {
+                    "name": "Plunder"
+                },
+                "pt": {
+                    "name": "Plunder"
+                },
+                "th": {
+                    "name": "Plunder"
+                },
+                "vi": {
+                    "name": "Plunder"
+                },
+                "zhhans": {
+                    "name": "Plunder"
+                },
+                "zhhant": {
                     "name": "Plunder"
                 }
             }
@@ -6122,7 +14252,37 @@
             "power": null,
             "text": "Play: Exhaust a creature. Draw a card for each exhausted creature. Destroy each exhausted creature.\n",
             "locale": {
+                "de": {
+                    "name": "Sand ins Auge"
+                },
                 "en": {
+                    "name": "Sand In Your Eye"
+                },
+                "es": {
+                    "name": "Sand In Your Eye"
+                },
+                "fr": {
+                    "name": "Du Sable dans l'Œil"
+                },
+                "it": {
+                    "name": "Sand In Your Eye"
+                },
+                "pl": {
+                    "name": "Sand In Your Eye"
+                },
+                "pt": {
+                    "name": "Sand In Your Eye"
+                },
+                "th": {
+                    "name": "Sand In Your Eye"
+                },
+                "vi": {
+                    "name": "Sand In Your Eye"
+                },
+                "zhhans": {
+                    "name": "Sand In Your Eye"
+                },
+                "zhhant": {
                     "name": "Sand In Your Eye"
                 }
             }
@@ -6145,7 +14305,37 @@
             "power": 5,
             "text": "At the start of your opponent’s turn, that player discards the top card of their deck and exhausts each creature of that card’s house.\n",
             "locale": {
+                "de": {
+                    "name": "Sibyl Waimare"
+                },
                 "en": {
+                    "name": "Sibyl Waimare"
+                },
+                "es": {
+                    "name": "Sibyl Waimare"
+                },
+                "fr": {
+                    "name": "Sybille Waimare"
+                },
+                "it": {
+                    "name": "Sibyl Waimare"
+                },
+                "pl": {
+                    "name": "Sibyl Waimare"
+                },
+                "pt": {
+                    "name": "Sibyl Waimare"
+                },
+                "th": {
+                    "name": "Sibyl Waimare"
+                },
+                "vi": {
+                    "name": "Sibyl Waimare"
+                },
+                "zhhans": {
+                    "name": "Sibyl Waimare"
+                },
+                "zhhant": {
                     "name": "Sibyl Waimare"
                 }
             }
@@ -6166,7 +14356,37 @@
             "power": null,
             "text": "Enhance .\nThis creature gains, “At the start of your turn, if this creature is exhausted, purge another creature that shares a house with it.”\n",
             "locale": {
+                "de": {
+                    "name": "Sternenmal"
+                },
                 "en": {
+                    "name": "Starpatch"
+                },
+                "es": {
+                    "name": "Starpatch"
+                },
+                "fr": {
+                    "name": "Souffre-Chef"
+                },
+                "it": {
+                    "name": "Starpatch"
+                },
+                "pl": {
+                    "name": "Starpatch"
+                },
+                "pt": {
+                    "name": "Starpatch"
+                },
+                "th": {
+                    "name": "Starpatch"
+                },
+                "vi": {
+                    "name": "Starpatch"
+                },
+                "zhhans": {
+                    "name": "Starpatch"
+                },
+                "zhhant": {
                     "name": "Starpatch"
                 }
             }
@@ -6187,7 +14407,37 @@
             "power": null,
             "text": "Play: Discard the top 10 cards of your opponent’s deck.",
             "locale": {
+                "de": {
+                    "name": "Thalassophobie"
+                },
                 "en": {
+                    "name": "Thalassophobia"
+                },
+                "es": {
+                    "name": "Thalassophobia"
+                },
+                "fr": {
+                    "name": "Thalassophobie"
+                },
+                "it": {
+                    "name": "Thalassophobia"
+                },
+                "pl": {
+                    "name": "Thalassophobia"
+                },
+                "pt": {
+                    "name": "Thalassophobia"
+                },
+                "th": {
+                    "name": "Thalassophobia"
+                },
+                "vi": {
+                    "name": "Thalassophobia"
+                },
+                "zhhans": {
+                    "name": "Thalassophobia"
+                },
+                "zhhant": {
                     "name": "Thalassophobia"
                 }
             }
@@ -6210,7 +14460,37 @@
             "power": 9,
             "text": "Instead of readying creatures they control during their “ready cards” step, your opponent deals 1 to The Chosen One for each exhausted creature they control.",
             "locale": {
+                "de": {
+                    "name": "Der Auserwählte"
+                },
                 "en": {
+                    "name": "The Chosen One"
+                },
+                "es": {
+                    "name": "The Chosen One"
+                },
+                "fr": {
+                    "name": "L’Élu"
+                },
+                "it": {
+                    "name": "The Chosen One"
+                },
+                "pl": {
+                    "name": "The Chosen One"
+                },
+                "pt": {
+                    "name": "The Chosen One"
+                },
+                "th": {
+                    "name": "The Chosen One"
+                },
+                "vi": {
+                    "name": "The Chosen One"
+                },
+                "zhhans": {
+                    "name": "The Chosen One"
+                },
+                "zhhant": {
                     "name": "The Chosen One"
                 }
             }
@@ -6233,7 +14513,37 @@
             "power": 30,
             "text": "Thing from the Deep cannot be played unless Open the Seal is in your discard pile.\nAfter Fight: Steal 2.\n",
             "locale": {
+                "de": {
+                    "name": "Das Ding aus der Tiefe"
+                },
                 "en": {
+                    "name": "Thing from the Deep"
+                },
+                "es": {
+                    "name": "Thing from the Deep"
+                },
+                "fr": {
+                    "name": "Chose des Profondeurs"
+                },
+                "it": {
+                    "name": "Thing from the Deep"
+                },
+                "pl": {
+                    "name": "Thing from the Deep"
+                },
+                "pt": {
+                    "name": "Thing from the Deep"
+                },
+                "th": {
+                    "name": "Thing from the Deep"
+                },
+                "vi": {
+                    "name": "Thing from the Deep"
+                },
+                "zhhans": {
+                    "name": "Thing from the Deep"
+                },
+                "zhhant": {
                     "name": "Thing from the Deep"
                 }
             }
@@ -6254,7 +14564,37 @@
             "power": null,
             "text": "This creature gains, “While this creature is exhausted, your keys cost +6.”\n",
             "locale": {
+                "de": {
+                    "name": "Schwachstelle"
+                },
                 "en": {
+                    "name": "Weak Link"
+                },
+                "es": {
+                    "name": "Weak Link"
+                },
+                "fr": {
+                    "name": "Maillon Faible"
+                },
+                "it": {
+                    "name": "Weak Link"
+                },
+                "pl": {
+                    "name": "Weak Link"
+                },
+                "pt": {
+                    "name": "Weak Link"
+                },
+                "th": {
+                    "name": "Weak Link"
+                },
+                "vi": {
+                    "name": "Weak Link"
+                },
+                "zhhans": {
+                    "name": "Weak Link"
+                },
+                "zhhant": {
                     "name": "Weak Link"
                 }
             }
@@ -6277,7 +14617,37 @@
             "power": 5,
             "text": "After Fight: Your opponent discards\n2 random cards from their hand.\n",
             "locale": {
+                "de": {
+                    "name": "Verderbensfisch"
+                },
                 "en": {
+                    "name": "Addlefish"
+                },
+                "es": {
+                    "name": "Addlefish"
+                },
+                "fr": {
+                    "name": "Poisson Iridescent"
+                },
+                "it": {
+                    "name": "Addlefish"
+                },
+                "pl": {
+                    "name": "Addlefish"
+                },
+                "pt": {
+                    "name": "Addlefish"
+                },
+                "th": {
+                    "name": "Addlefish"
+                },
+                "vi": {
+                    "name": "Addlefish"
+                },
+                "zhhans": {
+                    "name": "Addlefish"
+                },
+                "zhhant": {
                     "name": "Addlefish"
                 }
             }
@@ -6298,7 +14668,37 @@
             "power": null,
             "text": "Play: Choose a house on your opponent’s identity card. If your opponent does not choose that house as their active house on their next turn, gain 3.",
             "locale": {
+                "de": {
+                    "name": "Dezenter Größenwahn"
+                },
                 "en": {
+                    "name": "Allusions of Grandeur"
+                },
+                "es": {
+                    "name": "Allusions of Grandeur"
+                },
+                "fr": {
+                    "name": "Allusions de Grandeur"
+                },
+                "it": {
+                    "name": "Allusions of Grandeur"
+                },
+                "pl": {
+                    "name": "Allusions of Grandeur"
+                },
+                "pt": {
+                    "name": "Allusions of Grandeur"
+                },
+                "th": {
+                    "name": "Allusions of Grandeur"
+                },
+                "vi": {
+                    "name": "Allusions of Grandeur"
+                },
+                "zhhans": {
+                    "name": "Allusions of Grandeur"
+                },
+                "zhhant": {
                     "name": "Allusions of Grandeur"
                 }
             }
@@ -6321,7 +14721,37 @@
             "power": null,
             "text": "Action: Put a friendly creature on the bottom of its owner’s deck. If you do, exhaust 3 enemy creatures.",
             "locale": {
+                "de": {
+                    "name": "Azur-Becken-Außenposten"
+                },
                 "en": {
+                    "name": "Azure Basin Outpost"
+                },
+                "es": {
+                    "name": "Azure Basin Outpost"
+                },
+                "fr": {
+                    "name": "Avant-Poste Azuréen"
+                },
+                "it": {
+                    "name": "Azure Basin Outpost"
+                },
+                "pl": {
+                    "name": "Azure Basin Outpost"
+                },
+                "pt": {
+                    "name": "Azure Basin Outpost"
+                },
+                "th": {
+                    "name": "Azure Basin Outpost"
+                },
+                "vi": {
+                    "name": "Azure Basin Outpost"
+                },
+                "zhhans": {
+                    "name": "Azure Basin Outpost"
+                },
+                "zhhant": {
                     "name": "Azure Basin Outpost"
                 }
             }
@@ -6342,7 +14772,37 @@
             "power": null,
             "text": "Play: Return each creature to its owner’s hand. Each player discards random cards from their hand until they have 6 or fewer cards in hand. Gain 2 chains.",
             "locale": {
+                "de": {
+                    "name": "Fangen und Freilassen"
+                },
                 "en": {
+                    "name": "Catch and Release"
+                },
+                "es": {
+                    "name": "Catch and Release"
+                },
+                "fr": {
+                    "name": "Attrapé-Relâché"
+                },
+                "it": {
+                    "name": "Catch and Release"
+                },
+                "pl": {
+                    "name": "Catch and Release"
+                },
+                "pt": {
+                    "name": "Catch and Release"
+                },
+                "th": {
+                    "name": "Catch and Release"
+                },
+                "vi": {
+                    "name": "Catch and Release"
+                },
+                "zhhans": {
+                    "name": "Catch and Release"
+                },
+                "zhhant": {
                     "name": "Catch and Release"
                 }
             }
@@ -6363,7 +14823,37 @@
             "power": null,
             "text": "Play: Exhaust a creature. For each copy of Dreamcall in your discard pile, exhaust another creature and draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Traumruf"
+                },
                 "en": {
+                    "name": "Dreamcall"
+                },
+                "es": {
+                    "name": "Dreamcall"
+                },
+                "fr": {
+                    "name": "Chant des Sirènes"
+                },
+                "it": {
+                    "name": "Dreamcall"
+                },
+                "pl": {
+                    "name": "Dreamcall"
+                },
+                "pt": {
+                    "name": "Dreamcall"
+                },
+                "th": {
+                    "name": "Dreamcall"
+                },
+                "vi": {
+                    "name": "Dreamcall"
+                },
+                "zhhans": {
+                    "name": "Dreamcall"
+                },
+                "zhhant": {
                     "name": "Dreamcall"
                 }
             }
@@ -6384,7 +14874,37 @@
             "power": null,
             "text": "Play: Capture half of your opponent’s  (rounding down), distributed among any number of friendly creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Tiefenteilung"
+                },
                 "en": {
+                    "name": "Fathomshare"
+                },
+                "es": {
+                    "name": "Fathomshare"
+                },
+                "fr": {
+                    "name": "Partage Sous le Rivage"
+                },
+                "it": {
+                    "name": "Fathomshare"
+                },
+                "pl": {
+                    "name": "Fathomshare"
+                },
+                "pt": {
+                    "name": "Fathomshare"
+                },
+                "th": {
+                    "name": "Fathomshare"
+                },
+                "vi": {
+                    "name": "Fathomshare"
+                },
+                "zhhans": {
+                    "name": "Fathomshare"
+                },
+                "zhhant": {
                     "name": "Fathomshare"
                 }
             }
@@ -6408,7 +14928,37 @@
             "power": 3,
             "text": "After Reap: Choose a house. Exhaust each creature of that house.\nScrap: Exhaust a creature or an artifact.\n",
             "locale": {
+                "de": {
+                    "name": "Hukaru Eisflosse"
+                },
                 "en": {
+                    "name": "Hukaru Icefin"
+                },
+                "es": {
+                    "name": "Hukaru Icefin"
+                },
+                "fr": {
+                    "name": "Hukaru Congèleron"
+                },
+                "it": {
+                    "name": "Hukaru Icefin"
+                },
+                "pl": {
+                    "name": "Hukaru Icefin"
+                },
+                "pt": {
+                    "name": "Hukaru Icefin"
+                },
+                "th": {
+                    "name": "Hukaru Icefin"
+                },
+                "vi": {
+                    "name": "Hukaru Icefin"
+                },
+                "zhhans": {
+                    "name": "Hukaru Icefin"
+                },
+                "zhhant": {
                     "name": "Hukaru Icefin"
                 }
             }
@@ -6433,7 +14983,37 @@
             "power": 5,
             "text": "Taunt.\nAt the end of your turn, fully heal each of Kaipo’s neighbors.\n",
             "locale": {
+                "de": {
+                    "name": "Kaipo"
+                },
                 "en": {
+                    "name": "Kaipo"
+                },
+                "es": {
+                    "name": "Kaipo"
+                },
+                "fr": {
+                    "name": "Kayto"
+                },
+                "it": {
+                    "name": "Kaipo"
+                },
+                "pl": {
+                    "name": "Kaipo"
+                },
+                "pt": {
+                    "name": "Kaipo"
+                },
+                "th": {
+                    "name": "Kaipo"
+                },
+                "vi": {
+                    "name": "Kaipo"
+                },
+                "zhhans": {
+                    "name": "Kaipo"
+                },
+                "zhhant": {
                     "name": "Kaipo"
                 }
             }
@@ -6456,7 +15036,37 @@
             "power": 4,
             "text": "Entrench.\nWhile Malina is exhausted, your opponent cannot play creatures more powerful than the most powerful creature in play.\n",
             "locale": {
+                "de": {
+                    "name": "Malina"
+                },
                 "en": {
+                    "name": "Malina"
+                },
+                "es": {
+                    "name": "Malina"
+                },
+                "fr": {
+                    "name": "Mannina"
+                },
+                "it": {
+                    "name": "Malina"
+                },
+                "pl": {
+                    "name": "Malina"
+                },
+                "pt": {
+                    "name": "Malina"
+                },
+                "th": {
+                    "name": "Malina"
+                },
+                "vi": {
+                    "name": "Malina"
+                },
+                "zhhans": {
+                    "name": "Malina"
+                },
+                "zhhant": {
                     "name": "Malina"
                 }
             }
@@ -6481,7 +15091,37 @@
             "power": 2,
             "text": "Skirmish. (When you use this creature to fight, it is dealt no damage in return.)\nAfter Fight: Stun and exhaust the creature Sparkfist fights.",
             "locale": {
+                "de": {
+                    "name": "Funkelfaust"
+                },
                 "en": {
+                    "name": "Sparkfist"
+                },
+                "es": {
+                    "name": "Sparkfist"
+                },
+                "fr": {
+                    "name": "Poing-Étincelle"
+                },
+                "it": {
+                    "name": "Sparkfist"
+                },
+                "pl": {
+                    "name": "Sparkfist"
+                },
+                "pt": {
+                    "name": "Sparkfist"
+                },
+                "th": {
+                    "name": "Sparkfist"
+                },
+                "vi": {
+                    "name": "Sparkfist"
+                },
+                "zhhans": {
+                    "name": "Sparkfist"
+                },
+                "zhhant": {
                     "name": "Sparkfist"
                 }
             }
@@ -6502,7 +15142,37 @@
             "power": null,
             "text": "Play: Deal 4 to each ready creature.\n",
             "locale": {
+                "de": {
+                    "name": "Tsunami"
+                },
                 "en": {
+                    "name": "Tsunami"
+                },
+                "es": {
+                    "name": "Tsunami"
+                },
+                "fr": {
+                    "name": "Tsunami"
+                },
+                "it": {
+                    "name": "Tsunami"
+                },
+                "pl": {
+                    "name": "Tsunami"
+                },
+                "pt": {
+                    "name": "Tsunami"
+                },
+                "th": {
+                    "name": "Tsunami"
+                },
+                "vi": {
+                    "name": "Tsunami"
+                },
+                "zhhans": {
+                    "name": "Tsunami"
+                },
+                "zhhant": {
                     "name": "Tsunami"
                 }
             }
@@ -6523,7 +15193,37 @@
             "power": null,
             "text": "This creature cannot ready.\n",
             "locale": {
+                "de": {
+                    "name": "Unter Druck"
+                },
                 "en": {
+                    "name": "Under Pressure"
+                },
+                "es": {
+                    "name": "Under Pressure"
+                },
+                "fr": {
+                    "name": "Sous Pression"
+                },
+                "it": {
+                    "name": "Under Pressure"
+                },
+                "pl": {
+                    "name": "Under Pressure"
+                },
+                "pt": {
+                    "name": "Under Pressure"
+                },
+                "th": {
+                    "name": "Under Pressure"
+                },
+                "vi": {
+                    "name": "Under Pressure"
+                },
+                "zhhans": {
+                    "name": "Under Pressure"
+                },
+                "zhhant": {
                     "name": "Under Pressure"
                 }
             }
@@ -6544,7 +15244,37 @@
             "power": null,
             "text": "Play: Destroy a friendly creature. If you do, look at your opponent’s hand and choose a card from it. That player discards that card.\n",
             "locale": {
+                "de": {
+                    "name": "Blick aus dem Abgrund"
+                },
                 "en": {
+                    "name": "Abyssal Sight"
+                },
+                "es": {
+                    "name": "Abyssal Sight"
+                },
+                "fr": {
+                    "name": "Vision Abyssale"
+                },
+                "it": {
+                    "name": "Abyssal Sight"
+                },
+                "pl": {
+                    "name": "Abyssal Sight"
+                },
+                "pt": {
+                    "name": "Abyssal Sight"
+                },
+                "th": {
+                    "name": "Abyssal Sight"
+                },
+                "vi": {
+                    "name": "Abyssal Sight"
+                },
+                "zhhans": {
+                    "name": "Abyssal Sight"
+                },
+                "zhhant": {
                     "name": "Abyssal Sight"
                 }
             }
@@ -6565,7 +15295,37 @@
             "power": null,
             "text": "Play: Each player discards the top 5 cards of their deck.\n",
             "locale": {
+                "de": {
+                    "name": "Brackwasser-Abrechnung"
+                },
                 "en": {
+                    "name": "Brine Reckoning"
+                },
+                "es": {
+                    "name": "Brine Reckoning"
+                },
+                "fr": {
+                    "name": "Montée des Eaux"
+                },
+                "it": {
+                    "name": "Brine Reckoning"
+                },
+                "pl": {
+                    "name": "Brine Reckoning"
+                },
+                "pt": {
+                    "name": "Brine Reckoning"
+                },
+                "th": {
+                    "name": "Brine Reckoning"
+                },
+                "vi": {
+                    "name": "Brine Reckoning"
+                },
+                "zhhans": {
+                    "name": "Brine Reckoning"
+                },
+                "zhhant": {
                     "name": "Brine Reckoning"
                 }
             }
@@ -6586,7 +15346,37 @@
             "power": null,
             "text": "Play: Exhaust a creature. If it was already exhausted, destroy it instead and its controller loses 1.\n",
             "locale": {
+                "de": {
+                    "name": "Ruf der Leere"
+                },
                 "en": {
+                    "name": "Call of the Void"
+                },
+                "es": {
+                    "name": "Call of the Void"
+                },
+                "fr": {
+                    "name": "Appel du Vide"
+                },
+                "it": {
+                    "name": "Call of the Void"
+                },
+                "pl": {
+                    "name": "Call of the Void"
+                },
+                "pt": {
+                    "name": "Call of the Void"
+                },
+                "th": {
+                    "name": "Call of the Void"
+                },
+                "vi": {
+                    "name": "Call of the Void"
+                },
+                "zhhans": {
+                    "name": "Call of the Void"
+                },
+                "zhhant": {
                     "name": "Call of the Void"
                 }
             }
@@ -6609,7 +15399,37 @@
             "power": null,
             "text": "Action: Exhaust a creature or artifact.\n",
             "locale": {
+                "de": {
+                    "name": "Stab der Kälte"
+                },
                 "en": {
+                    "name": "Frigorific Rod"
+                },
+                "es": {
+                    "name": "Frigorific Rod"
+                },
+                "fr": {
+                    "name": "Baguette Frigorifique"
+                },
+                "it": {
+                    "name": "Frigorific Rod"
+                },
+                "pl": {
+                    "name": "Frigorific Rod"
+                },
+                "pt": {
+                    "name": "Frigorific Rod"
+                },
+                "th": {
+                    "name": "Frigorific Rod"
+                },
+                "vi": {
+                    "name": "Frigorific Rod"
+                },
+                "zhhans": {
+                    "name": "Frigorific Rod"
+                },
+                "zhhant": {
                     "name": "Frigorific Rod"
                 }
             }
@@ -6632,7 +15452,37 @@
             "power": 2,
             "text": "Play: If there are no enemy exhausted creatures, your opponent loses 2.\n",
             "locale": {
+                "de": {
+                    "name": "Hermogrith"
+                },
                 "en": {
+                    "name": "Hemogrith"
+                },
+                "es": {
+                    "name": "Hemogrith"
+                },
+                "fr": {
+                    "name": "Hémogritte"
+                },
+                "it": {
+                    "name": "Hemogrith"
+                },
+                "pl": {
+                    "name": "Hemogrith"
+                },
+                "pt": {
+                    "name": "Hemogrith"
+                },
+                "th": {
+                    "name": "Hemogrith"
+                },
+                "vi": {
+                    "name": "Hemogrith"
+                },
+                "zhhans": {
+                    "name": "Hemogrith"
+                },
+                "zhhant": {
                     "name": "Hemogrith"
                 }
             }
@@ -6655,7 +15505,37 @@
             "power": 2,
             "text": "Enhance .\nPlay: Choose an enemy creature with no +1 power counters on it. Exhaust that creature and each of its neighbors.\n",
             "locale": {
+                "de": {
+                    "name": "Keenu"
+                },
                 "en": {
+                    "name": "Keenu"
+                },
+                "es": {
+                    "name": "Keenu"
+                },
+                "fr": {
+                    "name": "Keenu"
+                },
+                "it": {
+                    "name": "Keenu"
+                },
+                "pl": {
+                    "name": "Keenu"
+                },
+                "pt": {
+                    "name": "Keenu"
+                },
+                "th": {
+                    "name": "Keenu"
+                },
+                "vi": {
+                    "name": "Keenu"
+                },
+                "zhhans": {
+                    "name": "Keenu"
+                },
+                "zhhant": {
                     "name": "Keenu"
                 }
             }
@@ -6680,7 +15560,37 @@
             "power": 3,
             "text": "Deploy. Entrench.\nWhile Knuckler is exhausted, each of its neighbors gets +2 armor.\n",
             "locale": {
+                "de": {
+                    "name": "Knöchelkriecher"
+                },
                 "en": {
+                    "name": "Knuckler"
+                },
+                "es": {
+                    "name": "Knuckler"
+                },
+                "fr": {
+                    "name": "Petite Frappe"
+                },
+                "it": {
+                    "name": "Knuckler"
+                },
+                "pl": {
+                    "name": "Knuckler"
+                },
+                "pt": {
+                    "name": "Knuckler"
+                },
+                "th": {
+                    "name": "Knuckler"
+                },
+                "vi": {
+                    "name": "Knuckler"
+                },
+                "zhhans": {
+                    "name": "Knuckler"
+                },
+                "zhhant": {
                     "name": "Knuckler"
                 }
             }
@@ -6703,7 +15613,37 @@
             "power": 3,
             "text": "After Reap: Stun, enrage, and exhaust a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Lähmender Steinfisch"
+                },
                 "en": {
+                    "name": "Paralysis Synan"
+                },
+                "es": {
+                    "name": "Paralysis Synan"
+                },
+                "fr": {
+                    "name": "Synan le Curarisant"
+                },
+                "it": {
+                    "name": "Paralysis Synan"
+                },
+                "pl": {
+                    "name": "Paralysis Synan"
+                },
+                "pt": {
+                    "name": "Paralysis Synan"
+                },
+                "th": {
+                    "name": "Paralysis Synan"
+                },
+                "vi": {
+                    "name": "Paralysis Synan"
+                },
+                "zhhans": {
+                    "name": "Paralysis Synan"
+                },
+                "zhhant": {
                     "name": "Paralysis Synan"
                 }
             }
@@ -6727,7 +15667,37 @@
             "power": 3,
             "text": "After Reap: Exhaust an enemy creature. If you do, ready a non-Priest creature.\n",
             "locale": {
+                "de": {
+                    "name": "Priesterin Leilani"
+                },
                 "en": {
+                    "name": "Priestess Leilani"
+                },
+                "es": {
+                    "name": "Priestess Leilani"
+                },
+                "fr": {
+                    "name": "Prêtresse Leilani"
+                },
+                "it": {
+                    "name": "Priestess Leilani"
+                },
+                "pl": {
+                    "name": "Priestess Leilani"
+                },
+                "pt": {
+                    "name": "Priestess Leilani"
+                },
+                "th": {
+                    "name": "Priestess Leilani"
+                },
+                "vi": {
+                    "name": "Priestess Leilani"
+                },
+                "zhhans": {
+                    "name": "Priestess Leilani"
+                },
+                "zhhant": {
                     "name": "Priestess Leilani"
                 }
             }
@@ -6750,7 +15720,37 @@
             "power": 4,
             "text": "After Fight/After Reap: Discard the top card of a player’s deck. For each bonus icon on the discarded card, your opponent loses 1.\n",
             "locale": {
+                "de": {
+                    "name": "Siphonrachen"
+                },
                 "en": {
+                    "name": "Siphon Maw"
+                },
+                "es": {
+                    "name": "Siphon Maw"
+                },
+                "fr": {
+                    "name": "Gueule à Siphon"
+                },
+                "it": {
+                    "name": "Siphon Maw"
+                },
+                "pl": {
+                    "name": "Siphon Maw"
+                },
+                "pt": {
+                    "name": "Siphon Maw"
+                },
+                "th": {
+                    "name": "Siphon Maw"
+                },
+                "vi": {
+                    "name": "Siphon Maw"
+                },
+                "zhhans": {
+                    "name": "Siphon Maw"
+                },
+                "zhhant": {
                     "name": "Siphon Maw"
                 }
             }
@@ -6773,7 +15773,37 @@
             "power": null,
             "text": "At the start of your turn, destroy each card with a corrosion counter on it.\nAction: Put a corrosion counter on a card in play.\n",
             "locale": {
+                "de": {
+                    "name": "Pfuschlack"
+                },
                 "en": {
+                    "name": "Slapdash Enamel"
+                },
+                "es": {
+                    "name": "Slapdash Enamel"
+                },
+                "fr": {
+                    "name": "Eaux Corrosives"
+                },
+                "it": {
+                    "name": "Slapdash Enamel"
+                },
+                "pl": {
+                    "name": "Slapdash Enamel"
+                },
+                "pt": {
+                    "name": "Slapdash Enamel"
+                },
+                "th": {
+                    "name": "Slapdash Enamel"
+                },
+                "vi": {
+                    "name": "Slapdash Enamel"
+                },
+                "zhhans": {
+                    "name": "Slapdash Enamel"
+                },
+                "zhhant": {
                     "name": "Slapdash Enamel"
                 }
             }
@@ -6796,7 +15826,37 @@
             "power": 5,
             "text": "Play: Put an enemy creature on top of its owner’s deck.\n",
             "locale": {
+                "de": {
+                    "name": "„Blubber“"
+                },
                 "en": {
+                    "name": "“Bubbles”"
+                },
+                "es": {
+                    "name": "“Bubbles”"
+                },
+                "fr": {
+                    "name": "« Bubulles »"
+                },
+                "it": {
+                    "name": "“Bubbles”"
+                },
+                "pl": {
+                    "name": "“Bubbles”"
+                },
+                "pt": {
+                    "name": "“Bubbles”"
+                },
+                "th": {
+                    "name": "“Bubbles”"
+                },
+                "vi": {
+                    "name": "“Bubbles”"
+                },
+                "zhhans": {
+                    "name": "“Bubbles”"
+                },
+                "zhhant": {
                     "name": "“Bubbles”"
                 }
             }
@@ -6817,7 +15877,37 @@
             "power": null,
             "text": "Enhance . (These icons have already been added to cards in your deck.)\n",
             "locale": {
+                "de": {
+                    "name": "Öffnet das Siegel"
+                },
                 "en": {
+                    "name": "Open the Seal"
+                },
+                "es": {
+                    "name": "Open the Seal"
+                },
+                "fr": {
+                    "name": "Briser le Sceau"
+                },
+                "it": {
+                    "name": "Open the Seal"
+                },
+                "pl": {
+                    "name": "Open the Seal"
+                },
+                "pt": {
+                    "name": "Open the Seal"
+                },
+                "th": {
+                    "name": "Open the Seal"
+                },
+                "vi": {
+                    "name": "Open the Seal"
+                },
+                "zhhans": {
+                    "name": "Open the Seal"
+                },
+                "zhhant": {
                     "name": "Open the Seal"
                 }
             }

--- a/src/ArchonArcanaApiToKeytekiConverter.js
+++ b/src/ArchonArcanaApiToKeytekiConverter.js
@@ -11,7 +11,10 @@ const ValidKeywords = [
     'hazardous',
     'assault',
     'poison',
-    'splash-attack'
+    'splash-attack',
+    'treachery',
+    'versatile',
+    'entrench'
 ];
 
 function httpRequest(url, options = {}) {
@@ -73,10 +76,10 @@ class DecksOfKeyforgeApiToKeytekiConverter {
             'fields=CardData.Power,CardData.Rarity,CardData.Name,CardData.House,CardData.Type,CardData.Image,' +
             'CardData.House,SetData.CardNumber,SetData.Meta,CardData.Text,CardData.SearchText,CardData.SearchFlavorText,' +
             'CardData.Traits,CardData.Armor,CardData.Source,CardData.Amber,CardData._rowID=RowID&' +
-            'where=((SetName="Winds of Exchange") AND (Meta="SpoilerNew" AND Name IS NOT NULL))&' + 
-            'join_on=CardData._pageName=SetData._pageName&group_by=CardData.Power,CardData.Rarity,CardData.Name,' + 
-            'CardData.House,CardData.Type,CardData.Image,CardData.House,SetData.CardNumber,SetData.Meta,CardData.Text,' + 
-            'CardData.SearchText,CardData.SearchFlavorText,CardData.Traits,CardData.Armor,CardData.Source,CardData.Amber,' + 
+            'where=((SetName="Winds of Exchange") AND (Meta="SpoilerNew" AND Name IS NOT NULL))&' +
+            'join_on=CardData._pageName=SetData._pageName&group_by=CardData.Power,CardData.Rarity,CardData.Name,' +
+            'CardData.House,CardData.Type,CardData.Image,CardData.House,SetData.CardNumber,SetData.Meta,CardData.Text,' +
+            'CardData.SearchText,CardData.SearchFlavorText,CardData.Traits,CardData.Armor,CardData.Source,CardData.Amber,' +
             'CardData._rowID&limit=300&offset=0&order_by=CardNumber';
 
         let packCardMap = pack.cards.reduce(function (map, obj) {
@@ -103,9 +106,9 @@ class DecksOfKeyforgeApiToKeytekiConverter {
         let generatedNumber = 900;
         let generatedNumberCards = {
         };
-        
+
         console.log(`Loading ${response.cargoquery.length} cards`);
-        
+
         for (let el of response.cargoquery) {
             let card = el.title;
 
@@ -131,7 +134,7 @@ class DecksOfKeyforgeApiToKeytekiConverter {
             if(card.Name === '') {
                 continue;
             }
-            
+
             // Fix the house of an anomaly to brobnar so that we can test them until they get a real house
             if (card.anomaly) { // TODO
                 card.house = 'brobnar';
@@ -141,11 +144,11 @@ class DecksOfKeyforgeApiToKeytekiConverter {
             while (cardId.endsWith(' ') || cardId.endsWith('?')) {
                 cardId = cardId.substring(0, cardId.length - 1);
             }
-            
+
             while (card.CardNumber.endsWith(' ') || card.CardNumber.endsWith('?')) {
                 card.CardNumber = card.CardNumber.substring(0, card.length - 1);
             }
-    
+
             if (cardId === '') {
                 cardId = 'card-' + card.CardNumber;
             }
@@ -245,7 +248,7 @@ class DecksOfKeyforgeApiToKeytekiConverter {
         let printedKeywords = potentialKeywords.filter(potentialKeyword => {
             return ValidKeywords.some(keyword => potentialKeyword.indexOf(keyword) === 0);
         });
-        
+
         console.log('printedKeywords: ', printedKeywords);
 
         return printedKeywords;

--- a/src/DecksOfKeyforgeApiToKeytekiConverter.js
+++ b/src/DecksOfKeyforgeApiToKeytekiConverter.js
@@ -11,7 +11,10 @@ const ValidKeywords = [
     'hazardous',
     'assault',
     'poison',
-    'splash-attack'
+    'splash-attack',
+    'treachery',
+    'versatile',
+    'entrench'
 ];
 
 function httpRequest(url, options = {}) {

--- a/src/KeyforgeApiToKeytekiConverter.js
+++ b/src/KeyforgeApiToKeytekiConverter.js
@@ -13,7 +13,8 @@ const ValidKeywords = [
     'poison',
     'splash-attack',
     'treachery',
-    'versatile'
+    'versatile',
+    'entrench'
 ];
 
 function httpRequest(url, options = {}) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds a new static data file; risk is limited to data correctness/format compatibility for consumers loading pack JSON.
> 
> **Overview**
> Adds a new `packs/DM.json` expansion definition for **Draconian Measures** (`code: DM`, id `928`), including full card metadata (houses, traits, images, text) and a `releaseDate`.
> 
> Includes a small data correction during import by explicitly adding the missing `entrench` keyword (e.g., on `Waspscream`) where upstream data was incomplete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5a3cd98983967a0d5364921ec38ccaa8d92ccdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->