### PR TITLE
Handle "Gigantic *" types in other languages

### DIFF
--- a/src/KeyforgeApiToKeytekiConverter.js
+++ b/src/KeyforgeApiToKeytekiConverter.js
@@ -311,23 +311,43 @@ class KeyforgeApiToKeytekiConverter {
                 // "creature1"/"creature2" types.  Card text is the only way to
                 // distinguish them.
 
-                let h = card.house.charAt(0).toUpperCase() + card.house.slice(1)
+                let h = card.house.charAt(0).toUpperCase() + card.house.slice(1);
                 if (h === 'Staralliance') {
-                    h = "Star Alliance"
+                    h = 'Star Alliance';
                 }
 
-                let cardKey = `${card.number}/Creature/${h}/rare`
-                let topHalf = cards[cardKey];
-                if (!topHalf) {
-                    console.info('No card found', cardKey);
+                let keys = [
+                    `${card.number}/creature/${card.house}/rare`,
+                    `${card.number}/Creature/${h}/rare`,
+                    `${card.number}/Gigantic Creature Art/${h}/rare`,
+                    `${card.number}/Gigantic Creature Art/${card.house}/rare`,
+                    `${card.number}/gigantic creature art/${card.house}/rare`
+                ];
+                if (card.house === 'staralliance') {
+                    keys.push(
+                        `${card.number}/Creature/Star Alliance/rare`,
+                        `${card.number}/Gigantic Creature Art/Star Alliance/rare`
+                    );
                 }
 
-                topHalf.text = card.text;
-                topHalf.power = card.power;
-                topHalf.amber = card.amber;
-                topHalf.armor = card.armor;
-                topHalf.traits = card.traits;
-                topHalf.id += '2';
+                let topHalf = null;
+                for (let k of keys) {
+                    if (cards[k]) {
+                        topHalf = cards[k];
+                        break;
+                    }
+                }
+
+                if (topHalf) {
+                    topHalf.text = card.text;
+                    topHalf.power = card.power;
+                    topHalf.amber = card.amber;
+                    topHalf.armor = card.armor;
+                    topHalf.traits = card.traits;
+                    topHalf.id += '2';
+                } else {
+                    console.info('No card found', keys[0]);
+                }
             }
         }
 

--- a/src/KeyforgeApiToKeytekiConverter.js
+++ b/src/KeyforgeApiToKeytekiConverter.js
@@ -323,12 +323,6 @@ class KeyforgeApiToKeytekiConverter {
                     `${card.number}/Gigantic Creature Art/${card.house}/rare`,
                     `${card.number}/gigantic creature art/${card.house}/rare`
                 ];
-                if (card.house === 'staralliance') {
-                    keys.push(
-                        `${card.number}/Creature/Star Alliance/rare`,
-                        `${card.number}/Gigantic Creature Art/Star Alliance/rare`
-                    );
-                }
 
                 let topHalf = null;
                 for (let k of keys) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: narrow change to card-conversion key matching that mainly adds fallbacks and avoids null dereferences when a matching gigantic-half card isn’t found.
> 
> **Overview**
> Improves handling of *localized* “Gigantic” cards by looking up the other half using a small set of alternative `cards` keys (different casing/type strings/house formats) instead of assuming a single `cardKey`.
> 
> Also guards the merge/update of the top-half card so missing matches no longer cause crashes, logging when no matching card is found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e1ea30d89b0180c6188a9f0ea8e5a14474e5a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->