### PR TITLE
fix: update dm names and ids

### DIFF
--- a/packs/DM.json
+++ b/packs/DM.json
@@ -636,7 +636,7 @@
             }
         },
         {
-            "id": "oŏni-lars",
+            "id": "ooni-lars",
             "name": "Oŏni-Lars",
             "number": "013",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_013_75e1a0d9e214_en.png",
@@ -1035,7 +1035,7 @@
             }
         },
         {
-            "id": "bleă-fŏrh",
+            "id": "blea-forh",
             "name": "Bleă-Fŏrh",
             "number": "031",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_031_1f7b48b50bd8_en.png",
@@ -1098,7 +1098,7 @@
             }
         },
         {
-            "id": "cŏnrăd-fisiquĕ",
+            "id": "conrad-fisique",
             "name": "Cŏnrăd Fisiquĕ",
             "number": "034",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_034_286c5f9020b9_en.png",
@@ -1266,7 +1266,7 @@
             }
         },
         {
-            "id": "văst-stŏik",
+            "id": "vast-stoik",
             "name": "Văst Stŏik",
             "number": "042",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_042_9360c260fee2_en.png",
@@ -1623,7 +1623,7 @@
             }
         },
         {
-            "id": "varghast-s-vengeance",
+            "id": "varghasts-vengeance",
             "name": "Varghast’s Vengeance",
             "number": "058",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_058_8290fd671ea6_en.png",
@@ -2442,7 +2442,7 @@
             }
         },
         {
-            "id": "zzyszz-s-compactor",
+            "id": "zzyszzs-compactor",
             "name": "Zzyszz’s Compactor",
             "number": "096",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_096_0a826ca23ce1_en.png",
@@ -5088,7 +5088,7 @@
             }
         },
         {
-            "id": "hannibal-s-mark",
+            "id": "hannibals-mark",
             "name": "Hannibal’s Mark",
             "number": "219",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_219_9966eb8fe23f_en.png",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Low code risk but **medium integration risk** because changing card `id` values can break any downstream references (deck lists, lookups, translations, URLs) that still use the old identifiers.
> 
> **Overview**
> Normalizes several `packs/DM.json` card `id` values by removing diacritics and punctuation (e.g., `Oŏni-Lars`, `Bleă-Fŏrh`, `Cŏnrăd Fisiquĕ`, and cards with apostrophes like `Varghast’s Vengeance`, `Zzyszz’s Compactor`, `Hannibal’s Mark`).
> 
> No card rules/text are changed; this is strictly an identifier cleanup for the Draconian Measures dataset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b5dc5e737250ce4c3e700cfc7b3ef8eeb606d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->