### PR TITLE
DM: card name translations

### DIFF
--- a/packs/DM.json
+++ b/packs/DM.json
@@ -1711,7 +1711,7 @@
             }
         },
         {
-            "id": "the-golden-queen22222222222",
+            "id": "the-golden-queen2",
             "name": "The Golden Queen",
             "number": "015",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_015_6c53d8681450_en.png",
@@ -3452,7 +3452,7 @@
             }
         },
         {
-            "id": "gigantor22222222222",
+            "id": "gigantor2",
             "name": "Gigantor",
             "number": "047",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_047_876e0e294701_en.png",
@@ -5837,7 +5837,7 @@
             }
         },
         {
-            "id": "monster-zero22222222222",
+            "id": "monster-zero2",
             "name": "Monster Zero",
             "number": "091",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_091_7863a243829e_en.png",
@@ -7793,7 +7793,7 @@
             }
         },
         {
-            "id": "kulsha22222222222",
+            "id": "kulsha2",
             "name": "Kulsha",
             "number": "128",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_128_c5974a21655f_en.png",
@@ -9583,7 +9583,7 @@
             }
         },
         {
-            "id": "boosted-b4-rry22222222222",
+            "id": "boosted-b4-rry2",
             "name": "Boosted B4-RRY",
             "number": "160",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_160_67897e890546_en.png",
@@ -12385,7 +12385,7 @@
             }
         },
         {
-            "id": "zomok22222222222",
+            "id": "zomok2",
             "name": "Zomok",
             "number": "213",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_213_02de64b9d6a8_en.png",
@@ -14073,7 +14073,7 @@
             }
         },
         {
-            "id": "hydrogan22222222222",
+            "id": "hydrogan2",
             "name": "Hydrogan",
             "number": "244",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_244_6fbbb8715d70_en.png",

--- a/packs/DM.json
+++ b/packs/DM.json
@@ -1,8 +1,10 @@
 {
-    "ids": ["928"],
+    "ids": [
+        "928"
+    ],
     "code": "DM",
     "name": "Draconian Measures",
-    "cardCount": "370",
+    "cardCount": "303",
     "releaseDate": "2026-04-28",
     "cards": [
         {
@@ -21,7 +23,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -42,7 +74,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -63,7 +125,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -84,7 +176,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -105,7 +227,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -126,7 +278,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -147,7 +329,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and archive them.\n",
             "locale": {
+                "de": {
+                    "name": "Build Your Champion"
+                },
                 "en": {
+                    "name": "Build Your Champion"
+                },
+                "es": {
+                    "name": "Build Your Champion"
+                },
+                "fr": {
+                    "name": "Build Your Champion"
+                },
+                "it": {
+                    "name": "Build Your Champion"
+                },
+                "pl": {
+                    "name": "Build Your Champion"
+                },
+                "pt": {
+                    "name": "Build Your Champion"
+                },
+                "th": {
+                    "name": "Build Your Champion"
+                },
+                "vi": {
+                    "name": "Build Your Champion"
+                },
+                "zhhans": {
+                    "name": "Build Your Champion"
+                },
+                "zhhant": {
                     "name": "Build Your Champion"
                 }
             }
@@ -168,7 +380,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -189,7 +431,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -210,7 +482,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -231,7 +533,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -252,7 +584,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -273,7 +635,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -294,7 +686,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature and reveal them. Put them on top of your deck in any order.\n",
             "locale": {
+                "de": {
+                    "name": "Digging Up the Monster"
+                },
                 "en": {
+                    "name": "Digging Up the Monster"
+                },
+                "es": {
+                    "name": "Digging Up the Monster"
+                },
+                "fr": {
+                    "name": "Digging Up the Monster"
+                },
+                "it": {
+                    "name": "Digging Up the Monster"
+                },
+                "pl": {
+                    "name": "Digging Up the Monster"
+                },
+                "pt": {
+                    "name": "Digging Up the Monster"
+                },
+                "th": {
+                    "name": "Digging Up the Monster"
+                },
+                "vi": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhans": {
+                    "name": "Digging Up the Monster"
+                },
+                "zhhant": {
                     "name": "Digging Up the Monster"
                 }
             }
@@ -315,7 +737,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -336,7 +788,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -357,7 +839,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -378,7 +890,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -399,7 +941,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -420,7 +992,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -441,7 +1043,37 @@
             "power": null,
             "text": "Play: Search your deck and discard pile for two halves of a gigantic creature, reveal them, and put them in your hand. Purge Tomes Gigantica.\n",
             "locale": {
+                "de": {
+                    "name": "Tomes Gigantica"
+                },
                 "en": {
+                    "name": "Tomes Gigantica"
+                },
+                "es": {
+                    "name": "Tomes Gigantica"
+                },
+                "fr": {
+                    "name": "Tomes Gigantica"
+                },
+                "it": {
+                    "name": "Tomes Gigantica"
+                },
+                "pl": {
+                    "name": "Tomes Gigantica"
+                },
+                "pt": {
+                    "name": "Tomes Gigantica"
+                },
+                "th": {
+                    "name": "Tomes Gigantica"
+                },
+                "vi": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhans": {
+                    "name": "Tomes Gigantica"
+                },
+                "zhhant": {
                     "name": "Tomes Gigantica"
                 }
             }
@@ -462,7 +1094,37 @@
             "power": null,
             "text": "Play: Unforge an opponent’s key. If you do, purge Art Project, and your opponent draws 10 cards.\n",
             "locale": {
+                "de": {
+                    "name": "Kunstprojekt"
+                },
                 "en": {
+                    "name": "Art Project"
+                },
+                "es": {
+                    "name": "Art Project"
+                },
+                "fr": {
+                    "name": "Projet Artistique"
+                },
+                "it": {
+                    "name": "Art Project"
+                },
+                "pl": {
+                    "name": "Art Project"
+                },
+                "pt": {
+                    "name": "Art Project"
+                },
+                "th": {
+                    "name": "Art Project"
+                },
+                "vi": {
+                    "name": "Art Project"
+                },
+                "zhhans": {
+                    "name": "Art Project"
+                },
+                "zhhant": {
                     "name": "Art Project"
                 }
             }
@@ -483,7 +1145,37 @@
             "power": null,
             "text": "Play: Each player reveals a random card from their hand or archives. Each player gains 1 for each  bonus icon on their revealed card. Destroy each creature that shares a house with at least one of the revealed cards. Discard the revealed cards.\n",
             "locale": {
+                "de": {
+                    "name": "Tausch und Spiele"
+                },
                 "en": {
+                    "name": "Barter and Games"
+                },
+                "es": {
+                    "name": "Barter and Games"
+                },
+                "fr": {
+                    "name": "Jeux de Troc"
+                },
+                "it": {
+                    "name": "Barter and Games"
+                },
+                "pl": {
+                    "name": "Barter and Games"
+                },
+                "pt": {
+                    "name": "Barter and Games"
+                },
+                "th": {
+                    "name": "Barter and Games"
+                },
+                "vi": {
+                    "name": "Barter and Games"
+                },
+                "zhhans": {
+                    "name": "Barter and Games"
+                },
+                "zhhant": {
                     "name": "Barter and Games"
                 }
             }
@@ -495,8 +1187,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_006_6cdd45601d9e_en.png",
             "expansion": 928,
             "house": "ekwidon",
-            "keywords": ["treachery"],
-            "traits": ["human", "merchant"],
+            "keywords": [
+                "treachery"
+            ],
+            "traits": [
+                "human",
+                "merchant"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -504,7 +1201,37 @@
             "power": 4,
             "text": "Treachery. (This card enters play under your opponent’s control.)\nAfter you forge a key, give control of the most powerful friendly creature to your opponent.\n",
             "locale": {
+                "de": {
+                    "name": "Elenya die Bezaubernde"
+                },
                 "en": {
+                    "name": "Elenya the Charming"
+                },
+                "es": {
+                    "name": "Elenya the Charming"
+                },
+                "fr": {
+                    "name": "Hĕlĕnya la Charmante"
+                },
+                "it": {
+                    "name": "Elenya the Charming"
+                },
+                "pl": {
+                    "name": "Elenya the Charming"
+                },
+                "pt": {
+                    "name": "Elenya the Charming"
+                },
+                "th": {
+                    "name": "Elenya the Charming"
+                },
+                "vi": {
+                    "name": "Elenya the Charming"
+                },
+                "zhhans": {
+                    "name": "Elenya the Charming"
+                },
+                "zhhant": {
                     "name": "Elenya the Charming"
                 }
             }
@@ -525,7 +1252,37 @@
             "power": null,
             "text": "Play: Give control of two friendly creatures to your opponent, one at a time. If you do, take control of two enemy creatures, one at a time.\n",
             "locale": {
+                "de": {
+                    "name": "Fairer Tausch"
+                },
                 "en": {
+                    "name": "Even Swap"
+                },
+                "es": {
+                    "name": "Even Swap"
+                },
+                "fr": {
+                    "name": "Échange Équitable"
+                },
+                "it": {
+                    "name": "Even Swap"
+                },
+                "pl": {
+                    "name": "Even Swap"
+                },
+                "pt": {
+                    "name": "Even Swap"
+                },
+                "th": {
+                    "name": "Even Swap"
+                },
+                "vi": {
+                    "name": "Even Swap"
+                },
+                "zhhans": {
+                    "name": "Even Swap"
+                },
+                "zhhant": {
                     "name": "Even Swap"
                 }
             }
@@ -538,7 +1295,9 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["item"],
+            "traits": [
+                "item"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -546,7 +1305,37 @@
             "power": null,
             "text": "Action: Lose 1. If you do, take control of an enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Willenskodierer"
+                },
                 "en": {
+                    "name": "Fiat Transcoder"
+                },
+                "es": {
+                    "name": "Fiat Transcoder"
+                },
+                "fr": {
+                    "name": "Transcodeur Fiduciaire"
+                },
+                "it": {
+                    "name": "Fiat Transcoder"
+                },
+                "pl": {
+                    "name": "Fiat Transcoder"
+                },
+                "pt": {
+                    "name": "Fiat Transcoder"
+                },
+                "th": {
+                    "name": "Fiat Transcoder"
+                },
+                "vi": {
+                    "name": "Fiat Transcoder"
+                },
+                "zhhans": {
+                    "name": "Fiat Transcoder"
+                },
+                "zhhant": {
                     "name": "Fiat Transcoder"
                 }
             }
@@ -567,7 +1356,37 @@
             "power": null,
             "text": "Play: Move each +1 power counter and each  from friendly creatures to the common supply. Forge a key at +6 current cost, reduced by 1 for the total number of +1 power counters and  moved to the common supply this way (to a minimum of 6).\n",
             "locale": {
+                "de": {
+                    "name": "Falsche Währung"
+                },
                 "en": {
+                    "name": "Forged Currency"
+                },
+                "es": {
+                    "name": "Forged Currency"
+                },
+                "fr": {
+                    "name": "Monnaie Contrefaite"
+                },
+                "it": {
+                    "name": "Forged Currency"
+                },
+                "pl": {
+                    "name": "Forged Currency"
+                },
+                "pt": {
+                    "name": "Forged Currency"
+                },
+                "th": {
+                    "name": "Forged Currency"
+                },
+                "vi": {
+                    "name": "Forged Currency"
+                },
+                "zhhans": {
+                    "name": "Forged Currency"
+                },
+                "zhhant": {
                     "name": "Forged Currency"
                 }
             }
@@ -588,7 +1407,37 @@
             "power": null,
             "text": "At the start of each turn, the active player takes control of this creature.\nThis creature may be used as if it belonged to the active house.\n",
             "locale": {
+                "de": {
+                    "name": "Freiberufler"
+                },
                 "en": {
+                    "name": "Freelancer"
+                },
+                "es": {
+                    "name": "Freelancer"
+                },
+                "fr": {
+                    "name": "Franc-Tireur"
+                },
+                "it": {
+                    "name": "Freelancer"
+                },
+                "pl": {
+                    "name": "Freelancer"
+                },
+                "pt": {
+                    "name": "Freelancer"
+                },
+                "th": {
+                    "name": "Freelancer"
+                },
+                "vi": {
+                    "name": "Freelancer"
+                },
+                "zhhans": {
+                    "name": "Freelancer"
+                },
+                "zhhant": {
                     "name": "Freelancer"
                 }
             }
@@ -601,7 +1450,10 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["getrookya", "analyst"],
+            "traits": [
+                "getrookya",
+                "analyst"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -609,7 +1461,37 @@
             "power": 3,
             "text": "Enhance  . (These icons have already been added to cards in your deck.)\nEach friendly Ekwidon creature cannot reap and gains, “Action: Steal 1.”\n",
             "locale": {
+                "de": {
+                    "name": "Spielveränderer"
+                },
                 "en": {
+                    "name": "Game Changer"
+                },
+                "es": {
+                    "name": "Game Changer"
+                },
+                "fr": {
+                    "name": "Dĕs Sizĩph"
+                },
+                "it": {
+                    "name": "Game Changer"
+                },
+                "pl": {
+                    "name": "Game Changer"
+                },
+                "pt": {
+                    "name": "Game Changer"
+                },
+                "th": {
+                    "name": "Game Changer"
+                },
+                "vi": {
+                    "name": "Game Changer"
+                },
+                "zhhans": {
+                    "name": "Game Changer"
+                },
+                "zhhant": {
                     "name": "Game Changer"
                 }
             }
@@ -630,7 +1512,37 @@
             "power": null,
             "text": "Play: Choose 9 creatures. Move all  on the chosen creatures to their controllers’ pools. Destroy the chosen creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Festlichkeiten zur Jahresmitte"
+                },
                 "en": {
+                    "name": "Midyear Festivities"
+                },
+                "es": {
+                    "name": "Midyear Festivities"
+                },
+                "fr": {
+                    "name": "Festival des Héritiers"
+                },
+                "it": {
+                    "name": "Midyear Festivities"
+                },
+                "pl": {
+                    "name": "Midyear Festivities"
+                },
+                "pt": {
+                    "name": "Midyear Festivities"
+                },
+                "th": {
+                    "name": "Midyear Festivities"
+                },
+                "vi": {
+                    "name": "Midyear Festivities"
+                },
+                "zhhans": {
+                    "name": "Midyear Festivities"
+                },
+                "zhhant": {
                     "name": "Midyear Festivities"
                 }
             }
@@ -643,7 +1555,10 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["getrookya", "politician"],
+            "traits": [
+                "getrookya",
+                "politician"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -651,7 +1566,37 @@
             "power": 6,
             "text": "After Reap: You may pay your opponent 1. If you do, your opponent’s keys cost +4 during their next turn.\n",
             "locale": {
+                "de": {
+                    "name": "Oŏni-Lars"
+                },
                 "en": {
+                    "name": "Oŏni-Lars"
+                },
+                "es": {
+                    "name": "Oŏni-Lars"
+                },
+                "fr": {
+                    "name": "Oŏni-Lars"
+                },
+                "it": {
+                    "name": "Oŏni-Lars"
+                },
+                "pl": {
+                    "name": "Oŏni-Lars"
+                },
+                "pt": {
+                    "name": "Oŏni-Lars"
+                },
+                "th": {
+                    "name": "Oŏni-Lars"
+                },
+                "vi": {
+                    "name": "Oŏni-Lars"
+                },
+                "zhhans": {
+                    "name": "Oŏni-Lars"
+                },
+                "zhhant": {
                     "name": "Oŏni-Lars"
                 }
             }
@@ -663,8 +1608,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_014_ed69cdec7dca_en.png",
             "expansion": 928,
             "house": "ekwidon",
-            "keywords": ["versatile"],
-            "traits": ["getrookya"],
+            "keywords": [
+                "versatile"
+            ],
+            "traits": [
+                "getrookya"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 1,
@@ -672,7 +1621,37 @@
             "power": 2,
             "text": "Versatile. (This card may be used as if it belonged to the active house.)\nPlay: Look at your opponent’s hand and play a creature from it as if it were yours. Your opponent takes control of Talent Scout.\n",
             "locale": {
+                "de": {
+                    "name": "Talentsucher"
+                },
                 "en": {
+                    "name": "Talent Scout"
+                },
+                "es": {
+                    "name": "Talent Scout"
+                },
+                "fr": {
+                    "name": "Dénicheur de Talents"
+                },
+                "it": {
+                    "name": "Talent Scout"
+                },
+                "pl": {
+                    "name": "Talent Scout"
+                },
+                "pt": {
+                    "name": "Talent Scout"
+                },
+                "th": {
+                    "name": "Talent Scout"
+                },
+                "vi": {
+                    "name": "Talent Scout"
+                },
+                "zhhans": {
+                    "name": "Talent Scout"
+                },
+                "zhhant": {
                     "name": "Talent Scout"
                 }
             }
@@ -685,7 +1664,10 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["insect", "cyborg"],
+            "traits": [
+                "insect",
+                "cyborg"
+            ],
             "type": "creature",
             "rarity": "Special",
             "amber": 0,
@@ -693,28 +1675,91 @@
             "power": 10,
             "text": "(Play only with the other half of The Golden Queen.)\nEach player refills their hand to 1 additional card during their “draw cards” step.\nAfter Fight/After Reap: Each player discards a random card from their hand. For each non-Ekwidon card discarded this way, gain 1.\n",
             "locale": {
+                "de": {
+                    "name": "Die Goldene Königin"
+                },
                 "en": {
+                    "name": "The Golden Queen"
+                },
+                "es": {
+                    "name": "The Golden Queen"
+                },
+                "fr": {
+                    "name": "La Reine Dorée"
+                },
+                "it": {
+                    "name": "The Golden Queen"
+                },
+                "pl": {
+                    "name": "The Golden Queen"
+                },
+                "pt": {
+                    "name": "The Golden Queen"
+                },
+                "th": {
+                    "name": "The Golden Queen"
+                },
+                "vi": {
+                    "name": "The Golden Queen"
+                },
+                "zhhans": {
+                    "name": "The Golden Queen"
+                },
+                "zhhant": {
                     "name": "The Golden Queen"
                 }
             }
         },
         {
-            "id": "the-golden-queen2",
+            "id": "the-golden-queen22222222222",
             "name": "The Golden Queen",
             "number": "015",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_015_6c53d8681450_en.png",
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": [],
+            "traits": [
+                "insect",
+                "cyborg"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
             "armor": null,
-            "power": null,
-            "text": "",
+            "power": 10,
+            "text": "(Play only with the other half of The Golden Queen.)\nEach player refills their hand to 1 additional card during their “draw cards” step.\nAfter Fight/After Reap: Each player discards a random card from their hand. For each non-Ekwidon card discarded this way, gain 1.\n",
             "locale": {
+                "de": {
+                    "name": "Die Goldene Königin"
+                },
                 "en": {
+                    "name": "The Golden Queen"
+                },
+                "es": {
+                    "name": "The Golden Queen"
+                },
+                "fr": {
+                    "name": "La Reine Dorée"
+                },
+                "it": {
+                    "name": "The Golden Queen"
+                },
+                "pl": {
+                    "name": "The Golden Queen"
+                },
+                "pt": {
+                    "name": "The Golden Queen"
+                },
+                "th": {
+                    "name": "The Golden Queen"
+                },
+                "vi": {
+                    "name": "The Golden Queen"
+                },
+                "zhhans": {
+                    "name": "The Golden Queen"
+                },
+                "zhhant": {
                     "name": "The Golden Queen"
                 }
             }
@@ -735,7 +1780,37 @@
             "power": null,
             "text": "Play: Your opponent draws 3 cards, discards a random card from their hand, puts a random card from their hand on top of their deck, and purges a random card from their hand.\n",
             "locale": {
+                "de": {
+                    "name": "Ganz schön betrunken"
+                },
                 "en": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "es": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "fr": {
+                    "name": "Torchon Chiffon Carpette"
+                },
+                "it": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "pl": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "pt": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "th": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "vi": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "zhhans": {
+                    "name": "Three Sheets to the Wind"
+                },
+                "zhhant": {
                     "name": "Three Sheets to the Wind"
                 }
             }
@@ -748,7 +1823,10 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["human", "scientist"],
+            "traits": [
+                "human",
+                "scientist"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -756,7 +1834,37 @@
             "power": 4,
             "text": "Each time you play an artifact from your discard pile, gain 1.\nPlay/After Reap: You may play an artifact from your discard pile.\n",
             "locale": {
+                "de": {
+                    "name": "Zavel, „Archäologe“"
+                },
                 "en": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "es": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "fr": {
+                    "name": "Zavel, « Archéologue »"
+                },
+                "it": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "pl": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "pt": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "th": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "vi": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "zhhans": {
+                    "name": "Zavel, “Archaeologist”"
+                },
+                "zhhant": {
                     "name": "Zavel, “Archaeologist”"
                 }
             }
@@ -769,7 +1877,9 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["power"],
+            "traits": [
+                "power"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -777,7 +1887,37 @@
             "power": null,
             "text": "Your keys cost +1. \nDuring your “draw cards” step, refill your hand to 1 additional card.\n",
             "locale": {
+                "de": {
+                    "name": "Æmbitrage"
+                },
                 "en": {
+                    "name": "Æmbitrage"
+                },
+                "es": {
+                    "name": "Æmbitrage"
+                },
+                "fr": {
+                    "name": "Aombitrage"
+                },
+                "it": {
+                    "name": "Æmbitrage"
+                },
+                "pl": {
+                    "name": "Æmbitrage"
+                },
+                "pt": {
+                    "name": "Æmbitrage"
+                },
+                "th": {
+                    "name": "Æmbitrage"
+                },
+                "vi": {
+                    "name": "Æmbitrage"
+                },
+                "zhhans": {
+                    "name": "Æmbitrage"
+                },
+                "zhhant": {
                     "name": "Æmbitrage"
                 }
             }
@@ -798,7 +1938,37 @@
             "power": null,
             "text": "Play: A friendly creature captures 2. Draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Autorisierter Einzug"
+                },
                 "en": {
+                    "name": "Authorized Requisitions"
+                },
+                "es": {
+                    "name": "Authorized Requisitions"
+                },
+                "fr": {
+                    "name": "Réquisition Autorisée"
+                },
+                "it": {
+                    "name": "Authorized Requisitions"
+                },
+                "pl": {
+                    "name": "Authorized Requisitions"
+                },
+                "pt": {
+                    "name": "Authorized Requisitions"
+                },
+                "th": {
+                    "name": "Authorized Requisitions"
+                },
+                "vi": {
+                    "name": "Authorized Requisitions"
+                },
+                "zhhans": {
+                    "name": "Authorized Requisitions"
+                },
+                "zhhant": {
                     "name": "Authorized Requisitions"
                 }
             }
@@ -811,7 +1981,10 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["getrookya", "merchant"],
+            "traits": [
+                "getrookya",
+                "merchant"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -819,7 +1992,37 @@
             "power": 4,
             "text": "After Fight/After Reap: For each card in your opponent’s hand in excess of 5, they lose 1.\n",
             "locale": {
+                "de": {
+                    "name": "Betreiber des Wandels"
+                },
                 "en": {
+                    "name": "Change Agent"
+                },
+                "es": {
+                    "name": "Change Agent"
+                },
+                "fr": {
+                    "name": "Agent de Change"
+                },
+                "it": {
+                    "name": "Change Agent"
+                },
+                "pl": {
+                    "name": "Change Agent"
+                },
+                "pt": {
+                    "name": "Change Agent"
+                },
+                "th": {
+                    "name": "Change Agent"
+                },
+                "vi": {
+                    "name": "Change Agent"
+                },
+                "zhhans": {
+                    "name": "Change Agent"
+                },
+                "zhhant": {
                     "name": "Change Agent"
                 }
             }
@@ -840,7 +2043,37 @@
             "power": null,
             "text": "This creature gains, “Action: Deal 4 to a creature. If this damage destroys that creature, return Dapper Chapeau to its owner’s hand. Otherwise, attach Dapper Chapeau to that creature.”\n",
             "locale": {
+                "de": {
+                    "name": "Schicker Hut"
+                },
                 "en": {
+                    "name": "Dapper Chapeau"
+                },
+                "es": {
+                    "name": "Dapper Chapeau"
+                },
+                "fr": {
+                    "name": "Chapeau Pimpant"
+                },
+                "it": {
+                    "name": "Dapper Chapeau"
+                },
+                "pl": {
+                    "name": "Dapper Chapeau"
+                },
+                "pt": {
+                    "name": "Dapper Chapeau"
+                },
+                "th": {
+                    "name": "Dapper Chapeau"
+                },
+                "vi": {
+                    "name": "Dapper Chapeau"
+                },
+                "zhhans": {
+                    "name": "Dapper Chapeau"
+                },
+                "zhhant": {
                     "name": "Dapper Chapeau"
                 }
             }
@@ -861,7 +2094,37 @@
             "power": null,
             "text": "Play: Purge up to 2 cards from your hand. For each card purged this way, gain 1.\n",
             "locale": {
+                "de": {
+                    "name": "Drastische Maßnahmen"
+                },
                 "en": {
+                    "name": "Drastic Measures"
+                },
+                "es": {
+                    "name": "Drastic Measures"
+                },
+                "fr": {
+                    "name": "Mesures Drastiques"
+                },
+                "it": {
+                    "name": "Drastic Measures"
+                },
+                "pl": {
+                    "name": "Drastic Measures"
+                },
+                "pt": {
+                    "name": "Drastic Measures"
+                },
+                "th": {
+                    "name": "Drastic Measures"
+                },
+                "vi": {
+                    "name": "Drastic Measures"
+                },
+                "zhhans": {
+                    "name": "Drastic Measures"
+                },
+                "zhhant": {
                     "name": "Drastic Measures"
                 }
             }
@@ -874,7 +2137,10 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["human", "merchant"],
+            "traits": [
+                "human",
+                "merchant"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -882,7 +2148,37 @@
             "power": 3,
             "text": "After Reap: Capture 2. You may discard a card. If you do, move 1 from Exeldon Yash to your pool.\n",
             "locale": {
+                "de": {
+                    "name": "Händlerfürst Yash"
+                },
                 "en": {
+                    "name": "Exeldon Yash"
+                },
+                "es": {
+                    "name": "Exeldon Yash"
+                },
+                "fr": {
+                    "name": "Exeldon Vălnŏr"
+                },
+                "it": {
+                    "name": "Exeldon Yash"
+                },
+                "pl": {
+                    "name": "Exeldon Yash"
+                },
+                "pt": {
+                    "name": "Exeldon Yash"
+                },
+                "th": {
+                    "name": "Exeldon Yash"
+                },
+                "vi": {
+                    "name": "Exeldon Yash"
+                },
+                "zhhans": {
+                    "name": "Exeldon Yash"
+                },
+                "zhhant": {
                     "name": "Exeldon Yash"
                 }
             }
@@ -903,7 +2199,37 @@
             "power": null,
             "text": "This creature's text box is considered blank, except for traits.\nPlay: Destroy all other upgrades attached to this creature.\n",
             "locale": {
+                "de": {
+                    "name": "Glücksumkehrer"
+                },
                 "en": {
+                    "name": "Fortune Reverser"
+                },
+                "es": {
+                    "name": "Fortune Reverser"
+                },
+                "fr": {
+                    "name": "Inverseur de Bonne Fortune"
+                },
+                "it": {
+                    "name": "Fortune Reverser"
+                },
+                "pl": {
+                    "name": "Fortune Reverser"
+                },
+                "pt": {
+                    "name": "Fortune Reverser"
+                },
+                "th": {
+                    "name": "Fortune Reverser"
+                },
+                "vi": {
+                    "name": "Fortune Reverser"
+                },
+                "zhhans": {
+                    "name": "Fortune Reverser"
+                },
+                "zhhant": {
                     "name": "Fortune Reverser"
                 }
             }
@@ -916,7 +2242,10 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["getrookya", "soldier"],
+            "traits": [
+                "getrookya",
+                "soldier"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -924,7 +2253,37 @@
             "power": 3,
             "text": "Play/After Fight: Take control of an enemy artifact. Give your opponent control of Gegrrŏkŭŭ Sapper.\nScrap: Destroy a friendly artifact. If you do, destroy an enemy artifact.\n",
             "locale": {
+                "de": {
+                    "name": "Gegrrŏkŭŭ-Pionier"
+                },
                 "en": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "es": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "fr": {
+                    "name": "Sapeur Gegrrŏkŭŭ"
+                },
+                "it": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "pl": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "pt": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "th": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "vi": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "zhhans": {
+                    "name": "Gegrrŏkŭŭ Sapper"
+                },
+                "zhhant": {
                     "name": "Gegrrŏkŭŭ Sapper"
                 }
             }
@@ -937,7 +2296,9 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["human"],
+            "traits": [
+                "human"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -945,7 +2306,37 @@
             "power": 4,
             "text": "After Fight: Take control of an enemy artifact.\n",
             "locale": {
+                "de": {
+                    "name": "Krisper Ruld"
+                },
                 "en": {
+                    "name": "Krisper Ruld"
+                },
+                "es": {
+                    "name": "Krisper Ruld"
+                },
+                "fr": {
+                    "name": "Krisper Ruld"
+                },
+                "it": {
+                    "name": "Krisper Ruld"
+                },
+                "pl": {
+                    "name": "Krisper Ruld"
+                },
+                "pt": {
+                    "name": "Krisper Ruld"
+                },
+                "th": {
+                    "name": "Krisper Ruld"
+                },
+                "vi": {
+                    "name": "Krisper Ruld"
+                },
+                "zhhans": {
+                    "name": "Krisper Ruld"
+                },
+                "zhhant": {
                     "name": "Krisper Ruld"
                 }
             }
@@ -958,7 +2349,9 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["human"],
+            "traits": [
+                "human"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -966,7 +2359,37 @@
             "power": 5,
             "text": "Action: Exhaust an enemy creature. If you do, each player gains 1.\n",
             "locale": {
+                "de": {
+                    "name": "Brieffreund"
+                },
                 "en": {
+                    "name": "Pen Pal"
+                },
+                "es": {
+                    "name": "Pen Pal"
+                },
+                "fr": {
+                    "name": "Correspondant"
+                },
+                "it": {
+                    "name": "Pen Pal"
+                },
+                "pl": {
+                    "name": "Pen Pal"
+                },
+                "pt": {
+                    "name": "Pen Pal"
+                },
+                "th": {
+                    "name": "Pen Pal"
+                },
+                "vi": {
+                    "name": "Pen Pal"
+                },
+                "zhhans": {
+                    "name": "Pen Pal"
+                },
+                "zhhant": {
                     "name": "Pen Pal"
                 }
             }
@@ -987,7 +2410,37 @@
             "power": null,
             "text": "Enhance .\nPlay: Each player reveals a random card from their hand and gains 1 for each  bonus icon on their revealed card.\n",
             "locale": {
+                "de": {
+                    "name": "Ernte des wilden Windes"
+                },
                 "en": {
+                    "name": "Reap the Wild Wind"
+                },
+                "es": {
+                    "name": "Reap the Wild Wind"
+                },
+                "fr": {
+                    "name": "Récolte la Tempête"
+                },
+                "it": {
+                    "name": "Reap the Wild Wind"
+                },
+                "pl": {
+                    "name": "Reap the Wild Wind"
+                },
+                "pt": {
+                    "name": "Reap the Wild Wind"
+                },
+                "th": {
+                    "name": "Reap the Wild Wind"
+                },
+                "vi": {
+                    "name": "Reap the Wild Wind"
+                },
+                "zhhans": {
+                    "name": "Reap the Wild Wind"
+                },
+                "zhhant": {
                     "name": "Reap the Wild Wind"
                 }
             }
@@ -1008,7 +2461,37 @@
             "power": null,
             "text": "Play: Discard the top 10 cards of your deck. If you discard 5 or more cards of the same house this way, steal 2.\n",
             "locale": {
+                "de": {
+                    "name": "Technorachnophobie"
+                },
                 "en": {
+                    "name": "Technorachnophobia"
+                },
+                "es": {
+                    "name": "Technorachnophobia"
+                },
+                "fr": {
+                    "name": "Technoarachnophobie"
+                },
+                "it": {
+                    "name": "Technorachnophobia"
+                },
+                "pl": {
+                    "name": "Technorachnophobia"
+                },
+                "pt": {
+                    "name": "Technorachnophobia"
+                },
+                "th": {
+                    "name": "Technorachnophobia"
+                },
+                "vi": {
+                    "name": "Technorachnophobia"
+                },
+                "zhhans": {
+                    "name": "Technorachnophobia"
+                },
+                "zhhant": {
                     "name": "Technorachnophobia"
                 }
             }
@@ -1020,8 +2503,14 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_030_6a9967a856dc_en.png",
             "expansion": 928,
             "house": "ekwidon",
-            "keywords": ["entrench", "poison"],
-            "traits": ["insect", "cyborg"],
+            "keywords": [
+                "entrench",
+                "poison"
+            ],
+            "traits": [
+                "insect",
+                "cyborg"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -1029,7 +2518,37 @@
             "power": 2,
             "text": "Entrench. Poison.\nAt the start of your turn, if Waspscream is exhausted, take control of an enemy creature. \n",
             "locale": {
+                "de": {
+                    "name": "Wespenschrei"
+                },
                 "en": {
+                    "name": "Waspscream"
+                },
+                "es": {
+                    "name": "Waspscream"
+                },
+                "fr": {
+                    "name": "Guêpe Envoûtante"
+                },
+                "it": {
+                    "name": "Waspscream"
+                },
+                "pl": {
+                    "name": "Waspscream"
+                },
+                "pt": {
+                    "name": "Waspscream"
+                },
+                "th": {
+                    "name": "Waspscream"
+                },
+                "vi": {
+                    "name": "Waspscream"
+                },
+                "zhhans": {
+                    "name": "Waspscream"
+                },
+                "zhhant": {
                     "name": "Waspscream"
                 }
             }
@@ -1042,7 +2561,10 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["getrookya", "soldier"],
+            "traits": [
+                "getrookya",
+                "soldier"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -1050,7 +2572,37 @@
             "power": 4,
             "text": "After Fight: Heal up to 2 damage from a creature. For each damage healed this way, exalt that creature.\n",
             "locale": {
+                "de": {
+                    "name": "Bleă-Fŏrh"
+                },
                 "en": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "es": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "fr": {
+                    "name": "Tŏmă-Wăky"
+                },
+                "it": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "pl": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "pt": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "th": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "vi": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "zhhans": {
+                    "name": "Bleă-Fŏrh"
+                },
+                "zhhant": {
                     "name": "Bleă-Fŏrh"
                 }
             }
@@ -1062,8 +2614,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_032_ff278f1127e6_en.png",
             "expansion": 928,
             "house": "ekwidon",
-            "keywords": ["entrench"],
-            "traits": ["getrookya", "thief"],
+            "keywords": [
+                "entrench"
+            ],
+            "traits": [
+                "getrookya",
+                "thief"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -1071,7 +2628,37 @@
             "power": 2,
             "text": "Entrench.\nWhile Bypass Burglar is exhausted, each of its neighbors gains, “Action: Steal 1. Deal 1 to this creature.”\n",
             "locale": {
+                "de": {
+                    "name": "Drahtzieher-Einbrecher"
+                },
                 "en": {
+                    "name": "Bypass Burglar"
+                },
+                "es": {
+                    "name": "Bypass Burglar"
+                },
+                "fr": {
+                    "name": "Avide Commanditaire"
+                },
+                "it": {
+                    "name": "Bypass Burglar"
+                },
+                "pl": {
+                    "name": "Bypass Burglar"
+                },
+                "pt": {
+                    "name": "Bypass Burglar"
+                },
+                "th": {
+                    "name": "Bypass Burglar"
+                },
+                "vi": {
+                    "name": "Bypass Burglar"
+                },
+                "zhhans": {
+                    "name": "Bypass Burglar"
+                },
+                "zhhant": {
                     "name": "Bypass Burglar"
                 }
             }
@@ -1084,7 +2671,10 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["getrookya", "soldier"],
+            "traits": [
+                "getrookya",
+                "soldier"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -1092,7 +2682,37 @@
             "power": 4,
             "text": "After Fight/After Reap: If you are overwhelmed, destroy an enemy creature. Otherwise, destroy an enemy artifact.\n",
             "locale": {
+                "de": {
+                    "name": "Chromatischer Wächter"
+                },
                 "en": {
+                    "name": "Chromatic Guardian"
+                },
+                "es": {
+                    "name": "Chromatic Guardian"
+                },
+                "fr": {
+                    "name": "Gardien Chromatique"
+                },
+                "it": {
+                    "name": "Chromatic Guardian"
+                },
+                "pl": {
+                    "name": "Chromatic Guardian"
+                },
+                "pt": {
+                    "name": "Chromatic Guardian"
+                },
+                "th": {
+                    "name": "Chromatic Guardian"
+                },
+                "vi": {
+                    "name": "Chromatic Guardian"
+                },
+                "zhhans": {
+                    "name": "Chromatic Guardian"
+                },
+                "zhhant": {
                     "name": "Chromatic Guardian"
                 }
             }
@@ -1105,7 +2725,9 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["getrookya"],
+            "traits": [
+                "getrookya"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -1113,7 +2735,37 @@
             "power": 2,
             "text": "Enhance .\nPlay: You may move each +1 power counter from a creature to another creature.\n",
             "locale": {
+                "de": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
                 "en": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "es": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "fr": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "it": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "pl": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "pt": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "th": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "vi": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "zhhans": {
+                    "name": "Cŏnrăd Fisiquĕ"
+                },
+                "zhhant": {
                     "name": "Cŏnrăd Fisiquĕ"
                 }
             }
@@ -1126,7 +2778,10 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["getrookya", "merchant"],
+            "traits": [
+                "getrookya",
+                "merchant"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -1134,7 +2789,37 @@
             "power": 6,
             "text": "Action: Steal 1. Deal 1 to Gemcoat Vendor.\n",
             "locale": {
+                "de": {
+                    "name": "Edelstein-Händler"
+                },
                 "en": {
+                    "name": "Gemcoat Vendor"
+                },
+                "es": {
+                    "name": "Gemcoat Vendor"
+                },
+                "fr": {
+                    "name": "Vendeur Sous Cape"
+                },
+                "it": {
+                    "name": "Gemcoat Vendor"
+                },
+                "pl": {
+                    "name": "Gemcoat Vendor"
+                },
+                "pt": {
+                    "name": "Gemcoat Vendor"
+                },
+                "th": {
+                    "name": "Gemcoat Vendor"
+                },
+                "vi": {
+                    "name": "Gemcoat Vendor"
+                },
+                "zhhans": {
+                    "name": "Gemcoat Vendor"
+                },
+                "zhhant": {
                     "name": "Gemcoat Vendor"
                 }
             }
@@ -1147,7 +2832,10 @@
             "expansion": 928,
             "house": "ekwidon",
             "keywords": [],
-            "traits": ["getrookya", "merchant"],
+            "traits": [
+                "getrookya",
+                "merchant"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -1155,7 +2843,37 @@
             "power": 3,
             "text": "After Reap: Deal 3 to a creature. If this damage destroys that creature, its owner gains 1.\n",
             "locale": {
+                "de": {
+                    "name": "Goldener Dolch"
+                },
                 "en": {
+                    "name": "Golden Dagger"
+                },
+                "es": {
+                    "name": "Golden Dagger"
+                },
+                "fr": {
+                    "name": "Dague d'Or"
+                },
+                "it": {
+                    "name": "Golden Dagger"
+                },
+                "pl": {
+                    "name": "Golden Dagger"
+                },
+                "pt": {
+                    "name": "Golden Dagger"
+                },
+                "th": {
+                    "name": "Golden Dagger"
+                },
+                "vi": {
+                    "name": "Golden Dagger"
+                },
+                "zhhans": {
+                    "name": "Golden Dagger"
+                },
+                "zhhant": {
                     "name": "Golden Dagger"
                 }
             }
@@ -1176,7 +2894,37 @@
             "power": null,
             "text": "Play: Put a creature into its owner’s archives.\n",
             "locale": {
+                "de": {
+                    "name": "Hebevorgänge"
+                },
                 "en": {
+                    "name": "Hoist Operations"
+                },
+                "es": {
+                    "name": "Hoist Operations"
+                },
+                "fr": {
+                    "name": "Opérations de Levage"
+                },
+                "it": {
+                    "name": "Hoist Operations"
+                },
+                "pl": {
+                    "name": "Hoist Operations"
+                },
+                "pt": {
+                    "name": "Hoist Operations"
+                },
+                "th": {
+                    "name": "Hoist Operations"
+                },
+                "vi": {
+                    "name": "Hoist Operations"
+                },
+                "zhhans": {
+                    "name": "Hoist Operations"
+                },
+                "zhhant": {
                     "name": "Hoist Operations"
                 }
             }
@@ -1197,7 +2945,37 @@
             "power": null,
             "text": "Play: Exhaust a creature. If you do, ready a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Warmes Bett"
+                },
                 "en": {
+                    "name": "Hot Bunk"
+                },
+                "es": {
+                    "name": "Hot Bunk"
+                },
+                "fr": {
+                    "name": "Changement de Quart"
+                },
+                "it": {
+                    "name": "Hot Bunk"
+                },
+                "pl": {
+                    "name": "Hot Bunk"
+                },
+                "pt": {
+                    "name": "Hot Bunk"
+                },
+                "th": {
+                    "name": "Hot Bunk"
+                },
+                "vi": {
+                    "name": "Hot Bunk"
+                },
+                "zhhans": {
+                    "name": "Hot Bunk"
+                },
+                "zhhant": {
                     "name": "Hot Bunk"
                 }
             }
@@ -1218,7 +2996,37 @@
             "power": null,
             "text": "Play: Your opponent discards a random card from their hand. For each bonus icon on the discarded card, they lose 1.\n",
             "locale": {
+                "de": {
+                    "name": "Nullsteuer"
+                },
                 "en": {
+                    "name": "Nada Tax"
+                },
+                "es": {
+                    "name": "Nada Tax"
+                },
+                "fr": {
+                    "name": "La Taxe Nada"
+                },
+                "it": {
+                    "name": "Nada Tax"
+                },
+                "pl": {
+                    "name": "Nada Tax"
+                },
+                "pt": {
+                    "name": "Nada Tax"
+                },
+                "th": {
+                    "name": "Nada Tax"
+                },
+                "vi": {
+                    "name": "Nada Tax"
+                },
+                "zhhans": {
+                    "name": "Nada Tax"
+                },
+                "zhhant": {
                     "name": "Nada Tax"
                 }
             }
@@ -1239,7 +3047,37 @@
             "power": null,
             "text": "Play: Return a creature to its owner’s hand and archive a card. If you are overwhelmed, repeat the preceding effect.\n",
             "locale": {
+                "de": {
+                    "name": "Jetzt und später"
+                },
                 "en": {
+                    "name": "Now and Later"
+                },
+                "es": {
+                    "name": "Now and Later"
+                },
+                "fr": {
+                    "name": "Maintenant et Après"
+                },
+                "it": {
+                    "name": "Now and Later"
+                },
+                "pl": {
+                    "name": "Now and Later"
+                },
+                "pt": {
+                    "name": "Now and Later"
+                },
+                "th": {
+                    "name": "Now and Later"
+                },
+                "vi": {
+                    "name": "Now and Later"
+                },
+                "zhhans": {
+                    "name": "Now and Later"
+                },
+                "zhhant": {
                     "name": "Now and Later"
                 }
             }
@@ -1260,7 +3098,37 @@
             "power": null,
             "text": "Play: Exhaust a friendly creature. If you do, steal 2.\n",
             "locale": {
+                "de": {
+                    "name": "Akte"
+                },
                 "en": {
+                    "name": "Permanent Record"
+                },
+                "es": {
+                    "name": "Permanent Record"
+                },
+                "fr": {
+                    "name": "Rodomontade"
+                },
+                "it": {
+                    "name": "Permanent Record"
+                },
+                "pl": {
+                    "name": "Permanent Record"
+                },
+                "pt": {
+                    "name": "Permanent Record"
+                },
+                "th": {
+                    "name": "Permanent Record"
+                },
+                "vi": {
+                    "name": "Permanent Record"
+                },
+                "zhhans": {
+                    "name": "Permanent Record"
+                },
+                "zhhant": {
                     "name": "Permanent Record"
                 }
             }
@@ -1272,8 +3140,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_042_9360c260fee2_en.png",
             "expansion": 928,
             "house": "ekwidon",
-            "keywords": ["taunt"],
-            "traits": ["getrookya", "soldier"],
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "getrookya",
+                "soldier"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -1281,7 +3154,37 @@
             "power": 4,
             "text": "Taunt.\nAfter Fight: Move 1 from a creature to the common supply. If you do, draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Văst Stŏik"
+                },
                 "en": {
+                    "name": "Văst Stŏik"
+                },
+                "es": {
+                    "name": "Văst Stŏik"
+                },
+                "fr": {
+                    "name": "Văst Stŏik"
+                },
+                "it": {
+                    "name": "Văst Stŏik"
+                },
+                "pl": {
+                    "name": "Văst Stŏik"
+                },
+                "pt": {
+                    "name": "Văst Stŏik"
+                },
+                "th": {
+                    "name": "Văst Stŏik"
+                },
+                "vi": {
+                    "name": "Văst Stŏik"
+                },
+                "zhhans": {
+                    "name": "Văst Stŏik"
+                },
+                "zhhant": {
                     "name": "Văst Stŏik"
                 }
             }
@@ -1294,7 +3197,9 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["item"],
+            "traits": [
+                "item"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -1302,7 +3207,37 @@
             "power": null,
             "text": "Action: Discard a card. If you do, purge a card of the same type as the discarded card from a discard pile.\n",
             "locale": {
+                "de": {
+                    "name": "Auraskop"
+                },
                 "en": {
+                    "name": "Aurascope"
+                },
+                "es": {
+                    "name": "Aurascope"
+                },
+                "fr": {
+                    "name": "Auratoscope"
+                },
+                "it": {
+                    "name": "Aurascope"
+                },
+                "pl": {
+                    "name": "Aurascope"
+                },
+                "pt": {
+                    "name": "Aurascope"
+                },
+                "th": {
+                    "name": "Aurascope"
+                },
+                "vi": {
+                    "name": "Aurascope"
+                },
+                "zhhans": {
+                    "name": "Aurascope"
+                },
+                "zhhant": {
                     "name": "Aurascope"
                 }
             }
@@ -1323,7 +3258,37 @@
             "power": null,
             "text": "Enhance .\nPlay: A friendly creature captures 3. If you are haunted, put Empathic Malice on the bottom of your deck.\n",
             "locale": {
+                "de": {
+                    "name": "Empathische Bosheit"
+                },
                 "en": {
+                    "name": "Empathic Malice"
+                },
+                "es": {
+                    "name": "Empathic Malice"
+                },
+                "fr": {
+                    "name": "Hypocrisie"
+                },
+                "it": {
+                    "name": "Empathic Malice"
+                },
+                "pl": {
+                    "name": "Empathic Malice"
+                },
+                "pt": {
+                    "name": "Empathic Malice"
+                },
+                "th": {
+                    "name": "Empathic Malice"
+                },
+                "vi": {
+                    "name": "Empathic Malice"
+                },
+                "zhhans": {
+                    "name": "Empathic Malice"
+                },
+                "zhhant": {
                     "name": "Empathic Malice"
                 }
             }
@@ -1344,7 +3309,37 @@
             "power": null,
             "text": "Play: Swap each player's deck with their discard pile. Shuffle each player's deck.\n",
             "locale": {
+                "de": {
+                    "name": "Zukunft ist Vergangenheit"
+                },
                 "en": {
+                    "name": "Future is Past"
+                },
+                "es": {
+                    "name": "Future is Past"
+                },
+                "fr": {
+                    "name": "Avenir Révolu"
+                },
+                "it": {
+                    "name": "Future is Past"
+                },
+                "pl": {
+                    "name": "Future is Past"
+                },
+                "pt": {
+                    "name": "Future is Past"
+                },
+                "th": {
+                    "name": "Future is Past"
+                },
+                "vi": {
+                    "name": "Future is Past"
+                },
+                "zhhans": {
+                    "name": "Future is Past"
+                },
+                "zhhant": {
                     "name": "Future is Past"
                 }
             }
@@ -1357,7 +3352,9 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["location"],
+            "traits": [
+                "location"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 1,
@@ -1365,7 +3362,37 @@
             "power": null,
             "text": "Action: If you are haunted, archive a card. Otherwise, discard a card. \n",
             "locale": {
+                "de": {
+                    "name": "Geisterstadt"
+                },
                 "en": {
+                    "name": "Ghost Town"
+                },
+                "es": {
+                    "name": "Ghost Town"
+                },
+                "fr": {
+                    "name": "Ville Fantôme"
+                },
+                "it": {
+                    "name": "Ghost Town"
+                },
+                "pl": {
+                    "name": "Ghost Town"
+                },
+                "pt": {
+                    "name": "Ghost Town"
+                },
+                "th": {
+                    "name": "Ghost Town"
+                },
+                "vi": {
+                    "name": "Ghost Town"
+                },
+                "zhhans": {
+                    "name": "Ghost Town"
+                },
+                "zhhant": {
                     "name": "Ghost Town"
                 }
             }
@@ -1378,7 +3405,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter", "robot"],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Special",
             "amber": 0,
@@ -1386,28 +3416,91 @@
             "power": 8,
             "text": "(Play only with the other half of Gigantor.)\nAfter Fight/After Reap: Purge up to 3 cards from a discard pile. For each card purged this way, draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Gigantor"
+                },
                 "en": {
+                    "name": "Gigantor"
+                },
+                "es": {
+                    "name": "Gigantor"
+                },
+                "fr": {
+                    "name": "Gigantor"
+                },
+                "it": {
+                    "name": "Gigantor"
+                },
+                "pl": {
+                    "name": "Gigantor"
+                },
+                "pt": {
+                    "name": "Gigantor"
+                },
+                "th": {
+                    "name": "Gigantor"
+                },
+                "vi": {
+                    "name": "Gigantor"
+                },
+                "zhhans": {
+                    "name": "Gigantor"
+                },
+                "zhhant": {
                     "name": "Gigantor"
                 }
             }
         },
         {
-            "id": "gigantor2",
+            "id": "gigantor22222222222",
             "name": "Gigantor",
             "number": "047",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_047_876e0e294701_en.png",
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": [],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
             "armor": null,
-            "power": null,
-            "text": "",
+            "power": 8,
+            "text": "(Play only with the other half of Gigantor.)\nAfter Fight/After Reap: Purge up to 3 cards from a discard pile. For each card purged this way, draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Gigantor"
+                },
                 "en": {
+                    "name": "Gigantor"
+                },
+                "es": {
+                    "name": "Gigantor"
+                },
+                "fr": {
+                    "name": "Gigantor"
+                },
+                "it": {
+                    "name": "Gigantor"
+                },
+                "pl": {
+                    "name": "Gigantor"
+                },
+                "pt": {
+                    "name": "Gigantor"
+                },
+                "th": {
+                    "name": "Gigantor"
+                },
+                "vi": {
+                    "name": "Gigantor"
+                },
+                "zhhans": {
+                    "name": "Gigantor"
+                },
+                "zhhant": {
                     "name": "Gigantor"
                 }
             }
@@ -1420,7 +3513,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["ai", "specter"],
+            "traits": [
+                "ai",
+                "specter"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -1428,7 +3524,37 @@
             "power": 3,
             "text": "Enhance .\nEach friendly Geistoid creature gains versatile.\n",
             "locale": {
+                "de": {
+                    "name": "Holografische Todesfee"
+                },
                 "en": {
+                    "name": "Holographic Banshee"
+                },
+                "es": {
+                    "name": "Holographic Banshee"
+                },
+                "fr": {
+                    "name": "Hurlographique"
+                },
+                "it": {
+                    "name": "Holographic Banshee"
+                },
+                "pl": {
+                    "name": "Holographic Banshee"
+                },
+                "pt": {
+                    "name": "Holographic Banshee"
+                },
+                "th": {
+                    "name": "Holographic Banshee"
+                },
+                "vi": {
+                    "name": "Holographic Banshee"
+                },
+                "zhhans": {
+                    "name": "Holographic Banshee"
+                },
+                "zhhant": {
                     "name": "Holographic Banshee"
                 }
             }
@@ -1441,7 +3567,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter", "robot"],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -1449,7 +3578,37 @@
             "power": 3,
             "text": "Enhance .\nEach friendly creature with  on it gains, “After Reap: Move 1 from this creature to your pool.”\n",
             "locale": {
+                "de": {
+                    "name": "Jahnspuk"
+                },
                 "en": {
+                    "name": "Jahneerie"
+                },
+                "es": {
+                    "name": "Jahneerie"
+                },
+                "fr": {
+                    "name": "Jane Eerie"
+                },
+                "it": {
+                    "name": "Jahneerie"
+                },
+                "pl": {
+                    "name": "Jahneerie"
+                },
+                "pt": {
+                    "name": "Jahneerie"
+                },
+                "th": {
+                    "name": "Jahneerie"
+                },
+                "vi": {
+                    "name": "Jahneerie"
+                },
+                "zhhans": {
+                    "name": "Jahneerie"
+                },
+                "zhhant": {
                     "name": "Jahneerie"
                 }
             }
@@ -1462,7 +3621,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter", "robot"],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -1470,7 +3632,37 @@
             "power": 3,
             "text": "After a friendly Geistoid creature enters play, each player discards the top 2 cards of their deck.\nAfter Reap: Play the topmost creature from your discard pile.\n",
             "locale": {
+                "de": {
+                    "name": "Fräulein Unfug"
+                },
                 "en": {
+                    "name": "Miss Chievous"
+                },
+                "es": {
+                    "name": "Miss Chievous"
+                },
+                "fr": {
+                    "name": "Ma' Licieuse"
+                },
+                "it": {
+                    "name": "Miss Chievous"
+                },
+                "pl": {
+                    "name": "Miss Chievous"
+                },
+                "pt": {
+                    "name": "Miss Chievous"
+                },
+                "th": {
+                    "name": "Miss Chievous"
+                },
+                "vi": {
+                    "name": "Miss Chievous"
+                },
+                "zhhans": {
+                    "name": "Miss Chievous"
+                },
+                "zhhant": {
                     "name": "Miss Chievous"
                 }
             }
@@ -1483,7 +3675,9 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter"],
+            "traits": [
+                "specter"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -1491,7 +3685,37 @@
             "power": 2,
             "text": "Play: Gain 1 for each card in your opponent’s archives. Your opponent discards each card in their archives.\n",
             "locale": {
+                "de": {
+                    "name": "P.K.E.-Absauger"
+                },
                 "en": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "es": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "fr": {
+                    "name": "Sniffeur P.K.E"
+                },
+                "it": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "pl": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "pt": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "th": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "vi": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "zhhans": {
+                    "name": "P.K.E. Syphonator"
+                },
+                "zhhant": {
                     "name": "P.K.E. Syphonator"
                 }
             }
@@ -1512,7 +3736,37 @@
             "power": null,
             "text": "This creature gains, “After Reap: If you are haunted, gain 2.”\n",
             "locale": {
+                "de": {
+                    "name": "Phantastischer Mantel"
+                },
                 "en": {
+                    "name": "Phantasm Cloak"
+                },
+                "es": {
+                    "name": "Phantasm Cloak"
+                },
+                "fr": {
+                    "name": "Cape Fantômatique"
+                },
+                "it": {
+                    "name": "Phantasm Cloak"
+                },
+                "pl": {
+                    "name": "Phantasm Cloak"
+                },
+                "pt": {
+                    "name": "Phantasm Cloak"
+                },
+                "th": {
+                    "name": "Phantasm Cloak"
+                },
+                "vi": {
+                    "name": "Phantasm Cloak"
+                },
+                "zhhans": {
+                    "name": "Phantasm Cloak"
+                },
+                "zhhant": {
                     "name": "Phantasm Cloak"
                 }
             }
@@ -1533,7 +3787,37 @@
             "power": null,
             "text": "Play: Purge a card from a discard pile. If you do, play a creature or artifact from your purged zone as if it were in your hand. Attach Poltergeistoids to it as an upgrade with the text, “This card belongs to house Geistoid.”\n",
             "locale": {
+                "de": {
+                    "name": "Poltergeistoiden"
+                },
                 "en": {
+                    "name": "Poltergeistoids"
+                },
+                "es": {
+                    "name": "Poltergeistoids"
+                },
+                "fr": {
+                    "name": "Polterspectroïdes"
+                },
+                "it": {
+                    "name": "Poltergeistoids"
+                },
+                "pl": {
+                    "name": "Poltergeistoids"
+                },
+                "pt": {
+                    "name": "Poltergeistoids"
+                },
+                "th": {
+                    "name": "Poltergeistoids"
+                },
+                "vi": {
+                    "name": "Poltergeistoids"
+                },
+                "zhhans": {
+                    "name": "Poltergeistoids"
+                },
+                "zhhant": {
                     "name": "Poltergeistoids"
                 }
             }
@@ -1545,8 +3829,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_054_b147e0a64fe2_en.png",
             "expansion": 928,
             "house": "geistoid",
-            "keywords": ["taunt"],
-            "traits": ["specter"],
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "specter"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -1554,7 +3842,37 @@
             "power": 3,
             "text": "Taunt.\nWhile you are haunted, Protective Playmate gets +6 power. Otherwise, Protective Playmate gains elusive.\n",
             "locale": {
+                "de": {
+                    "name": "Beschützender Kamerad"
+                },
                 "en": {
+                    "name": "Protective Playmate"
+                },
+                "es": {
+                    "name": "Protective Playmate"
+                },
+                "fr": {
+                    "name": "Parangon"
+                },
+                "it": {
+                    "name": "Protective Playmate"
+                },
+                "pl": {
+                    "name": "Protective Playmate"
+                },
+                "pt": {
+                    "name": "Protective Playmate"
+                },
+                "th": {
+                    "name": "Protective Playmate"
+                },
+                "vi": {
+                    "name": "Protective Playmate"
+                },
+                "zhhans": {
+                    "name": "Protective Playmate"
+                },
+                "zhhant": {
                     "name": "Protective Playmate"
                 }
             }
@@ -1575,7 +3893,37 @@
             "power": null,
             "text": "Play: Destroy each creature that is not on a flank. Put a creature from any discard pile into play under your control. Gain 2 chains.\n",
             "locale": {
+                "de": {
+                    "name": "Hülle eines Geistes"
+                },
                 "en": {
+                    "name": "Shell of a Ghost"
+                },
+                "es": {
+                    "name": "Shell of a Ghost"
+                },
+                "fr": {
+                    "name": "Équiper les Morts"
+                },
+                "it": {
+                    "name": "Shell of a Ghost"
+                },
+                "pl": {
+                    "name": "Shell of a Ghost"
+                },
+                "pt": {
+                    "name": "Shell of a Ghost"
+                },
+                "th": {
+                    "name": "Shell of a Ghost"
+                },
+                "vi": {
+                    "name": "Shell of a Ghost"
+                },
+                "zhhans": {
+                    "name": "Shell of a Ghost"
+                },
+                "zhhant": {
                     "name": "Shell of a Ghost"
                 }
             }
@@ -1596,7 +3944,37 @@
             "power": null,
             "text": "Play: Destroy each creature. Each player reveals their hand and discards each creature revealed this way. Each player refills their hand as if it were their “draw cards” step.\n",
             "locale": {
+                "de": {
+                    "name": "Müllhalde"
+                },
                 "en": {
+                    "name": "Trash Heap"
+                },
+                "es": {
+                    "name": "Trash Heap"
+                },
+                "fr": {
+                    "name": "Tas d'Ordures"
+                },
+                "it": {
+                    "name": "Trash Heap"
+                },
+                "pl": {
+                    "name": "Trash Heap"
+                },
+                "pt": {
+                    "name": "Trash Heap"
+                },
+                "th": {
+                    "name": "Trash Heap"
+                },
+                "vi": {
+                    "name": "Trash Heap"
+                },
+                "zhhans": {
+                    "name": "Trash Heap"
+                },
+                "zhhant": {
                     "name": "Trash Heap"
                 }
             }
@@ -1609,7 +3987,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter", "robot"],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -1617,7 +3998,37 @@
             "power": 4,
             "text": "Varad the Indulgent gets +1 power for each  on it.\nAfter another friendly Geistoid creature fights, Varad the Indulgent captures 1.\n",
             "locale": {
+                "de": {
+                    "name": "Varad der Nachsichtige"
+                },
                 "en": {
+                    "name": "Varad the Indulgent"
+                },
+                "es": {
+                    "name": "Varad the Indulgent"
+                },
+                "fr": {
+                    "name": "Alvad l'Indulgent"
+                },
+                "it": {
+                    "name": "Varad the Indulgent"
+                },
+                "pl": {
+                    "name": "Varad the Indulgent"
+                },
+                "pt": {
+                    "name": "Varad the Indulgent"
+                },
+                "th": {
+                    "name": "Varad the Indulgent"
+                },
+                "vi": {
+                    "name": "Varad the Indulgent"
+                },
+                "zhhans": {
+                    "name": "Varad the Indulgent"
+                },
+                "zhhant": {
                     "name": "Varad the Indulgent"
                 }
             }
@@ -1630,7 +4041,9 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["power"],
+            "traits": [
+                "power"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 1,
@@ -1638,7 +4051,37 @@
             "power": null,
             "text": "Omni: Name a card. Until the start of your next turn, cards with that name cannot be played or used. Gain 2 chains.\nScrap: Purge a card from your opponent's discard pile. Your opponent shuffles their discard pile into their deck.\n",
             "locale": {
+                "de": {
+                    "name": "Varghasts Rache"
+                },
                 "en": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "es": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "fr": {
+                    "name": "Vengeance de Varghast"
+                },
+                "it": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "pl": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "pt": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "th": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "vi": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "zhhans": {
+                    "name": "Varghast’s Vengeance"
+                },
+                "zhhant": {
                     "name": "Varghast’s Vengeance"
                 }
             }
@@ -1659,7 +4102,37 @@
             "power": null,
             "text": "Play: Purge a card from your discard pile. If you do, a friendly creature captures 2.\n",
             "locale": {
+                "de": {
+                    "name": "Apoptose"
+                },
                 "en": {
+                    "name": "Apoptosis"
+                },
+                "es": {
+                    "name": "Apoptosis"
+                },
+                "fr": {
+                    "name": "Apoptose"
+                },
+                "it": {
+                    "name": "Apoptosis"
+                },
+                "pl": {
+                    "name": "Apoptosis"
+                },
+                "pt": {
+                    "name": "Apoptosis"
+                },
+                "th": {
+                    "name": "Apoptosis"
+                },
+                "vi": {
+                    "name": "Apoptosis"
+                },
+                "zhhans": {
+                    "name": "Apoptosis"
+                },
+                "zhhant": {
                     "name": "Apoptosis"
                 }
             }
@@ -1672,7 +4145,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter", "robot"],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -1680,7 +4156,37 @@
             "power": 2,
             "text": "Destroyed: Deal 6 to each enemy flank creature.\nScrap: Deal 1 to each enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Dampfkessel"
+                },
                 "en": {
+                    "name": "Boiler"
+                },
+                "es": {
+                    "name": "Boiler"
+                },
+                "fr": {
+                    "name": "Chaudière"
+                },
+                "it": {
+                    "name": "Boiler"
+                },
+                "pl": {
+                    "name": "Boiler"
+                },
+                "pt": {
+                    "name": "Boiler"
+                },
+                "th": {
+                    "name": "Boiler"
+                },
+                "vi": {
+                    "name": "Boiler"
+                },
+                "zhhans": {
+                    "name": "Boiler"
+                },
+                "zhhant": {
                     "name": "Boiler"
                 }
             }
@@ -1701,7 +4207,37 @@
             "power": null,
             "text": "Play: Choose a friendly creature. Move each  from that creature to your pool. Destroy that creature.\n",
             "locale": {
+                "de": {
+                    "name": "Dämmerungsstrahlen"
+                },
                 "en": {
+                    "name": "Crepuscular Rays"
+                },
+                "es": {
+                    "name": "Crepuscular Rays"
+                },
+                "fr": {
+                    "name": "Rayons Crépusculaires"
+                },
+                "it": {
+                    "name": "Crepuscular Rays"
+                },
+                "pl": {
+                    "name": "Crepuscular Rays"
+                },
+                "pt": {
+                    "name": "Crepuscular Rays"
+                },
+                "th": {
+                    "name": "Crepuscular Rays"
+                },
+                "vi": {
+                    "name": "Crepuscular Rays"
+                },
+                "zhhans": {
+                    "name": "Crepuscular Rays"
+                },
+                "zhhant": {
                     "name": "Crepuscular Rays"
                 }
             }
@@ -1714,7 +4250,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter", "ai"],
+            "traits": [
+                "specter",
+                "ai"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -1722,7 +4261,37 @@
             "power": 2,
             "text": "Play: Draw 3 cards. Discard 2 cards. Archive a card.\n",
             "locale": {
+                "de": {
+                    "name": "Datamator"
+                },
                 "en": {
+                    "name": "Dammater"
+                },
+                "es": {
+                    "name": "Dammater"
+                },
+                "fr": {
+                    "name": "Dammater"
+                },
+                "it": {
+                    "name": "Dammater"
+                },
+                "pl": {
+                    "name": "Dammater"
+                },
+                "pt": {
+                    "name": "Dammater"
+                },
+                "th": {
+                    "name": "Dammater"
+                },
+                "vi": {
+                    "name": "Dammater"
+                },
+                "zhhans": {
+                    "name": "Dammater"
+                },
+                "zhhant": {
                     "name": "Dammater"
                 }
             }
@@ -1743,7 +4312,37 @@
             "power": null,
             "text": "Play: Shuffle Out of Ideas and the top card of your discard pile into their owner’s deck.\n",
             "locale": {
+                "de": {
+                    "name": "Keine Ideen mehr"
+                },
                 "en": {
+                    "name": "Out of Ideas"
+                },
+                "es": {
+                    "name": "Out of Ideas"
+                },
+                "fr": {
+                    "name": "À Court d'Idées"
+                },
+                "it": {
+                    "name": "Out of Ideas"
+                },
+                "pl": {
+                    "name": "Out of Ideas"
+                },
+                "pt": {
+                    "name": "Out of Ideas"
+                },
+                "th": {
+                    "name": "Out of Ideas"
+                },
+                "vi": {
+                    "name": "Out of Ideas"
+                },
+                "zhhans": {
+                    "name": "Out of Ideas"
+                },
+                "zhhant": {
                     "name": "Out of Ideas"
                 }
             }
@@ -1755,8 +4354,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_064_dc904f55b95a_en.png",
             "expansion": 928,
             "house": "geistoid",
-            "keywords": ["entrench"],
-            "traits": ["specter", "item"],
+            "keywords": [
+                "entrench"
+            ],
+            "traits": [
+                "specter",
+                "item"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -1764,7 +4368,37 @@
             "power": 3,
             "text": "Entrench.\nWhile Paranormal Palisade is exhausted, it gets +4 armor and gains taunt.\n",
             "locale": {
+                "de": {
+                    "name": "Paranormale Palisade"
+                },
                 "en": {
+                    "name": "Paranormal Palisade"
+                },
+                "es": {
+                    "name": "Paranormal Palisade"
+                },
+                "fr": {
+                    "name": "Palissade Paranormale"
+                },
+                "it": {
+                    "name": "Paranormal Palisade"
+                },
+                "pl": {
+                    "name": "Paranormal Palisade"
+                },
+                "pt": {
+                    "name": "Paranormal Palisade"
+                },
+                "th": {
+                    "name": "Paranormal Palisade"
+                },
+                "vi": {
+                    "name": "Paranormal Palisade"
+                },
+                "zhhans": {
+                    "name": "Paranormal Palisade"
+                },
+                "zhhant": {
                     "name": "Paranormal Palisade"
                 }
             }
@@ -1785,7 +4419,37 @@
             "power": null,
             "text": "Play: Shuffle the top 10 cards of your discard pile into your deck. If you do, destroy each creature.\n",
             "locale": {
+                "de": {
+                    "name": "Asche zu Asche"
+                },
                 "en": {
+                    "name": "Return to Rubble"
+                },
+                "es": {
+                    "name": "Return to Rubble"
+                },
+                "fr": {
+                    "name": "Redevenir Poussière"
+                },
+                "it": {
+                    "name": "Return to Rubble"
+                },
+                "pl": {
+                    "name": "Return to Rubble"
+                },
+                "pt": {
+                    "name": "Return to Rubble"
+                },
+                "th": {
+                    "name": "Return to Rubble"
+                },
+                "vi": {
+                    "name": "Return to Rubble"
+                },
+                "zhhans": {
+                    "name": "Return to Rubble"
+                },
+                "zhhant": {
                     "name": "Return to Rubble"
                 }
             }
@@ -1806,7 +4470,37 @@
             "power": null,
             "text": "Play: If your opponent is haunted, destroy an enemy artifact, Cyborg creature, or Robot creature. If you do, play that card as if it were in your hand. Attach Spontaneous Awakening to it as an upgrade with the text, “This card belongs to house Geistoid.”\n",
             "locale": {
+                "de": {
+                    "name": "Spontanes Erwachen"
+                },
                 "en": {
+                    "name": "Spontaneous Awakening"
+                },
+                "es": {
+                    "name": "Spontaneous Awakening"
+                },
+                "fr": {
+                    "name": "Réveil Spontané"
+                },
+                "it": {
+                    "name": "Spontaneous Awakening"
+                },
+                "pl": {
+                    "name": "Spontaneous Awakening"
+                },
+                "pt": {
+                    "name": "Spontaneous Awakening"
+                },
+                "th": {
+                    "name": "Spontaneous Awakening"
+                },
+                "vi": {
+                    "name": "Spontaneous Awakening"
+                },
+                "zhhans": {
+                    "name": "Spontaneous Awakening"
+                },
+                "zhhant": {
                     "name": "Spontaneous Awakening"
                 }
             }
@@ -1819,7 +4513,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter", "robot"],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -1827,7 +4524,37 @@
             "power": 3,
             "text": "After Fight/After Reap: Your opponent shuffles a random card from their hand into their deck.\n",
             "locale": {
+                "de": {
+                    "name": "Techno-Schatten"
+                },
                 "en": {
+                    "name": "Techno-Shade"
+                },
+                "es": {
+                    "name": "Techno-Shade"
+                },
+                "fr": {
+                    "name": "Techn'Ombre"
+                },
+                "it": {
+                    "name": "Techno-Shade"
+                },
+                "pl": {
+                    "name": "Techno-Shade"
+                },
+                "pt": {
+                    "name": "Techno-Shade"
+                },
+                "th": {
+                    "name": "Techno-Shade"
+                },
+                "vi": {
+                    "name": "Techno-Shade"
+                },
+                "zhhans": {
+                    "name": "Techno-Shade"
+                },
+                "zhhant": {
                     "name": "Techno-Shade"
                 }
             }
@@ -1840,7 +4567,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter", "robot"],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -1848,7 +4578,37 @@
             "power": 5,
             "text": "Enhance .\nEach friendly creature with  on it gains, “Destroyed: Draw 1 card.”\n",
             "locale": {
+                "de": {
+                    "name": "Gedankenfänger"
+                },
                 "en": {
+                    "name": "Thoughtcatcher"
+                },
+                "es": {
+                    "name": "Thoughtcatcher"
+                },
+                "fr": {
+                    "name": "Attrape-Pensées"
+                },
+                "it": {
+                    "name": "Thoughtcatcher"
+                },
+                "pl": {
+                    "name": "Thoughtcatcher"
+                },
+                "pt": {
+                    "name": "Thoughtcatcher"
+                },
+                "th": {
+                    "name": "Thoughtcatcher"
+                },
+                "vi": {
+                    "name": "Thoughtcatcher"
+                },
+                "zhhans": {
+                    "name": "Thoughtcatcher"
+                },
+                "zhhant": {
                     "name": "Thoughtcatcher"
                 }
             }
@@ -1860,8 +4620,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_069_d555c9c62e62_en.png",
             "expansion": 928,
             "house": "geistoid",
-            "keywords": ["taunt"],
-            "traits": ["specter", "cyborg"],
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "specter",
+                "cyborg"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -1869,7 +4634,37 @@
             "power": 6,
             "text": "Taunt.\nDestroyed: If it is not your turn, your opponent discards 5 cards from the top of their deck. Otherwise, discard 5 cards from the top of your deck.\n",
             "locale": {
+                "de": {
+                    "name": "Titanische Erscheinung"
+                },
                 "en": {
+                    "name": "Titan Apparition"
+                },
+                "es": {
+                    "name": "Titan Apparition"
+                },
+                "fr": {
+                    "name": "Titan Revenant"
+                },
+                "it": {
+                    "name": "Titan Apparition"
+                },
+                "pl": {
+                    "name": "Titan Apparition"
+                },
+                "pt": {
+                    "name": "Titan Apparition"
+                },
+                "th": {
+                    "name": "Titan Apparition"
+                },
+                "vi": {
+                    "name": "Titan Apparition"
+                },
+                "zhhans": {
+                    "name": "Titan Apparition"
+                },
+                "zhhant": {
                     "name": "Titan Apparition"
                 }
             }
@@ -1881,8 +4676,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_070_6168d3d312c9_en.png",
             "expansion": 928,
             "house": "geistoid",
-            "keywords": ["taunt"],
-            "traits": ["specter", "robot"],
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -1890,7 +4690,37 @@
             "power": 4,
             "text": "Taunt.\nPlay/After Fight: A friendly creature captures 1.\n",
             "locale": {
+                "de": {
+                    "name": "Tributsammler"
+                },
                 "en": {
+                    "name": "Tribute Collector"
+                },
+                "es": {
+                    "name": "Tribute Collector"
+                },
+                "fr": {
+                    "name": "Collecteur de Tributs"
+                },
+                "it": {
+                    "name": "Tribute Collector"
+                },
+                "pl": {
+                    "name": "Tribute Collector"
+                },
+                "pt": {
+                    "name": "Tribute Collector"
+                },
+                "th": {
+                    "name": "Tribute Collector"
+                },
+                "vi": {
+                    "name": "Tribute Collector"
+                },
+                "zhhans": {
+                    "name": "Tribute Collector"
+                },
+                "zhhant": {
                     "name": "Tribute Collector"
                 }
             }
@@ -1911,7 +4741,37 @@
             "power": null,
             "text": "Play: Forge a key at +20 current cost, reduced by 1 for each card in your discard pile (to a minimum of 6). If you do, purge Ecto-Charge.\n",
             "locale": {
+                "de": {
+                    "name": "Ekto-Ladung"
+                },
                 "en": {
+                    "name": "Ecto-Charge"
+                },
+                "es": {
+                    "name": "Ecto-Charge"
+                },
+                "fr": {
+                    "name": "Ecto-Charge"
+                },
+                "it": {
+                    "name": "Ecto-Charge"
+                },
+                "pl": {
+                    "name": "Ecto-Charge"
+                },
+                "pt": {
+                    "name": "Ecto-Charge"
+                },
+                "th": {
+                    "name": "Ecto-Charge"
+                },
+                "vi": {
+                    "name": "Ecto-Charge"
+                },
+                "zhhans": {
+                    "name": "Ecto-Charge"
+                },
+                "zhhant": {
                     "name": "Ecto-Charge"
                 }
             }
@@ -1923,8 +4783,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_072_3ca64451692d_en.png",
             "expansion": 928,
             "house": "geistoid",
-            "keywords": ["entrench"],
-            "traits": ["specter", "robot"],
+            "keywords": [
+                "entrench"
+            ],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -1932,7 +4797,37 @@
             "power": 3,
             "text": "Entrench.\nWhile Fading Apparition is exhausted, any  you would gain by reaping may be taken from  among friendly creatures instead of the common supply.\n",
             "locale": {
+                "de": {
+                    "name": "Verblassende Erscheinung"
+                },
                 "en": {
+                    "name": "Fading Apparition"
+                },
+                "es": {
+                    "name": "Fading Apparition"
+                },
+                "fr": {
+                    "name": "Apparition Estompée"
+                },
+                "it": {
+                    "name": "Fading Apparition"
+                },
+                "pl": {
+                    "name": "Fading Apparition"
+                },
+                "pt": {
+                    "name": "Fading Apparition"
+                },
+                "th": {
+                    "name": "Fading Apparition"
+                },
+                "vi": {
+                    "name": "Fading Apparition"
+                },
+                "zhhans": {
+                    "name": "Fading Apparition"
+                },
+                "zhhant": {
                     "name": "Fading Apparition"
                 }
             }
@@ -1945,7 +4840,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter", "robot"],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -1953,7 +4851,37 @@
             "power": 2,
             "text": "After Reap: Deal 2 to a creature. If this damage destroys that creature, give a friendly creature two +1 power counters.\n",
             "locale": {
+                "de": {
+                    "name": "Hammer-Schmied"
+                },
                 "en": {
+                    "name": "Hammer Smythe"
+                },
+                "es": {
+                    "name": "Hammer Smythe"
+                },
+                "fr": {
+                    "name": "Plume l'Enclume"
+                },
+                "it": {
+                    "name": "Hammer Smythe"
+                },
+                "pl": {
+                    "name": "Hammer Smythe"
+                },
+                "pt": {
+                    "name": "Hammer Smythe"
+                },
+                "th": {
+                    "name": "Hammer Smythe"
+                },
+                "vi": {
+                    "name": "Hammer Smythe"
+                },
+                "zhhans": {
+                    "name": "Hammer Smythe"
+                },
+                "zhhant": {
                     "name": "Hammer Smythe"
                 }
             }
@@ -1974,7 +4902,37 @@
             "power": null,
             "text": "Enhance . (These icons have already been added to cards in your deck.)\nPlay: If you are haunted, purge a card from a discard pile.\n",
             "locale": {
+                "de": {
+                    "name": "Spukdeck"
+                },
                 "en": {
+                    "name": "Haunting Deck"
+                },
+                "es": {
+                    "name": "Haunting Deck"
+                },
+                "fr": {
+                    "name": "Pont Hanté"
+                },
+                "it": {
+                    "name": "Haunting Deck"
+                },
+                "pl": {
+                    "name": "Haunting Deck"
+                },
+                "pt": {
+                    "name": "Haunting Deck"
+                },
+                "th": {
+                    "name": "Haunting Deck"
+                },
+                "vi": {
+                    "name": "Haunting Deck"
+                },
+                "zhhans": {
+                    "name": "Haunting Deck"
+                },
+                "zhhant": {
                     "name": "Haunting Deck"
                 }
             }
@@ -1995,7 +4953,37 @@
             "power": null,
             "text": "Play: Discard the top 6 cards of your deck. You may put a non-Geistoid card discarded this way into your hand.\n",
             "locale": {
+                "de": {
+                    "name": "Spukmaßnahmen"
+                },
                 "en": {
+                    "name": "Haunting Measures"
+                },
+                "es": {
+                    "name": "Haunting Measures"
+                },
+                "fr": {
+                    "name": "Décantation"
+                },
+                "it": {
+                    "name": "Haunting Measures"
+                },
+                "pl": {
+                    "name": "Haunting Measures"
+                },
+                "pt": {
+                    "name": "Haunting Measures"
+                },
+                "th": {
+                    "name": "Haunting Measures"
+                },
+                "vi": {
+                    "name": "Haunting Measures"
+                },
+                "zhhans": {
+                    "name": "Haunting Measures"
+                },
+                "zhhant": {
                     "name": "Haunting Measures"
                 }
             }
@@ -2008,7 +4996,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter", "robot"],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2016,7 +5007,37 @@
             "power": 3,
             "text": "After Fight: If you are overwhelmed, an enemy creature captures 1 from its own side. Otherwise, capture 1.\n",
             "locale": {
+                "de": {
+                    "name": "Schrott-Jimmy"
+                },
                 "en": {
+                    "name": "Janky Jimmy"
+                },
+                "es": {
+                    "name": "Janky Jimmy"
+                },
+                "fr": {
+                    "name": "Pascal le Bancal"
+                },
+                "it": {
+                    "name": "Janky Jimmy"
+                },
+                "pl": {
+                    "name": "Janky Jimmy"
+                },
+                "pt": {
+                    "name": "Janky Jimmy"
+                },
+                "th": {
+                    "name": "Janky Jimmy"
+                },
+                "vi": {
+                    "name": "Janky Jimmy"
+                },
+                "zhhans": {
+                    "name": "Janky Jimmy"
+                },
+                "zhhant": {
                     "name": "Janky Jimmy"
                 }
             }
@@ -2029,7 +5050,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter", "faerie"],
+            "traits": [
+                "specter",
+                "faerie"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2037,7 +5061,37 @@
             "power": 1,
             "text": "Play/Destroyed: Archive the top card of your discard pile.\n",
             "locale": {
+                "de": {
+                    "name": "Memette"
+                },
                 "en": {
+                    "name": "Memette"
+                },
+                "es": {
+                    "name": "Memette"
+                },
+                "fr": {
+                    "name": "Mémotte"
+                },
+                "it": {
+                    "name": "Memette"
+                },
+                "pl": {
+                    "name": "Memette"
+                },
+                "pt": {
+                    "name": "Memette"
+                },
+                "th": {
+                    "name": "Memette"
+                },
+                "vi": {
+                    "name": "Memette"
+                },
+                "zhhans": {
+                    "name": "Memette"
+                },
+                "zhhant": {
                     "name": "Memette"
                 }
             }
@@ -2058,7 +5112,37 @@
             "power": null,
             "text": "Enhance .\nPlay: A friendly creature captures 1. Give control of that creature to your opponent.\n",
             "locale": {
+                "de": {
+                    "name": "Alter Tauschtrick"
+                },
                 "en": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "es": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "fr": {
+                    "name": "Bon Vieux Troc"
+                },
+                "it": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "pl": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "pt": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "th": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "vi": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "zhhans": {
+                    "name": "Ol’ Switcheroo"
+                },
+                "zhhant": {
                     "name": "Ol’ Switcheroo"
                 }
             }
@@ -2071,7 +5155,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter", "cyborg"],
+            "traits": [
+                "specter",
+                "cyborg"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2079,7 +5166,37 @@
             "power": 2,
             "text": "Enhance .\nAfter Reap: Discard a card. If you do, give a creature two +1 power counters.\n",
             "locale": {
+                "de": {
+                    "name": "Rezyklops"
+                },
                 "en": {
+                    "name": "Recyclops"
+                },
+                "es": {
+                    "name": "Recyclops"
+                },
+                "fr": {
+                    "name": "Recyclope"
+                },
+                "it": {
+                    "name": "Recyclops"
+                },
+                "pl": {
+                    "name": "Recyclops"
+                },
+                "pt": {
+                    "name": "Recyclops"
+                },
+                "th": {
+                    "name": "Recyclops"
+                },
+                "vi": {
+                    "name": "Recyclops"
+                },
+                "zhhans": {
+                    "name": "Recyclops"
+                },
+                "zhhant": {
                     "name": "Recyclops"
                 }
             }
@@ -2100,7 +5217,37 @@
             "power": null,
             "text": "Play: If you are haunted, deal 5 to a creature. Otherwise, return a creature to its owner’s hand.\n",
             "locale": {
+                "de": {
+                    "name": "Zerlegen und Wiederverwerten"
+                },
                 "en": {
+                    "name": "Reduce, Reuse"
+                },
+                "es": {
+                    "name": "Reduce, Reuse"
+                },
+                "fr": {
+                    "name": "Réduire, Réutiliser"
+                },
+                "it": {
+                    "name": "Reduce, Reuse"
+                },
+                "pl": {
+                    "name": "Reduce, Reuse"
+                },
+                "pt": {
+                    "name": "Reduce, Reuse"
+                },
+                "th": {
+                    "name": "Reduce, Reuse"
+                },
+                "vi": {
+                    "name": "Reduce, Reuse"
+                },
+                "zhhans": {
+                    "name": "Reduce, Reuse"
+                },
+                "zhhant": {
                     "name": "Reduce, Reuse"
                 }
             }
@@ -2112,8 +5259,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_081_b6cde23ea192_en.png",
             "expansion": 928,
             "house": "geistoid",
-            "keywords": ["taunt"],
-            "traits": ["specter", "robot"],
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2121,7 +5273,37 @@
             "power": 4,
             "text": "Taunt. \nIf you are overwhelmed, Spikey Goeff gains hazardous 2.\nScrap: Deal 2 to a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Goeff der Stachelige"
+                },
                 "en": {
+                    "name": "Spikey Goeff"
+                },
+                "es": {
+                    "name": "Spikey Goeff"
+                },
+                "fr": {
+                    "name": "Geoff le Hérissé"
+                },
+                "it": {
+                    "name": "Spikey Goeff"
+                },
+                "pl": {
+                    "name": "Spikey Goeff"
+                },
+                "pt": {
+                    "name": "Spikey Goeff"
+                },
+                "th": {
+                    "name": "Spikey Goeff"
+                },
+                "vi": {
+                    "name": "Spikey Goeff"
+                },
+                "zhhans": {
+                    "name": "Spikey Goeff"
+                },
+                "zhhant": {
                     "name": "Spikey Goeff"
                 }
             }
@@ -2134,7 +5316,10 @@
             "expansion": 928,
             "house": "geistoid",
             "keywords": [],
-            "traits": ["specter", "robot"],
+            "traits": [
+                "specter",
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2142,7 +5327,37 @@
             "power": 4,
             "text": "At the start of your turn, discard a card from your hand.\n",
             "locale": {
+                "de": {
+                    "name": "Geisterkonstrukt"
+                },
                 "en": {
+                    "name": "Wraith Construct"
+                },
+                "es": {
+                    "name": "Wraith Construct"
+                },
+                "fr": {
+                    "name": "Colère Noire"
+                },
+                "it": {
+                    "name": "Wraith Construct"
+                },
+                "pl": {
+                    "name": "Wraith Construct"
+                },
+                "pt": {
+                    "name": "Wraith Construct"
+                },
+                "th": {
+                    "name": "Wraith Construct"
+                },
+                "vi": {
+                    "name": "Wraith Construct"
+                },
+                "zhhans": {
+                    "name": "Wraith Construct"
+                },
+                "zhhant": {
                     "name": "Wraith Construct"
                 }
             }
@@ -2155,7 +5370,10 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["martian", "soldier"],
+            "traits": [
+                "martian",
+                "soldier"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -2163,7 +5381,37 @@
             "power": 2,
             "text": "Each non-Mars creature and artifact gains, “After this card is used, destroy it.”\n",
             "locale": {
+                "de": {
+                    "name": "Bartos der Verwüster"
+                },
                 "en": {
+                    "name": "Bartos the Ruiner"
+                },
+                "es": {
+                    "name": "Bartos the Ruiner"
+                },
+                "fr": {
+                    "name": "Bartos le Ravageur"
+                },
+                "it": {
+                    "name": "Bartos the Ruiner"
+                },
+                "pl": {
+                    "name": "Bartos the Ruiner"
+                },
+                "pt": {
+                    "name": "Bartos the Ruiner"
+                },
+                "th": {
+                    "name": "Bartos the Ruiner"
+                },
+                "vi": {
+                    "name": "Bartos the Ruiner"
+                },
+                "zhhans": {
+                    "name": "Bartos the Ruiner"
+                },
+                "zhhant": {
                     "name": "Bartos the Ruiner"
                 }
             }
@@ -2184,7 +5432,37 @@
             "power": null,
             "text": "This creature gains, “After you play a Mars creature, ready this creature and for the remainder of the turn it belongs to house Mars.”",
             "locale": {
+                "de": {
+                    "name": "Hirnstamm-Antenne"
+                },
                 "en": {
+                    "name": "Brain Stem Antenna"
+                },
+                "es": {
+                    "name": "Brain Stem Antenna"
+                },
+                "fr": {
+                    "name": "Antenne Cérébrale"
+                },
+                "it": {
+                    "name": "Brain Stem Antenna"
+                },
+                "pl": {
+                    "name": "Brain Stem Antenna"
+                },
+                "pt": {
+                    "name": "Brain Stem Antenna"
+                },
+                "th": {
+                    "name": "Brain Stem Antenna"
+                },
+                "vi": {
+                    "name": "Brain Stem Antenna"
+                },
+                "zhhans": {
+                    "name": "Brain Stem Antenna"
+                },
+                "zhhant": {
                     "name": "Brain Stem Antenna"
                 }
             }
@@ -2197,7 +5475,10 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["elder", "recruiter"],
+            "traits": [
+                "elder",
+                "recruiter"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -2205,7 +5486,37 @@
             "power": 3,
             "text": "Enhance  . (These icons have already been added to cards in your deck.)\nAt the end of your turn, give each other Mars creature two +1 power counters.\n",
             "locale": {
+                "de": {
+                    "name": "Ältester Chargenbetreuer"
+                },
                 "en": {
+                    "name": "Eldest Batchminder"
+                },
+                "es": {
+                    "name": "Eldest Batchminder"
+                },
+                "fr": {
+                    "name": "Doyen des Lots"
+                },
+                "it": {
+                    "name": "Eldest Batchminder"
+                },
+                "pl": {
+                    "name": "Eldest Batchminder"
+                },
+                "pt": {
+                    "name": "Eldest Batchminder"
+                },
+                "th": {
+                    "name": "Eldest Batchminder"
+                },
+                "vi": {
+                    "name": "Eldest Batchminder"
+                },
+                "zhhans": {
+                    "name": "Eldest Batchminder"
+                },
+                "zhhant": {
                     "name": "Eldest Batchminder"
                 }
             }
@@ -2218,7 +5529,11 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["martian", "leader", "elder"],
+            "traits": [
+                "martian",
+                "leader",
+                "elder"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -2226,7 +5541,37 @@
             "power": 5,
             "text": "While Emperor Memrox is in the center of your battleline, it gains invulnerable.\nAfter Reap: Archive a card. Gain 1 for each card in your archives.\n",
             "locale": {
+                "de": {
+                    "name": "Imperator Memrox"
+                },
                 "en": {
+                    "name": "Emperor Memrox"
+                },
+                "es": {
+                    "name": "Emperor Memrox"
+                },
+                "fr": {
+                    "name": "Empereur Memrox"
+                },
+                "it": {
+                    "name": "Emperor Memrox"
+                },
+                "pl": {
+                    "name": "Emperor Memrox"
+                },
+                "pt": {
+                    "name": "Emperor Memrox"
+                },
+                "th": {
+                    "name": "Emperor Memrox"
+                },
+                "vi": {
+                    "name": "Emperor Memrox"
+                },
+                "zhhans": {
+                    "name": "Emperor Memrox"
+                },
+                "zhhant": {
                     "name": "Emperor Memrox"
                 }
             }
@@ -2247,7 +5592,37 @@
             "power": null,
             "text": "Play: Destroy a creature and each creature that shares a trait with it. Gain 1 chain.",
             "locale": {
+                "de": {
+                    "name": "Vernichtung"
+                },
                 "en": {
+                    "name": "Extinction"
+                },
+                "es": {
+                    "name": "Extinction"
+                },
+                "fr": {
+                    "name": "Extinction"
+                },
+                "it": {
+                    "name": "Extinction"
+                },
+                "pl": {
+                    "name": "Extinction"
+                },
+                "pt": {
+                    "name": "Extinction"
+                },
+                "th": {
+                    "name": "Extinction"
+                },
+                "vi": {
+                    "name": "Extinction"
+                },
+                "zhhans": {
+                    "name": "Extinction"
+                },
+                "zhhant": {
                     "name": "Extinction"
                 }
             }
@@ -2268,7 +5643,37 @@
             "power": null,
             "text": "Play: For each friendly Mars creature, choose an enemy creature to capture 1 from its own side.",
             "locale": {
+                "de": {
+                    "name": "Hypnotischer Befehl"
+                },
                 "en": {
+                    "name": "Hypnotic Command"
+                },
+                "es": {
+                    "name": "Hypnotic Command"
+                },
+                "fr": {
+                    "name": "Ordre Hypnotique"
+                },
+                "it": {
+                    "name": "Hypnotic Command"
+                },
+                "pl": {
+                    "name": "Hypnotic Command"
+                },
+                "pt": {
+                    "name": "Hypnotic Command"
+                },
+                "th": {
+                    "name": "Hypnotic Command"
+                },
+                "vi": {
+                    "name": "Hypnotic Command"
+                },
+                "zhhans": {
+                    "name": "Hypnotic Command"
+                },
+                "zhhant": {
                     "name": "Hypnotic Command"
                 }
             }
@@ -2289,7 +5694,37 @@
             "power": null,
             "text": "Play: Destroy each friendly creature. For each creature destroyed this way, draw 2 cards.\n",
             "locale": {
+                "de": {
+                    "name": "Marsianische Ausbreitung"
+                },
                 "en": {
+                    "name": "Martian Propagation"
+                },
+                "es": {
+                    "name": "Martian Propagation"
+                },
+                "fr": {
+                    "name": "Propagation Martienne"
+                },
+                "it": {
+                    "name": "Martian Propagation"
+                },
+                "pl": {
+                    "name": "Martian Propagation"
+                },
+                "pt": {
+                    "name": "Martian Propagation"
+                },
+                "th": {
+                    "name": "Martian Propagation"
+                },
+                "vi": {
+                    "name": "Martian Propagation"
+                },
+                "zhhans": {
+                    "name": "Martian Propagation"
+                },
+                "zhhant": {
                     "name": "Martian Propagation"
                 }
             }
@@ -2310,7 +5745,37 @@
             "power": null,
             "text": "Play: Put up to 3 damaged enemy creatures into your archives. If any of these creatures leave your archives, they are put into their owner’s hand instead.",
             "locale": {
+                "de": {
+                    "name": "Massenentführung"
+                },
                 "en": {
+                    "name": "Mass Abduction"
+                },
+                "es": {
+                    "name": "Mass Abduction"
+                },
+                "fr": {
+                    "name": "Enlèvement de Masse"
+                },
+                "it": {
+                    "name": "Mass Abduction"
+                },
+                "pl": {
+                    "name": "Mass Abduction"
+                },
+                "pt": {
+                    "name": "Mass Abduction"
+                },
+                "th": {
+                    "name": "Mass Abduction"
+                },
+                "vi": {
+                    "name": "Mass Abduction"
+                },
+                "zhhans": {
+                    "name": "Mass Abduction"
+                },
+                "zhhant": {
                     "name": "Mass Abduction"
                 }
             }
@@ -2322,8 +5787,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_091_e35c857e4e4a_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": ["deploy"],
-            "traits": ["beast", "experiment"],
+            "keywords": [
+                "deploy"
+            ],
+            "traits": [
+                "beast",
+                "experiment"
+            ],
             "type": "creature",
             "rarity": "Special",
             "amber": 0,
@@ -2331,28 +5801,91 @@
             "power": 1,
             "text": "(Play only with the other half of Monster Zero.)\nDeploy.\nEach of Monster Zero's neighbors belongs to house Mars (instead of its other houses).\nPlay: Give Monster Zero a number of +1 power counters equal to the most powerful friendly creature’s power.\n",
             "locale": {
+                "de": {
+                    "name": "Monster Zero"
+                },
                 "en": {
+                    "name": "Monster Zero"
+                },
+                "es": {
+                    "name": "Monster Zero"
+                },
+                "fr": {
+                    "name": "Monstre Zéro"
+                },
+                "it": {
+                    "name": "Monster Zero"
+                },
+                "pl": {
+                    "name": "Monster Zero"
+                },
+                "pt": {
+                    "name": "Monster Zero"
+                },
+                "th": {
+                    "name": "Monster Zero"
+                },
+                "vi": {
+                    "name": "Monster Zero"
+                },
+                "zhhans": {
+                    "name": "Monster Zero"
+                },
+                "zhhant": {
                     "name": "Monster Zero"
                 }
             }
         },
         {
-            "id": "monster-zero2",
+            "id": "monster-zero22222222222",
             "name": "Monster Zero",
             "number": "091",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_091_7863a243829e_en.png",
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": [],
+            "traits": [
+                "beast",
+                "experiment"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
             "armor": null,
-            "power": null,
-            "text": "",
+            "power": 1,
+            "text": "(Play only with the other half of Monster Zero.)\nDeploy.\nEach of Monster Zero's neighbors belongs to house Mars (instead of its other houses).\nPlay: Give Monster Zero a number of +1 power counters equal to the most powerful friendly creature’s power.\n",
             "locale": {
+                "de": {
+                    "name": "Monster Zero"
+                },
                 "en": {
+                    "name": "Monster Zero"
+                },
+                "es": {
+                    "name": "Monster Zero"
+                },
+                "fr": {
+                    "name": "Monstre Zéro"
+                },
+                "it": {
+                    "name": "Monster Zero"
+                },
+                "pl": {
+                    "name": "Monster Zero"
+                },
+                "pt": {
+                    "name": "Monster Zero"
+                },
+                "th": {
+                    "name": "Monster Zero"
+                },
+                "vi": {
+                    "name": "Monster Zero"
+                },
+                "zhhans": {
+                    "name": "Monster Zero"
+                },
+                "zhhant": {
                     "name": "Monster Zero"
                 }
             }
@@ -2365,7 +5898,9 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["power"],
+            "traits": [
+                "power"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -2373,7 +5908,37 @@
             "power": null,
             "text": "Enraged creatures cannot be used to fight friendly Mars creatures.\nAction: Enrage each enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Psychischer Dunst"
+                },
                 "en": {
+                    "name": "Psychic Haze"
+                },
+                "es": {
+                    "name": "Psychic Haze"
+                },
+                "fr": {
+                    "name": "Brume Psychique"
+                },
+                "it": {
+                    "name": "Psychic Haze"
+                },
+                "pl": {
+                    "name": "Psychic Haze"
+                },
+                "pt": {
+                    "name": "Psychic Haze"
+                },
+                "th": {
+                    "name": "Psychic Haze"
+                },
+                "vi": {
+                    "name": "Psychic Haze"
+                },
+                "zhhans": {
+                    "name": "Psychic Haze"
+                },
+                "zhhant": {
                     "name": "Psychic Haze"
                 }
             }
@@ -2386,7 +5951,9 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["beast"],
+            "traits": [
+                "beast"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -2394,7 +5961,37 @@
             "power": 4,
             "text": "You may play a Mars card during each turn in which Mars is not your active house.\n",
             "locale": {
+                "de": {
+                    "name": "Tangrant"
+                },
                 "en": {
+                    "name": "Tangrant"
+                },
+                "es": {
+                    "name": "Tangrant"
+                },
+                "fr": {
+                    "name": "Tangrant"
+                },
+                "it": {
+                    "name": "Tangrant"
+                },
+                "pl": {
+                    "name": "Tangrant"
+                },
+                "pt": {
+                    "name": "Tangrant"
+                },
+                "th": {
+                    "name": "Tangrant"
+                },
+                "vi": {
+                    "name": "Tangrant"
+                },
+                "zhhans": {
+                    "name": "Tangrant"
+                },
+                "zhhant": {
                     "name": "Tangrant"
                 }
             }
@@ -2415,7 +6012,37 @@
             "power": null,
             "text": "Play: For the remainder of the turn, each enemy creature gains, “Destroyed: Fully heal this creature and give control of it to your opponent instead.”\n",
             "locale": {
+                "de": {
+                    "name": "Die Körperfresser"
+                },
                 "en": {
+                    "name": "The Body Snatchers"
+                },
+                "es": {
+                    "name": "The Body Snatchers"
+                },
+                "fr": {
+                    "name": "Usurpation des Corps"
+                },
+                "it": {
+                    "name": "The Body Snatchers"
+                },
+                "pl": {
+                    "name": "The Body Snatchers"
+                },
+                "pt": {
+                    "name": "The Body Snatchers"
+                },
+                "th": {
+                    "name": "The Body Snatchers"
+                },
+                "vi": {
+                    "name": "The Body Snatchers"
+                },
+                "zhhans": {
+                    "name": "The Body Snatchers"
+                },
+                "zhhant": {
                     "name": "The Body Snatchers"
                 }
             }
@@ -2427,8 +6054,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_095_82674306632c_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": ["elusive"],
-            "traits": ["martian", "politician"],
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "martian",
+                "politician"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -2436,7 +6068,37 @@
             "power": 2,
             "text": "Elusive.\nAfter Reap: Lose all your . Destroy an enemy non-Mars creature for each  lost this way.\n",
             "locale": {
+                "de": {
+                    "name": "Urxym der „Diplomat“"
+                },
                 "en": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "es": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "fr": {
+                    "name": "Urxym le « Diplomate »"
+                },
+                "it": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "pl": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "pt": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "th": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "vi": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "zhhans": {
+                    "name": "Urxym the “Diplomat”"
+                },
+                "zhhant": {
                     "name": "Urxym the “Diplomat”"
                 }
             }
@@ -2449,7 +6111,9 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["power"],
+            "traits": [
+                "power"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -2457,7 +6121,37 @@
             "power": null,
             "text": "Action: Put a creature on the bottom of its owner’s deck. If you do, give a creature two +1 power counters.\n",
             "locale": {
+                "de": {
+                    "name": "Zzysz’ Verdichter"
+                },
                 "en": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "es": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "fr": {
+                    "name": "Compacteur de Zzyszzys"
+                },
+                "it": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "pl": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "pt": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "th": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "vi": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "zhhans": {
+                    "name": "Zzyszz’s Compactor"
+                },
+                "zhhant": {
                     "name": "Zzyszz’s Compactor"
                 }
             }
@@ -2470,7 +6164,9 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["power"],
+            "traits": [
+                "power"
+            ],
             "type": "artifact",
             "rarity": "Uncommon",
             "amber": 0,
@@ -2478,7 +6174,37 @@
             "power": null,
             "text": "Action: Ready and use a friendly creature.\n",
             "locale": {
+                "de": {
+                    "name": "Alle sind Mars"
+                },
                 "en": {
+                    "name": "All Are Mars"
+                },
+                "es": {
+                    "name": "All Are Mars"
+                },
+                "fr": {
+                    "name": "Tous Sont Mars"
+                },
+                "it": {
+                    "name": "All Are Mars"
+                },
+                "pl": {
+                    "name": "All Are Mars"
+                },
+                "pt": {
+                    "name": "All Are Mars"
+                },
+                "th": {
+                    "name": "All Are Mars"
+                },
+                "vi": {
+                    "name": "All Are Mars"
+                },
+                "zhhans": {
+                    "name": "All Are Mars"
+                },
+                "zhhant": {
                     "name": "All Are Mars"
                 }
             }
@@ -2499,7 +6225,37 @@
             "power": null,
             "text": "Play: Destroy an artifact, a creature, and an upgrade.",
             "locale": {
+                "de": {
+                    "name": "Vernichtet sie alle!"
+                },
                 "en": {
+                    "name": "Destroy Them All!"
+                },
+                "es": {
+                    "name": "Destroy Them All!"
+                },
+                "fr": {
+                    "name": "Détruisez-les Tous !"
+                },
+                "it": {
+                    "name": "Destroy Them All!"
+                },
+                "pl": {
+                    "name": "Destroy Them All!"
+                },
+                "pt": {
+                    "name": "Destroy Them All!"
+                },
+                "th": {
+                    "name": "Destroy Them All!"
+                },
+                "vi": {
+                    "name": "Destroy Them All!"
+                },
+                "zhhans": {
+                    "name": "Destroy Them All!"
+                },
+                "zhhant": {
                     "name": "Destroy Them All!"
                 }
             }
@@ -2520,7 +6276,37 @@
             "power": null,
             "text": "Play: Destroy a non-Mars artifact. If you do, you may ready a friendly card. \n",
             "locale": {
+                "de": {
+                    "name": "Mars-Monument"
+                },
                 "en": {
+                    "name": "Edifice for Mars"
+                },
+                "es": {
+                    "name": "Edifice for Mars"
+                },
+                "fr": {
+                    "name": "Édifice à Mars"
+                },
+                "it": {
+                    "name": "Edifice for Mars"
+                },
+                "pl": {
+                    "name": "Edifice for Mars"
+                },
+                "pt": {
+                    "name": "Edifice for Mars"
+                },
+                "th": {
+                    "name": "Edifice for Mars"
+                },
+                "vi": {
+                    "name": "Edifice for Mars"
+                },
+                "zhhans": {
+                    "name": "Edifice for Mars"
+                },
+                "zhhant": {
                     "name": "Edifice for Mars"
                 }
             }
@@ -2533,7 +6319,10 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["martian", "agent"],
+            "traits": [
+                "martian",
+                "agent"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -2541,7 +6330,37 @@
             "power": 3,
             "text": "After Fight: Capture 2. If there are 3 or more on Empowered Zark, you may move 3 from it to the common supply and ready each non-Agent Mars creature.\n",
             "locale": {
+                "de": {
+                    "name": "Ermächtigter Zark"
+                },
                 "en": {
+                    "name": "Empowered Zark"
+                },
+                "es": {
+                    "name": "Empowered Zark"
+                },
+                "fr": {
+                    "name": "Zark l’Augmenté"
+                },
+                "it": {
+                    "name": "Empowered Zark"
+                },
+                "pl": {
+                    "name": "Empowered Zark"
+                },
+                "pt": {
+                    "name": "Empowered Zark"
+                },
+                "th": {
+                    "name": "Empowered Zark"
+                },
+                "vi": {
+                    "name": "Empowered Zark"
+                },
+                "zhhans": {
+                    "name": "Empowered Zark"
+                },
+                "zhhant": {
                     "name": "Empowered Zark"
                 }
             }
@@ -2553,8 +6372,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_101_3c5e74d612ea_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": ["entrench"],
-            "traits": ["beast"],
+            "keywords": [
+                "entrench"
+            ],
+            "traits": [
+                "beast"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -2562,7 +6385,37 @@
             "power": 4,
             "text": "Entrench.\nWhile Golden K1-TT13 is exhausted, each of its neighbors gains, “After Reap: Gain 1.”\n",
             "locale": {
+                "de": {
+                    "name": "Goldenes K4-3TZ3CH3N"
+                },
                 "en": {
+                    "name": "Golden K1-TT13"
+                },
+                "es": {
+                    "name": "Golden K1-TT13"
+                },
+                "fr": {
+                    "name": "CH4-T0N Doré"
+                },
+                "it": {
+                    "name": "Golden K1-TT13"
+                },
+                "pl": {
+                    "name": "Golden K1-TT13"
+                },
+                "pt": {
+                    "name": "Golden K1-TT13"
+                },
+                "th": {
+                    "name": "Golden K1-TT13"
+                },
+                "vi": {
+                    "name": "Golden K1-TT13"
+                },
+                "zhhans": {
+                    "name": "Golden K1-TT13"
+                },
+                "zhhant": {
                     "name": "Golden K1-TT13"
                 }
             }
@@ -2574,8 +6427,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_102_9f799c3a38f5_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": ["elusive"],
-            "traits": ["martian"],
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "martian"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -2583,7 +6440,37 @@
             "power": 3,
             "text": "Elusive. Enhance .\nAction: Lose 1. If you do, move all  from a creature to your pool.\n",
             "locale": {
+                "de": {
+                    "name": "Iyxrenu der Kluge"
+                },
                 "en": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "es": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "fr": {
+                    "name": "Iyxrenu le Rusé"
+                },
+                "it": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "pl": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "pt": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "th": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "vi": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "zhhans": {
+                    "name": "Iyxrenu the Clever"
+                },
+                "zhhant": {
                     "name": "Iyxrenu the Clever"
                 }
             }
@@ -2604,7 +6491,37 @@
             "power": null,
             "text": "Play: You may discard any number of cards from your hand. Then, forge a key at +9 current cost, reduced by 1 for each card discarded this way.\n",
             "locale": {
+                "de": {
+                    "name": "Schlüsselentzug"
+                },
                 "en": {
+                    "name": "Key Drain"
+                },
+                "es": {
+                    "name": "Key Drain"
+                },
+                "fr": {
+                    "name": "Clé en Sous-Pression"
+                },
+                "it": {
+                    "name": "Key Drain"
+                },
+                "pl": {
+                    "name": "Key Drain"
+                },
+                "pt": {
+                    "name": "Key Drain"
+                },
+                "th": {
+                    "name": "Key Drain"
+                },
+                "vi": {
+                    "name": "Key Drain"
+                },
+                "zhhans": {
+                    "name": "Key Drain"
+                },
+                "zhhant": {
                     "name": "Key Drain"
                 }
             }
@@ -2617,7 +6534,10 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["martian", "soldier"],
+            "traits": [
+                "martian",
+                "soldier"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -2625,7 +6545,37 @@
             "power": 2,
             "text": "For each neighbor Nyzyk Resonator has, your opponent’s keys cost +2.",
             "locale": {
+                "de": {
+                    "name": "Nyzyk-Resonator"
+                },
                 "en": {
+                    "name": "Nyzyk Resonator"
+                },
+                "es": {
+                    "name": "Nyzyk Resonator"
+                },
+                "fr": {
+                    "name": "Résonateur Nyzyk"
+                },
+                "it": {
+                    "name": "Nyzyk Resonator"
+                },
+                "pl": {
+                    "name": "Nyzyk Resonator"
+                },
+                "pt": {
+                    "name": "Nyzyk Resonator"
+                },
+                "th": {
+                    "name": "Nyzyk Resonator"
+                },
+                "vi": {
+                    "name": "Nyzyk Resonator"
+                },
+                "zhhans": {
+                    "name": "Nyzyk Resonator"
+                },
+                "zhhant": {
                     "name": "Nyzyk Resonator"
                 }
             }
@@ -2646,7 +6596,37 @@
             "power": null,
             "text": "Play: Reveal any number of Mars cards from your hand. For each card revealed this way, deal 2 to a creature. (You may choose a different creature each time.)",
             "locale": {
+                "de": {
+                    "name": "Orbitalbombardement"
+                },
                 "en": {
+                    "name": "Orbital Bombardment"
+                },
+                "es": {
+                    "name": "Orbital Bombardment"
+                },
+                "fr": {
+                    "name": "Bombardement Orbital"
+                },
+                "it": {
+                    "name": "Orbital Bombardment"
+                },
+                "pl": {
+                    "name": "Orbital Bombardment"
+                },
+                "pt": {
+                    "name": "Orbital Bombardment"
+                },
+                "th": {
+                    "name": "Orbital Bombardment"
+                },
+                "vi": {
+                    "name": "Orbital Bombardment"
+                },
+                "zhhans": {
+                    "name": "Orbital Bombardment"
+                },
+                "zhhant": {
                     "name": "Orbital Bombardment"
                 }
             }
@@ -2667,7 +6647,37 @@
             "power": null,
             "text": "Play: Deal 2 to a friendly non-Mars creature. If it is not destroyed, it captures 2.\n",
             "locale": {
+                "de": {
+                    "name": "Haiköder"
+                },
                 "en": {
+                    "name": "Shark Bait"
+                },
+                "es": {
+                    "name": "Shark Bait"
+                },
+                "fr": {
+                    "name": "Appât à Requin"
+                },
+                "it": {
+                    "name": "Shark Bait"
+                },
+                "pl": {
+                    "name": "Shark Bait"
+                },
+                "pt": {
+                    "name": "Shark Bait"
+                },
+                "th": {
+                    "name": "Shark Bait"
+                },
+                "vi": {
+                    "name": "Shark Bait"
+                },
+                "zhhans": {
+                    "name": "Shark Bait"
+                },
+                "zhhant": {
                     "name": "Shark Bait"
                 }
             }
@@ -2680,7 +6690,9 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["beast"],
+            "traits": [
+                "beast"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -2688,7 +6700,37 @@
             "power": 12,
             "text": "Enhance .\nThe Red Death cannot ready unless you are haunted.\nAfter Fight: Gain 1 and draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Der Rote Tod"
+                },
                 "en": {
+                    "name": "The Red Death"
+                },
+                "es": {
+                    "name": "The Red Death"
+                },
+                "fr": {
+                    "name": "La Mort Rouge"
+                },
+                "it": {
+                    "name": "The Red Death"
+                },
+                "pl": {
+                    "name": "The Red Death"
+                },
+                "pt": {
+                    "name": "The Red Death"
+                },
+                "th": {
+                    "name": "The Red Death"
+                },
+                "vi": {
+                    "name": "The Red Death"
+                },
+                "zhhans": {
+                    "name": "The Red Death"
+                },
+                "zhhant": {
                     "name": "The Red Death"
                 }
             }
@@ -2700,8 +6742,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_108_a15c49e6356e_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": ["elusive"],
-            "traits": ["martian", "elder"],
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "martian",
+                "elder"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -2709,7 +6756,37 @@
             "power": 3,
             "text": "Elusive.\nAfter Reap: The least powerful enemy creature captures 1 from its own side.\n",
             "locale": {
+                "de": {
+                    "name": "lyylyug"
+                },
                 "en": {
+                    "name": "lyylyug"
+                },
+                "es": {
+                    "name": "lyylyug"
+                },
+                "fr": {
+                    "name": "lyylyug"
+                },
+                "it": {
+                    "name": "lyylyug"
+                },
+                "pl": {
+                    "name": "lyylyug"
+                },
+                "pt": {
+                    "name": "lyylyug"
+                },
+                "th": {
+                    "name": "lyylyug"
+                },
+                "vi": {
+                    "name": "lyylyug"
+                },
+                "zhhans": {
+                    "name": "lyylyug"
+                },
+                "zhhant": {
                     "name": "lyylyug"
                 }
             }
@@ -2722,7 +6799,10 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["martian", "agent"],
+            "traits": [
+                "martian",
+                "agent"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2730,7 +6810,37 @@
             "power": 4,
             "text": "After Reap: If you are overwhelmed, give a friendly creature three +1 power counters. Otherwise, give each friendly creature a +1 power counter.\n",
             "locale": {
+                "de": {
+                    "name": "Agent Buuff"
+                },
                 "en": {
+                    "name": "Agent Buuff"
+                },
+                "es": {
+                    "name": "Agent Buuff"
+                },
+                "fr": {
+                    "name": "Agent Buuff"
+                },
+                "it": {
+                    "name": "Agent Buuff"
+                },
+                "pl": {
+                    "name": "Agent Buuff"
+                },
+                "pt": {
+                    "name": "Agent Buuff"
+                },
+                "th": {
+                    "name": "Agent Buuff"
+                },
+                "vi": {
+                    "name": "Agent Buuff"
+                },
+                "zhhans": {
+                    "name": "Agent Buuff"
+                },
+                "zhhant": {
                     "name": "Agent Buuff"
                 }
             }
@@ -2743,7 +6853,9 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["robot"],
+            "traits": [
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2751,7 +6863,37 @@
             "power": 3,
             "text": "After Reap: Destroy a friendly non-Mars creature. If you do, take control of an enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Vermittler Vyynx"
+                },
                 "en": {
+                    "name": "Arbiter Vyynx"
+                },
+                "es": {
+                    "name": "Arbiter Vyynx"
+                },
+                "fr": {
+                    "name": "Médiateur Vyynx"
+                },
+                "it": {
+                    "name": "Arbiter Vyynx"
+                },
+                "pl": {
+                    "name": "Arbiter Vyynx"
+                },
+                "pt": {
+                    "name": "Arbiter Vyynx"
+                },
+                "th": {
+                    "name": "Arbiter Vyynx"
+                },
+                "vi": {
+                    "name": "Arbiter Vyynx"
+                },
+                "zhhans": {
+                    "name": "Arbiter Vyynx"
+                },
+                "zhhant": {
                     "name": "Arbiter Vyynx"
                 }
             }
@@ -2764,7 +6906,9 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["beast"],
+            "traits": [
+                "beast"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2772,7 +6916,37 @@
             "power": 2,
             "text": "After Fight: Put the creature Collector Worm fights into your archives. (Both creatures must survive the fight.) If that creature leaves your archives, put it in its owner’s hand instead.\n",
             "locale": {
+                "de": {
+                    "name": "Sammler-Wurm"
+                },
                 "en": {
+                    "name": "Collector Worm"
+                },
+                "es": {
+                    "name": "Collector Worm"
+                },
+                "fr": {
+                    "name": "Ver Collectionneur"
+                },
+                "it": {
+                    "name": "Collector Worm"
+                },
+                "pl": {
+                    "name": "Collector Worm"
+                },
+                "pt": {
+                    "name": "Collector Worm"
+                },
+                "th": {
+                    "name": "Collector Worm"
+                },
+                "vi": {
+                    "name": "Collector Worm"
+                },
+                "zhhans": {
+                    "name": "Collector Worm"
+                },
+                "zhhant": {
                     "name": "Collector Worm"
                 }
             }
@@ -2793,7 +6967,37 @@
             "power": null,
             "text": "Play: Discard the top card of your opponent’s deck. If it is not a Mars card, an enemy creature captures 1 from its own side.\n",
             "locale": {
+                "de": {
+                    "name": "Digitale Manipulation"
+                },
                 "en": {
+                    "name": "Digital Manipulation"
+                },
+                "es": {
+                    "name": "Digital Manipulation"
+                },
+                "fr": {
+                    "name": "Manipulation Numérique"
+                },
+                "it": {
+                    "name": "Digital Manipulation"
+                },
+                "pl": {
+                    "name": "Digital Manipulation"
+                },
+                "pt": {
+                    "name": "Digital Manipulation"
+                },
+                "th": {
+                    "name": "Digital Manipulation"
+                },
+                "vi": {
+                    "name": "Digital Manipulation"
+                },
+                "zhhans": {
+                    "name": "Digital Manipulation"
+                },
+                "zhhant": {
                     "name": "Digital Manipulation"
                 }
             }
@@ -2814,7 +7018,37 @@
             "power": null,
             "text": "Play: Deal 2 to a creature. Reveal a random card from a player’s archives. If you do, deal an additional 3 to the same creature. Discard the revealed card.\n",
             "locale": {
+                "de": {
+                    "name": "Harmonisches Rudel"
+                },
                 "en": {
+                    "name": "Harmonic Pack"
+                },
+                "es": {
+                    "name": "Harmonic Pack"
+                },
+                "fr": {
+                    "name": "Meute Harmonique"
+                },
+                "it": {
+                    "name": "Harmonic Pack"
+                },
+                "pl": {
+                    "name": "Harmonic Pack"
+                },
+                "pt": {
+                    "name": "Harmonic Pack"
+                },
+                "th": {
+                    "name": "Harmonic Pack"
+                },
+                "vi": {
+                    "name": "Harmonic Pack"
+                },
+                "zhhans": {
+                    "name": "Harmonic Pack"
+                },
+                "zhhant": {
                     "name": "Harmonic Pack"
                 }
             }
@@ -2835,7 +7069,37 @@
             "power": null,
             "text": "Play: Put each Mars creature into its owner’s archives. Destroy each creature. Gain 3 chains.\n",
             "locale": {
+                "de": {
+                    "name": "Kabumm!"
+                },
                 "en": {
+                    "name": "Kaboom!"
+                },
+                "es": {
+                    "name": "Kaboom!"
+                },
+                "fr": {
+                    "name": "Bâaoum !"
+                },
+                "it": {
+                    "name": "Kaboom!"
+                },
+                "pl": {
+                    "name": "Kaboom!"
+                },
+                "pt": {
+                    "name": "Kaboom!"
+                },
+                "th": {
+                    "name": "Kaboom!"
+                },
+                "vi": {
+                    "name": "Kaboom!"
+                },
+                "zhhans": {
+                    "name": "Kaboom!"
+                },
+                "zhhant": {
                     "name": "Kaboom!"
                 }
             }
@@ -2848,7 +7112,10 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["martian", "soldier"],
+            "traits": [
+                "martian",
+                "soldier"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2856,7 +7123,37 @@
             "power": 3,
             "text": "Enhance .\nAfter Reap: You may remove each +1 power counter from a creature. If one or more counters are removed this way, archive a card.\n",
             "locale": {
+                "de": {
+                    "name": "Klyyhnug"
+                },
                 "en": {
+                    "name": "Klyyhnug"
+                },
+                "es": {
+                    "name": "Klyyhnug"
+                },
+                "fr": {
+                    "name": "Klyyhnug"
+                },
+                "it": {
+                    "name": "Klyyhnug"
+                },
+                "pl": {
+                    "name": "Klyyhnug"
+                },
+                "pt": {
+                    "name": "Klyyhnug"
+                },
+                "th": {
+                    "name": "Klyyhnug"
+                },
+                "vi": {
+                    "name": "Klyyhnug"
+                },
+                "zhhans": {
+                    "name": "Klyyhnug"
+                },
+                "zhhant": {
                     "name": "Klyyhnug"
                 }
             }
@@ -2868,8 +7165,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_116_dda3661d5b7d_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": ["entrench"],
-            "traits": ["martian", "elder"],
+            "keywords": [
+                "entrench"
+            ],
+            "traits": [
+                "martian",
+                "elder"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2877,7 +7179,37 @@
             "power": 3,
             "text": "Entrench.\nWhile Operator Olluyyg is exhausted, your opponent’s keys cost +3.\n",
             "locale": {
+                "de": {
+                    "name": "Operator Olluyyg"
+                },
                 "en": {
+                    "name": "Operator Olluyyg"
+                },
+                "es": {
+                    "name": "Operator Olluyyg"
+                },
+                "fr": {
+                    "name": "Opérateur Olluyyg"
+                },
+                "it": {
+                    "name": "Operator Olluyyg"
+                },
+                "pl": {
+                    "name": "Operator Olluyyg"
+                },
+                "pt": {
+                    "name": "Operator Olluyyg"
+                },
+                "th": {
+                    "name": "Operator Olluyyg"
+                },
+                "vi": {
+                    "name": "Operator Olluyyg"
+                },
+                "zhhans": {
+                    "name": "Operator Olluyyg"
+                },
+                "zhhant": {
                     "name": "Operator Olluyyg"
                 }
             }
@@ -2898,7 +7230,37 @@
             "power": null,
             "text": "Play: You may discard a non-Mars card. If you do, a friendly creature captures 1 for each bonus icon on the discarded card.\n",
             "locale": {
+                "de": {
+                    "name": "Produktiver Müll"
+                },
                 "en": {
+                    "name": "Productive Trash"
+                },
+                "es": {
+                    "name": "Productive Trash"
+                },
+                "fr": {
+                    "name": "Déchets Productifs"
+                },
+                "it": {
+                    "name": "Productive Trash"
+                },
+                "pl": {
+                    "name": "Productive Trash"
+                },
+                "pt": {
+                    "name": "Productive Trash"
+                },
+                "th": {
+                    "name": "Productive Trash"
+                },
+                "vi": {
+                    "name": "Productive Trash"
+                },
+                "zhhans": {
+                    "name": "Productive Trash"
+                },
+                "zhhant": {
                     "name": "Productive Trash"
                 }
             }
@@ -2910,8 +7272,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_118_3a67c38224f0_en.png",
             "expansion": 928,
             "house": "mars",
-            "keywords": ["deploy"],
-            "traits": ["martian", "soldier"],
+            "keywords": [
+                "deploy"
+            ],
+            "traits": [
+                "martian",
+                "soldier"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2919,7 +7286,37 @@
             "power": 3,
             "text": "Deploy.\nPlay: Put a neighboring non-Soldier creature into its owner’s hand. If you do, the most powerful friendly creature captures 2.\n",
             "locale": {
+                "de": {
+                    "name": "Ersatz-Ziel"
+                },
                 "en": {
+                    "name": "Replacement Targ"
+                },
+                "es": {
+                    "name": "Replacement Targ"
+                },
+                "fr": {
+                    "name": "Agent de Remplacement"
+                },
+                "it": {
+                    "name": "Replacement Targ"
+                },
+                "pl": {
+                    "name": "Replacement Targ"
+                },
+                "pt": {
+                    "name": "Replacement Targ"
+                },
+                "th": {
+                    "name": "Replacement Targ"
+                },
+                "vi": {
+                    "name": "Replacement Targ"
+                },
+                "zhhans": {
+                    "name": "Replacement Targ"
+                },
+                "zhhant": {
                     "name": "Replacement Targ"
                 }
             }
@@ -2940,7 +7337,37 @@
             "power": null,
             "text": "Play: Give a creature two +1 power counters. You may remove any number of +1 power counters from a friendly creature. That creature captures 1 for each counter removed this way.\n",
             "locale": {
+                "de": {
+                    "name": "Transmutation"
+                },
                 "en": {
+                    "name": "Transmutation"
+                },
+                "es": {
+                    "name": "Transmutation"
+                },
+                "fr": {
+                    "name": "Transmutation"
+                },
+                "it": {
+                    "name": "Transmutation"
+                },
+                "pl": {
+                    "name": "Transmutation"
+                },
+                "pt": {
+                    "name": "Transmutation"
+                },
+                "th": {
+                    "name": "Transmutation"
+                },
+                "vi": {
+                    "name": "Transmutation"
+                },
+                "zhhans": {
+                    "name": "Transmutation"
+                },
+                "zhhant": {
                     "name": "Transmutation"
                 }
             }
@@ -2953,7 +7380,10 @@
             "expansion": 928,
             "house": "mars",
             "keywords": [],
-            "traits": ["martian", "soldier"],
+            "traits": [
+                "martian",
+                "soldier"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -2961,7 +7391,37 @@
             "power": 2,
             "text": "After Fight/After Reap: If you are overwhelmed, stun an enemy creature and each of its neighbors. Otherwise, stun a creature. \n",
             "locale": {
+                "de": {
+                    "name": "Ujkyytr der Primus"
+                },
                 "en": {
+                    "name": "Ujkyytr Prime"
+                },
+                "es": {
+                    "name": "Ujkyytr Prime"
+                },
+                "fr": {
+                    "name": "Ujkyytr Premier"
+                },
+                "it": {
+                    "name": "Ujkyytr Prime"
+                },
+                "pl": {
+                    "name": "Ujkyytr Prime"
+                },
+                "pt": {
+                    "name": "Ujkyytr Prime"
+                },
+                "th": {
+                    "name": "Ujkyytr Prime"
+                },
+                "vi": {
+                    "name": "Ujkyytr Prime"
+                },
+                "zhhans": {
+                    "name": "Ujkyytr Prime"
+                },
+                "zhhant": {
                     "name": "Ujkyytr Prime"
                 }
             }
@@ -2974,7 +7434,10 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon", "leader"],
+            "traits": [
+                "dragon",
+                "leader"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -2982,7 +7445,37 @@
             "power": 7,
             "text": "While Agorim is in the center of your battleline, friendly creatures get +5 power.\n",
             "locale": {
+                "de": {
+                    "name": "Agorim"
+                },
                 "en": {
+                    "name": "Agorim"
+                },
+                "es": {
+                    "name": "Agorim"
+                },
+                "fr": {
+                    "name": "Agorim"
+                },
+                "it": {
+                    "name": "Agorim"
+                },
+                "pl": {
+                    "name": "Agorim"
+                },
+                "pt": {
+                    "name": "Agorim"
+                },
+                "th": {
+                    "name": "Agorim"
+                },
+                "vi": {
+                    "name": "Agorim"
+                },
+                "zhhans": {
+                    "name": "Agorim"
+                },
+                "zhhant": {
                     "name": "Agorim"
                 }
             }
@@ -3003,7 +7496,37 @@
             "power": null,
             "text": "Play: If you are overwhelmed, draw 3 cards.\n",
             "locale": {
+                "de": {
+                    "name": "Ascheflügel-Protokoll"
+                },
                 "en": {
+                    "name": "Ashwing Protocol"
+                },
+                "es": {
+                    "name": "Ashwing Protocol"
+                },
+                "fr": {
+                    "name": "Protocole Cendraile"
+                },
+                "it": {
+                    "name": "Ashwing Protocol"
+                },
+                "pl": {
+                    "name": "Ashwing Protocol"
+                },
+                "pt": {
+                    "name": "Ashwing Protocol"
+                },
+                "th": {
+                    "name": "Ashwing Protocol"
+                },
+                "vi": {
+                    "name": "Ashwing Protocol"
+                },
+                "zhhans": {
+                    "name": "Ashwing Protocol"
+                },
+                "zhhant": {
                     "name": "Ashwing Protocol"
                 }
             }
@@ -3024,7 +7547,37 @@
             "power": null,
             "text": "Play: Deal 3 to each creature. For each creature destroyed this way, exhaust a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Chloroschlummer-Nebel"
+                },
                 "en": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "es": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "fr": {
+                    "name": "Vapeur Sédative"
+                },
+                "it": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "pl": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "pt": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "th": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "vi": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "zhhans": {
+                    "name": "Chlorodoze Vapor"
+                },
+                "zhhant": {
                     "name": "Chlorodoze Vapor"
                 }
             }
@@ -3037,7 +7590,9 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["power"],
+            "traits": [
+                "power"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -3045,7 +7600,37 @@
             "power": null,
             "text": "Keys cost +2.\nAfter your opponent forges a key, gain 2, draw 4 cards, and destroy Cyn Dynasty.\n",
             "locale": {
+                "de": {
+                    "name": "Cyn-Dynastie"
+                },
                 "en": {
+                    "name": "Cyn Dynasty"
+                },
+                "es": {
+                    "name": "Cyn Dynasty"
+                },
+                "fr": {
+                    "name": "Dynastie des Cyn"
+                },
+                "it": {
+                    "name": "Cyn Dynasty"
+                },
+                "pl": {
+                    "name": "Cyn Dynasty"
+                },
+                "pt": {
+                    "name": "Cyn Dynasty"
+                },
+                "th": {
+                    "name": "Cyn Dynasty"
+                },
+                "vi": {
+                    "name": "Cyn Dynasty"
+                },
+                "zhhans": {
+                    "name": "Cyn Dynasty"
+                },
+                "zhhant": {
                     "name": "Cyn Dynasty"
                 }
             }
@@ -3057,8 +7642,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_125_b2d19691951d_en.png",
             "expansion": 928,
             "house": "ouboros",
-            "keywords": ["entrench"],
-            "traits": ["dragon"],
+            "keywords": [
+                "entrench"
+            ],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3066,7 +7655,37 @@
             "power": 5,
             "text": "Entrench.\nAt the start of your turn, if Dray Conis is exhausted, destroy each creature.\n",
             "locale": {
+                "de": {
+                    "name": "Dray Conis"
+                },
                 "en": {
+                    "name": "Dray Conis"
+                },
+                "es": {
+                    "name": "Dray Conis"
+                },
+                "fr": {
+                    "name": "Dray Conis"
+                },
+                "it": {
+                    "name": "Dray Conis"
+                },
+                "pl": {
+                    "name": "Dray Conis"
+                },
+                "pt": {
+                    "name": "Dray Conis"
+                },
+                "th": {
+                    "name": "Dray Conis"
+                },
+                "vi": {
+                    "name": "Dray Conis"
+                },
+                "zhhans": {
+                    "name": "Dray Conis"
+                },
+                "zhhant": {
                     "name": "Dray Conis"
                 }
             }
@@ -3087,7 +7706,37 @@
             "power": null,
             "text": "Play: For each forged key your opponent has, an enemy creature captures 2 from its own side.\n",
             "locale": {
+                "de": {
+                    "name": "Goldene Bürde"
+                },
                 "en": {
+                    "name": "Gilded Burden"
+                },
+                "es": {
+                    "name": "Gilded Burden"
+                },
+                "fr": {
+                    "name": "Fardeau Doré"
+                },
+                "it": {
+                    "name": "Gilded Burden"
+                },
+                "pl": {
+                    "name": "Gilded Burden"
+                },
+                "pt": {
+                    "name": "Gilded Burden"
+                },
+                "th": {
+                    "name": "Gilded Burden"
+                },
+                "vi": {
+                    "name": "Gilded Burden"
+                },
+                "zhhans": {
+                    "name": "Gilded Burden"
+                },
+                "zhhant": {
                     "name": "Gilded Burden"
                 }
             }
@@ -3108,28 +7757,90 @@
             "power": null,
             "text": "This creature gains, “After Fight/After Reap: If you are overwhelmed, gain 1 and deal 3 to an enemy creature.”\n",
             "locale": {
+                "de": {
+                    "name": "Schatzschürfer"
+                },
                 "en": {
+                    "name": "Hoardgouge"
+                },
+                "es": {
+                    "name": "Hoardgouge"
+                },
+                "fr": {
+                    "name": "Creuse-Butin"
+                },
+                "it": {
+                    "name": "Hoardgouge"
+                },
+                "pl": {
+                    "name": "Hoardgouge"
+                },
+                "pt": {
+                    "name": "Hoardgouge"
+                },
+                "th": {
+                    "name": "Hoardgouge"
+                },
+                "vi": {
+                    "name": "Hoardgouge"
+                },
+                "zhhans": {
+                    "name": "Hoardgouge"
+                },
+                "zhhant": {
                     "name": "Hoardgouge"
                 }
             }
         },
         {
-            "id": "kulsha2",
+            "id": "kulsha22222222222",
             "name": "Kulsha",
             "number": "128",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_128_c5974a21655f_en.png",
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": [],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
             "armor": null,
-            "power": null,
-            "text": "",
+            "power": 15,
+            "text": "(Play only with the other half of Kulsha.)\nYour opponent’s keys cost +2 for each forged key they have. \nAfter Fight/After Reap: Exhaust up to 3 creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Kulsha"
+                },
                 "en": {
+                    "name": "Kulsha"
+                },
+                "es": {
+                    "name": "Kulsha"
+                },
+                "fr": {
+                    "name": "Kulsha"
+                },
+                "it": {
+                    "name": "Kulsha"
+                },
+                "pl": {
+                    "name": "Kulsha"
+                },
+                "pt": {
+                    "name": "Kulsha"
+                },
+                "th": {
+                    "name": "Kulsha"
+                },
+                "vi": {
+                    "name": "Kulsha"
+                },
+                "zhhans": {
+                    "name": "Kulsha"
+                },
+                "zhhant": {
                     "name": "Kulsha"
                 }
             }
@@ -3142,7 +7853,9 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon"],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Special",
             "amber": 0,
@@ -3150,7 +7863,37 @@
             "power": 15,
             "text": "(Play only with the other half of Kulsha.)\nYour opponent’s keys cost +2 for each forged key they have. \nAfter Fight/After Reap: Exhaust up to 3 creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Kulsha"
+                },
                 "en": {
+                    "name": "Kulsha"
+                },
+                "es": {
+                    "name": "Kulsha"
+                },
+                "fr": {
+                    "name": "Kulsha"
+                },
+                "it": {
+                    "name": "Kulsha"
+                },
+                "pl": {
+                    "name": "Kulsha"
+                },
+                "pt": {
+                    "name": "Kulsha"
+                },
+                "th": {
+                    "name": "Kulsha"
+                },
+                "vi": {
+                    "name": "Kulsha"
+                },
+                "zhhans": {
+                    "name": "Kulsha"
+                },
+                "zhhant": {
                     "name": "Kulsha"
                 }
             }
@@ -3163,7 +7906,10 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon", "psion"],
+            "traits": [
+                "dragon",
+                "psion"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3171,7 +7917,37 @@
             "power": 6,
             "text": "While fighting, Nizak, The Forgotten gains invulnerable. (It cannot be destroyed or dealt damage.)\nAfter an enemy creature is destroyed fighting Nizak, The Forgotten, return that creature to its owner’s hand.\n",
             "locale": {
+                "de": {
+                    "name": "Nizak der Vergessene"
+                },
                 "en": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "es": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "fr": {
+                    "name": "Nizak, l’Oublié"
+                },
+                "it": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "pl": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "pt": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "th": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "vi": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "zhhans": {
+                    "name": "Nizak, The Forgotten"
+                },
+                "zhhant": {
                     "name": "Nizak, The Forgotten"
                 }
             }
@@ -3192,7 +7968,37 @@
             "power": null,
             "text": "Play: Ready or exhaust a creature. If there are more exhausted friendly creatures than exhausted enemy creatures, gain 2.\n",
             "locale": {
+                "de": {
+                    "name": "Höchste Autorität"
+                },
                 "en": {
+                    "name": "Prime Authority"
+                },
+                "es": {
+                    "name": "Prime Authority"
+                },
+                "fr": {
+                    "name": "Autorité Primaire"
+                },
+                "it": {
+                    "name": "Prime Authority"
+                },
+                "pl": {
+                    "name": "Prime Authority"
+                },
+                "pt": {
+                    "name": "Prime Authority"
+                },
+                "th": {
+                    "name": "Prime Authority"
+                },
+                "vi": {
+                    "name": "Prime Authority"
+                },
+                "zhhans": {
+                    "name": "Prime Authority"
+                },
+                "zhhant": {
                     "name": "Prime Authority"
                 }
             }
@@ -3205,7 +8011,9 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon"],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3213,7 +8021,37 @@
             "power": 6,
             "text": "While Seda the Sleeper is exhausted and on a flank, it gains invulnerable. \nAfter you ready Seda the Sleeper, you may deal 2 to it. If you do, exhaust it.\nPlay: Capture 6.\n",
             "locale": {
+                "de": {
+                    "name": "Seda der Schläfer"
+                },
                 "en": {
+                    "name": "Seda the Sleeper"
+                },
+                "es": {
+                    "name": "Seda the Sleeper"
+                },
+                "fr": {
+                    "name": "Satya l’Endormi"
+                },
+                "it": {
+                    "name": "Seda the Sleeper"
+                },
+                "pl": {
+                    "name": "Seda the Sleeper"
+                },
+                "pt": {
+                    "name": "Seda the Sleeper"
+                },
+                "th": {
+                    "name": "Seda the Sleeper"
+                },
+                "vi": {
+                    "name": "Seda the Sleeper"
+                },
+                "zhhans": {
+                    "name": "Seda the Sleeper"
+                },
+                "zhhant": {
                     "name": "Seda the Sleeper"
                 }
             }
@@ -3234,7 +8072,37 @@
             "power": null,
             "text": "Enhance .\nPlay: Destroy an Ouboros creature. If you do, gain 2.\n",
             "locale": {
+                "de": {
+                    "name": "Schlafschwund"
+                },
                 "en": {
+                    "name": "Sleepwither"
+                },
+                "es": {
+                    "name": "Sleepwither"
+                },
+                "fr": {
+                    "name": "Sommeil Flétrissant"
+                },
+                "it": {
+                    "name": "Sleepwither"
+                },
+                "pl": {
+                    "name": "Sleepwither"
+                },
+                "pt": {
+                    "name": "Sleepwither"
+                },
+                "th": {
+                    "name": "Sleepwither"
+                },
+                "vi": {
+                    "name": "Sleepwither"
+                },
+                "zhhans": {
+                    "name": "Sleepwither"
+                },
+                "zhhant": {
                     "name": "Sleepwither"
                 }
             }
@@ -3247,7 +8115,9 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["treasure"],
+            "traits": [
+                "treasure"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 1,
@@ -3255,7 +8125,37 @@
             "power": null,
             "text": "Action: Destroy Spherular Gem. If you do, gain  equal to the number of forged keys.\n",
             "locale": {
+                "de": {
+                    "name": "Kugelartige Gemme"
+                },
                 "en": {
+                    "name": "Spherular Gem"
+                },
+                "es": {
+                    "name": "Spherular Gem"
+                },
+                "fr": {
+                    "name": "Gemme Sphérulaire"
+                },
+                "it": {
+                    "name": "Spherular Gem"
+                },
+                "pl": {
+                    "name": "Spherular Gem"
+                },
+                "pt": {
+                    "name": "Spherular Gem"
+                },
+                "th": {
+                    "name": "Spherular Gem"
+                },
+                "vi": {
+                    "name": "Spherular Gem"
+                },
+                "zhhans": {
+                    "name": "Spherular Gem"
+                },
+                "zhhant": {
                     "name": "Spherular Gem"
                 }
             }
@@ -3268,7 +8168,9 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon"],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3276,7 +8178,37 @@
             "power": 6,
             "text": "Tranquil Reiner does not ready during your “ready cards” step.\nAfter Fight/After Reap: Ready an exhausted non-Dragon creature. If you do, gain 3.\n",
             "locale": {
+                "de": {
+                    "name": "Reiner der Friedvolle"
+                },
                 "en": {
+                    "name": "Tranquil Reiner"
+                },
+                "es": {
+                    "name": "Tranquil Reiner"
+                },
+                "fr": {
+                    "name": "Tranquille Émile"
+                },
+                "it": {
+                    "name": "Tranquil Reiner"
+                },
+                "pl": {
+                    "name": "Tranquil Reiner"
+                },
+                "pt": {
+                    "name": "Tranquil Reiner"
+                },
+                "th": {
+                    "name": "Tranquil Reiner"
+                },
+                "vi": {
+                    "name": "Tranquil Reiner"
+                },
+                "zhhans": {
+                    "name": "Tranquil Reiner"
+                },
+                "zhhant": {
                     "name": "Tranquil Reiner"
                 }
             }
@@ -3289,7 +8221,10 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon", "sage"],
+            "traits": [
+                "dragon",
+                "sage"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3297,7 +8232,37 @@
             "power": 6,
             "text": "After Reap: Choose a creature. Until the start of your next turn, that creature gains invulnerable. (It cannot be destroyed or dealt damage.)\n",
             "locale": {
+                "de": {
+                    "name": "Treok der Weise"
+                },
                 "en": {
+                    "name": "Treok, The Wise"
+                },
+                "es": {
+                    "name": "Treok, The Wise"
+                },
+                "fr": {
+                    "name": "Treok, le Judicieux"
+                },
+                "it": {
+                    "name": "Treok, The Wise"
+                },
+                "pl": {
+                    "name": "Treok, The Wise"
+                },
+                "pt": {
+                    "name": "Treok, The Wise"
+                },
+                "th": {
+                    "name": "Treok, The Wise"
+                },
+                "vi": {
+                    "name": "Treok, The Wise"
+                },
+                "zhhans": {
+                    "name": "Treok, The Wise"
+                },
+                "zhhant": {
                     "name": "Treok, The Wise"
                 }
             }
@@ -3310,7 +8275,9 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon"],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -3318,7 +8285,37 @@
             "power": 4,
             "text": "Your keys cost –1 for each forged key your opponent has.\n",
             "locale": {
+                "de": {
+                    "name": "Bollwerkklaue"
+                },
                 "en": {
+                    "name": "Bastionclaw"
+                },
+                "es": {
+                    "name": "Bastionclaw"
+                },
+                "fr": {
+                    "name": "Bastus le Griffu"
+                },
+                "it": {
+                    "name": "Bastionclaw"
+                },
+                "pl": {
+                    "name": "Bastionclaw"
+                },
+                "pt": {
+                    "name": "Bastionclaw"
+                },
+                "th": {
+                    "name": "Bastionclaw"
+                },
+                "vi": {
+                    "name": "Bastionclaw"
+                },
+                "zhhans": {
+                    "name": "Bastionclaw"
+                },
+                "zhhant": {
                     "name": "Bastionclaw"
                 }
             }
@@ -3330,8 +8327,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_137_604de4641871_en.png",
             "expansion": 928,
             "house": "ouboros",
-            "keywords": ["entrench"],
-            "traits": ["dragon"],
+            "keywords": [
+                "entrench"
+            ],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -3339,7 +8340,37 @@
             "power": 3,
             "text": "Entrench.\nAt the end of your turn, if Caspart is exhausted, exhaust 2 other creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Caspart"
+                },
                 "en": {
+                    "name": "Caspart"
+                },
+                "es": {
+                    "name": "Caspart"
+                },
+                "fr": {
+                    "name": "Caspard"
+                },
+                "it": {
+                    "name": "Caspart"
+                },
+                "pl": {
+                    "name": "Caspart"
+                },
+                "pt": {
+                    "name": "Caspart"
+                },
+                "th": {
+                    "name": "Caspart"
+                },
+                "vi": {
+                    "name": "Caspart"
+                },
+                "zhhans": {
+                    "name": "Caspart"
+                },
+                "zhhant": {
                     "name": "Caspart"
                 }
             }
@@ -3360,7 +8391,37 @@
             "power": null,
             "text": "Play: Shuffle any number of Dragon creatures from your discard pile into your deck.\n",
             "locale": {
+                "de": {
+                    "name": "DRACHEN!!!"
+                },
                 "en": {
+                    "name": "DRAGONS!!!"
+                },
+                "es": {
+                    "name": "DRAGONS!!!"
+                },
+                "fr": {
+                    "name": "DRAGONS !!!"
+                },
+                "it": {
+                    "name": "DRAGONS!!!"
+                },
+                "pl": {
+                    "name": "DRAGONS!!!"
+                },
+                "pt": {
+                    "name": "DRAGONS!!!"
+                },
+                "th": {
+                    "name": "DRAGONS!!!"
+                },
+                "vi": {
+                    "name": "DRAGONS!!!"
+                },
+                "zhhans": {
+                    "name": "DRAGONS!!!"
+                },
+                "zhhant": {
                     "name": "DRAGONS!!!"
                 }
             }
@@ -3381,7 +8442,37 @@
             "power": null,
             "text": "Play: Exhaust each non-Dragon creature.\n",
             "locale": {
+                "de": {
+                    "name": "Schnarchschwinge"
+                },
                 "en": {
+                    "name": "Doze Wing"
+                },
+                "es": {
+                    "name": "Doze Wing"
+                },
+                "fr": {
+                    "name": "Sous Son Aile"
+                },
+                "it": {
+                    "name": "Doze Wing"
+                },
+                "pl": {
+                    "name": "Doze Wing"
+                },
+                "pt": {
+                    "name": "Doze Wing"
+                },
+                "th": {
+                    "name": "Doze Wing"
+                },
+                "vi": {
+                    "name": "Doze Wing"
+                },
+                "zhhans": {
+                    "name": "Doze Wing"
+                },
+                "zhhant": {
                     "name": "Doze Wing"
                 }
             }
@@ -3402,7 +8493,37 @@
             "power": null,
             "text": "Play: For each color represented among forged keys, steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Glitzernde Horde"
+                },
                 "en": {
+                    "name": "Glittering Horde"
+                },
+                "es": {
+                    "name": "Glittering Horde"
+                },
+                "fr": {
+                    "name": "Horde Scintillante"
+                },
+                "it": {
+                    "name": "Glittering Horde"
+                },
+                "pl": {
+                    "name": "Glittering Horde"
+                },
+                "pt": {
+                    "name": "Glittering Horde"
+                },
+                "th": {
+                    "name": "Glittering Horde"
+                },
+                "vi": {
+                    "name": "Glittering Horde"
+                },
+                "zhhans": {
+                    "name": "Glittering Horde"
+                },
+                "zhhant": {
                     "name": "Glittering Horde"
                 }
             }
@@ -3415,7 +8536,9 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon"],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -3423,7 +8546,37 @@
             "power": 4,
             "text": "Ignitus gains splash-attack X, where X is the number of exhausted creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Ignitus"
+                },
                 "en": {
+                    "name": "Ignitus"
+                },
+                "es": {
+                    "name": "Ignitus"
+                },
+                "fr": {
+                    "name": "Allumax"
+                },
+                "it": {
+                    "name": "Ignitus"
+                },
+                "pl": {
+                    "name": "Ignitus"
+                },
+                "pt": {
+                    "name": "Ignitus"
+                },
+                "th": {
+                    "name": "Ignitus"
+                },
+                "vi": {
+                    "name": "Ignitus"
+                },
+                "zhhans": {
+                    "name": "Ignitus"
+                },
+                "zhhant": {
                     "name": "Ignitus"
                 }
             }
@@ -3435,8 +8588,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_142_04f306267c69_en.png",
             "expansion": 928,
             "house": "ouboros",
-            "keywords": ["entrench"],
-            "traits": ["dragon"],
+            "keywords": [
+                "entrench"
+            ],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -3444,7 +8601,37 @@
             "power": 4,
             "text": "Entrench.\nAt the start of your turn, if Noxious Ionox is exhausted, destroy an enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Toxischer Ionos"
+                },
                 "en": {
+                    "name": "Noxious Ionox"
+                },
+                "es": {
+                    "name": "Noxious Ionox"
+                },
+                "fr": {
+                    "name": "Smaragdin le Nocif"
+                },
+                "it": {
+                    "name": "Noxious Ionox"
+                },
+                "pl": {
+                    "name": "Noxious Ionox"
+                },
+                "pt": {
+                    "name": "Noxious Ionox"
+                },
+                "th": {
+                    "name": "Noxious Ionox"
+                },
+                "vi": {
+                    "name": "Noxious Ionox"
+                },
+                "zhhans": {
+                    "name": "Noxious Ionox"
+                },
+                "zhhant": {
                     "name": "Noxious Ionox"
                 }
             }
@@ -3465,7 +8652,37 @@
             "power": null,
             "text": "Play: Forge a key at +8 current cost, reduced by 1 for each  in your opponent’s pool. If you do, purge Parasitic Charge.\n",
             "locale": {
+                "de": {
+                    "name": "Parasitäre Aufladung"
+                },
                 "en": {
+                    "name": "Parasitic Charge"
+                },
+                "es": {
+                    "name": "Parasitic Charge"
+                },
+                "fr": {
+                    "name": "Charge Parasite"
+                },
+                "it": {
+                    "name": "Parasitic Charge"
+                },
+                "pl": {
+                    "name": "Parasitic Charge"
+                },
+                "pt": {
+                    "name": "Parasitic Charge"
+                },
+                "th": {
+                    "name": "Parasitic Charge"
+                },
+                "vi": {
+                    "name": "Parasitic Charge"
+                },
+                "zhhans": {
+                    "name": "Parasitic Charge"
+                },
+                "zhhant": {
                     "name": "Parasitic Charge"
                 }
             }
@@ -3486,7 +8703,37 @@
             "power": null,
             "text": "Play: Until the start of your next turn, creatures cannot ready.\n",
             "locale": {
+                "de": {
+                    "name": "Thermische Erschöpfung"
+                },
                 "en": {
+                    "name": "Thermal Depletion"
+                },
+                "es": {
+                    "name": "Thermal Depletion"
+                },
+                "fr": {
+                    "name": "Réduire en Cendres"
+                },
+                "it": {
+                    "name": "Thermal Depletion"
+                },
+                "pl": {
+                    "name": "Thermal Depletion"
+                },
+                "pt": {
+                    "name": "Thermal Depletion"
+                },
+                "th": {
+                    "name": "Thermal Depletion"
+                },
+                "vi": {
+                    "name": "Thermal Depletion"
+                },
+                "zhhans": {
+                    "name": "Thermal Depletion"
+                },
+                "zhhant": {
                     "name": "Thermal Depletion"
                 }
             }
@@ -3507,7 +8754,37 @@
             "power": null,
             "text": "Play: Shuffle each friendly card in play into your deck. Draw a card for each card shuffled into your deck this way.\n",
             "locale": {
+                "de": {
+                    "name": "Zeitbeben"
+                },
                 "en": {
+                    "name": "Timequake"
+                },
+                "es": {
+                    "name": "Timequake"
+                },
+                "fr": {
+                    "name": "Tremblement de Temps"
+                },
+                "it": {
+                    "name": "Timequake"
+                },
+                "pl": {
+                    "name": "Timequake"
+                },
+                "pt": {
+                    "name": "Timequake"
+                },
+                "th": {
+                    "name": "Timequake"
+                },
+                "vi": {
+                    "name": "Timequake"
+                },
+                "zhhans": {
+                    "name": "Timequake"
+                },
+                "zhhant": {
                     "name": "Timequake"
                 }
             }
@@ -3520,7 +8797,9 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon"],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -3528,7 +8807,37 @@
             "power": 5,
             "text": "After Reap: Use an enemy artifact as if it were yours. Put that artifact on the bottom of its owner’s deck.\n",
             "locale": {
+                "de": {
+                    "name": "Voltash Blitzatem"
+                },
                 "en": {
+                    "name": "Voltash Coilbreath"
+                },
+                "es": {
+                    "name": "Voltash Coilbreath"
+                },
+                "fr": {
+                    "name": "Voltach le Fulgurant"
+                },
+                "it": {
+                    "name": "Voltash Coilbreath"
+                },
+                "pl": {
+                    "name": "Voltash Coilbreath"
+                },
+                "pt": {
+                    "name": "Voltash Coilbreath"
+                },
+                "th": {
+                    "name": "Voltash Coilbreath"
+                },
+                "vi": {
+                    "name": "Voltash Coilbreath"
+                },
+                "zhhans": {
+                    "name": "Voltash Coilbreath"
+                },
+                "zhhant": {
                     "name": "Voltash Coilbreath"
                 }
             }
@@ -3541,7 +8850,9 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon"],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -3549,7 +8860,37 @@
             "power": 5,
             "text": "After Reap: Ready and use a friendly non-Dragon creature.\n",
             "locale": {
+                "de": {
+                    "name": "Zartoo der Flinke"
+                },
                 "en": {
+                    "name": "Zartoo, the Swift"
+                },
+                "es": {
+                    "name": "Zartoo, the Swift"
+                },
+                "fr": {
+                    "name": "Zartou, le Doux"
+                },
+                "it": {
+                    "name": "Zartoo, the Swift"
+                },
+                "pl": {
+                    "name": "Zartoo, the Swift"
+                },
+                "pt": {
+                    "name": "Zartoo, the Swift"
+                },
+                "th": {
+                    "name": "Zartoo, the Swift"
+                },
+                "vi": {
+                    "name": "Zartoo, the Swift"
+                },
+                "zhhans": {
+                    "name": "Zartoo, the Swift"
+                },
+                "zhhant": {
                     "name": "Zartoo, the Swift"
                 }
             }
@@ -3570,7 +8911,37 @@
             "power": null,
             "text": "Play: Choose a friendly exhausted creature. Ready and use that creature.\n",
             "locale": {
+                "de": {
+                    "name": "Arkane Erleichterung"
+                },
                 "en": {
+                    "name": "Arcane Relief"
+                },
+                "es": {
+                    "name": "Arcane Relief"
+                },
+                "fr": {
+                    "name": "Relève Arcanique"
+                },
+                "it": {
+                    "name": "Arcane Relief"
+                },
+                "pl": {
+                    "name": "Arcane Relief"
+                },
+                "pt": {
+                    "name": "Arcane Relief"
+                },
+                "th": {
+                    "name": "Arcane Relief"
+                },
+                "vi": {
+                    "name": "Arcane Relief"
+                },
+                "zhhans": {
+                    "name": "Arcane Relief"
+                },
+                "zhhant": {
                     "name": "Arcane Relief"
                 }
             }
@@ -3591,7 +8962,37 @@
             "power": null,
             "text": "Play: If you are overwhelmed, choose a friendly creature. For each creature your opponent controls in excess of you, the chosen creature captures 1.\n",
             "locale": {
+                "de": {
+                    "name": "Klauenmantelschlag"
+                },
                 "en": {
+                    "name": "Clawcloak Swipe"
+                },
+                "es": {
+                    "name": "Clawcloak Swipe"
+                },
+                "fr": {
+                    "name": "Revers de Fortune"
+                },
+                "it": {
+                    "name": "Clawcloak Swipe"
+                },
+                "pl": {
+                    "name": "Clawcloak Swipe"
+                },
+                "pt": {
+                    "name": "Clawcloak Swipe"
+                },
+                "th": {
+                    "name": "Clawcloak Swipe"
+                },
+                "vi": {
+                    "name": "Clawcloak Swipe"
+                },
+                "zhhans": {
+                    "name": "Clawcloak Swipe"
+                },
+                "zhhant": {
                     "name": "Clawcloak Swipe"
                 }
             }
@@ -3604,7 +9005,9 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon"],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -3612,7 +9015,37 @@
             "power": 6,
             "text": "After a player readies a creature, deal 1 to it.\n",
             "locale": {
+                "de": {
+                    "name": "Kosmokrax"
+                },
                 "en": {
+                    "name": "Cosmicrux"
+                },
+                "es": {
+                    "name": "Cosmicrux"
+                },
+                "fr": {
+                    "name": "Cosmicrux"
+                },
+                "it": {
+                    "name": "Cosmicrux"
+                },
+                "pl": {
+                    "name": "Cosmicrux"
+                },
+                "pt": {
+                    "name": "Cosmicrux"
+                },
+                "th": {
+                    "name": "Cosmicrux"
+                },
+                "vi": {
+                    "name": "Cosmicrux"
+                },
+                "zhhans": {
+                    "name": "Cosmicrux"
+                },
+                "zhhant": {
                     "name": "Cosmicrux"
                 }
             }
@@ -3625,7 +9058,9 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon"],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -3633,7 +9068,37 @@
             "power": 4,
             "text": "After Fight: Gain 1 for each ready friendly creature of the active house.\n",
             "locale": {
+                "de": {
+                    "name": "Deltas der Kühne"
+                },
                 "en": {
+                    "name": "Daring Delt"
+                },
+                "es": {
+                    "name": "Daring Delt"
+                },
+                "fr": {
+                    "name": "Delth l’Audacieuse"
+                },
+                "it": {
+                    "name": "Daring Delt"
+                },
+                "pl": {
+                    "name": "Daring Delt"
+                },
+                "pt": {
+                    "name": "Daring Delt"
+                },
+                "th": {
+                    "name": "Daring Delt"
+                },
+                "vi": {
+                    "name": "Daring Delt"
+                },
+                "zhhans": {
+                    "name": "Daring Delt"
+                },
+                "zhhant": {
                     "name": "Daring Delt"
                 }
             }
@@ -3654,7 +9119,37 @@
             "power": null,
             "text": "Play: Each friendly exhausted creature captures 1.\n",
             "locale": {
+                "de": {
+                    "name": "Beute horten"
+                },
                 "en": {
+                    "name": "Hoarding the Goods"
+                },
+                "es": {
+                    "name": "Hoarding the Goods"
+                },
+                "fr": {
+                    "name": "Accaparer les Biens"
+                },
+                "it": {
+                    "name": "Hoarding the Goods"
+                },
+                "pl": {
+                    "name": "Hoarding the Goods"
+                },
+                "pt": {
+                    "name": "Hoarding the Goods"
+                },
+                "th": {
+                    "name": "Hoarding the Goods"
+                },
+                "vi": {
+                    "name": "Hoarding the Goods"
+                },
+                "zhhans": {
+                    "name": "Hoarding the Goods"
+                },
+                "zhhant": {
                     "name": "Hoarding the Goods"
                 }
             }
@@ -3675,7 +9170,37 @@
             "power": null,
             "text": "Play: If you are overwhelmed, exhaust each creature. Otherwise, exhaust a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Leylinien"
+                },
                 "en": {
+                    "name": "Ley Lines"
+                },
+                "es": {
+                    "name": "Ley Lines"
+                },
+                "fr": {
+                    "name": "Lignes Telluriques"
+                },
+                "it": {
+                    "name": "Ley Lines"
+                },
+                "pl": {
+                    "name": "Ley Lines"
+                },
+                "pt": {
+                    "name": "Ley Lines"
+                },
+                "th": {
+                    "name": "Ley Lines"
+                },
+                "vi": {
+                    "name": "Ley Lines"
+                },
+                "zhhans": {
+                    "name": "Ley Lines"
+                },
+                "zhhant": {
                     "name": "Ley Lines"
                 }
             }
@@ -3688,7 +9213,9 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon"],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -3696,7 +9223,37 @@
             "power": 2,
             "text": "Play: If your opponent has more forged keys than you, steal 2. Otherwise, capture 2.\n",
             "locale": {
+                "de": {
+                    "name": "Pip der Langfinger"
+                },
                 "en": {
+                    "name": "Pip the Pilferer"
+                },
+                "es": {
+                    "name": "Pip the Pilferer"
+                },
+                "fr": {
+                    "name": "Pip le Chapardeur"
+                },
+                "it": {
+                    "name": "Pip the Pilferer"
+                },
+                "pl": {
+                    "name": "Pip the Pilferer"
+                },
+                "pt": {
+                    "name": "Pip the Pilferer"
+                },
+                "th": {
+                    "name": "Pip the Pilferer"
+                },
+                "vi": {
+                    "name": "Pip the Pilferer"
+                },
+                "zhhans": {
+                    "name": "Pip the Pilferer"
+                },
+                "zhhant": {
                     "name": "Pip the Pilferer"
                 }
             }
@@ -3709,7 +9266,9 @@
             "expansion": 928,
             "house": "ouboros",
             "keywords": [],
-            "traits": ["dragon"],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -3717,7 +9276,37 @@
             "power": 2,
             "text": "Enhance .\nAfter Fight/After Reap: If you are overwhelmed, capture 1 for each +1 power counter on friendly creatures. Otherwise, capture 1.\n",
             "locale": {
+                "de": {
+                    "name": "Ria Schwarmgier"
+                },
                 "en": {
+                    "name": "Ria Bevy Gress"
+                },
+                "es": {
+                    "name": "Ria Bevy Gress"
+                },
+                "fr": {
+                    "name": "Ria Bevy Gress"
+                },
+                "it": {
+                    "name": "Ria Bevy Gress"
+                },
+                "pl": {
+                    "name": "Ria Bevy Gress"
+                },
+                "pt": {
+                    "name": "Ria Bevy Gress"
+                },
+                "th": {
+                    "name": "Ria Bevy Gress"
+                },
+                "vi": {
+                    "name": "Ria Bevy Gress"
+                },
+                "zhhans": {
+                    "name": "Ria Bevy Gress"
+                },
+                "zhhant": {
                     "name": "Ria Bevy Gress"
                 }
             }
@@ -3729,8 +9318,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_156_4035d48321a1_en.png",
             "expansion": 928,
             "house": "ouboros",
-            "keywords": ["treachery", "versatile"],
-            "traits": ["dragon"],
+            "keywords": [
+                "treachery",
+                "versatile"
+            ],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -3738,7 +9332,37 @@
             "power": 4,
             "text": "Treachery. Versatile.\nAfter a friendly creature is used, deal 1 to each friendly creature.\n",
             "locale": {
+                "de": {
+                    "name": "Schattenfinstergroll"
+                },
                 "en": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "es": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "fr": {
+                    "name": "Aigrefin des Ombres"
+                },
+                "it": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "pl": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "pt": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "th": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "vi": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "zhhans": {
+                    "name": "Shadow Gloomcoil"
+                },
+                "zhhant": {
                     "name": "Shadow Gloomcoil"
                 }
             }
@@ -3750,8 +9374,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_157_8a60e0c7e031_en.png",
             "expansion": 928,
             "house": "ouboros",
-            "keywords": ["entrench"],
-            "traits": ["dragon"],
+            "keywords": [
+                "entrench"
+            ],
+            "traits": [
+                "dragon"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -3759,7 +9387,37 @@
             "power": 3,
             "text": "Entrench.\nAt the end of your turn, if Snapper Dyn is exhausted, deal 1 to an enemy creature for each  in your opponent’s pool.\n",
             "locale": {
+                "de": {
+                    "name": "Schnapper Dyn"
+                },
                 "en": {
+                    "name": "Snapper Dyn"
+                },
+                "es": {
+                    "name": "Snapper Dyn"
+                },
+                "fr": {
+                    "name": "Dyn le Happeur"
+                },
+                "it": {
+                    "name": "Snapper Dyn"
+                },
+                "pl": {
+                    "name": "Snapper Dyn"
+                },
+                "pt": {
+                    "name": "Snapper Dyn"
+                },
+                "th": {
+                    "name": "Snapper Dyn"
+                },
+                "vi": {
+                    "name": "Snapper Dyn"
+                },
+                "zhhans": {
+                    "name": "Snapper Dyn"
+                },
+                "zhhant": {
                     "name": "Snapper Dyn"
                 }
             }
@@ -3771,8 +9429,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_158_2834e0b3e8e7_en.png",
             "expansion": 928,
             "house": "ouboros",
-            "keywords": ["entrench"],
-            "traits": ["dragon", "cyborg"],
+            "keywords": [
+                "entrench"
+            ],
+            "traits": [
+                "dragon",
+                "cyborg"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -3780,7 +9443,37 @@
             "power": 3,
             "text": "Entrench.\nAfter an enemy creature reaps, if Sparkscheme is exhausted, draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Funkenplan"
+                },
                 "en": {
+                    "name": "Sparkscheme"
+                },
+                "es": {
+                    "name": "Sparkscheme"
+                },
+                "fr": {
+                    "name": "Châtaigne"
+                },
+                "it": {
+                    "name": "Sparkscheme"
+                },
+                "pl": {
+                    "name": "Sparkscheme"
+                },
+                "pt": {
+                    "name": "Sparkscheme"
+                },
+                "th": {
+                    "name": "Sparkscheme"
+                },
+                "vi": {
+                    "name": "Sparkscheme"
+                },
+                "zhhans": {
+                    "name": "Sparkscheme"
+                },
+                "zhhant": {
                     "name": "Sparkscheme"
                 }
             }
@@ -3801,7 +9494,37 @@
             "power": null,
             "text": "Play: Deal 3 to a creature. If this damage destroys that creature, draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Wunden der Vorhut"
+                },
                 "en": {
+                    "name": "Vanguard Wounds"
+                },
+                "es": {
+                    "name": "Vanguard Wounds"
+                },
+                "fr": {
+                    "name": "Blessures Préventives"
+                },
+                "it": {
+                    "name": "Vanguard Wounds"
+                },
+                "pl": {
+                    "name": "Vanguard Wounds"
+                },
+                "pt": {
+                    "name": "Vanguard Wounds"
+                },
+                "th": {
+                    "name": "Vanguard Wounds"
+                },
+                "vi": {
+                    "name": "Vanguard Wounds"
+                },
+                "zhhans": {
+                    "name": "Vanguard Wounds"
+                },
+                "zhhant": {
                     "name": "Vanguard Wounds"
                 }
             }
@@ -3814,7 +9537,9 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": ["robot"],
+            "traits": [
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Special",
             "amber": 0,
@@ -3822,28 +9547,90 @@
             "power": 7,
             "text": "(Play only with the other half of Boosted B4-RRY.)\nPlay/After Fight/After Reap: Choose one:\nTake control of an enemy artifact. While under your control, it belongs to house Shadows (instead of its original house).\nPlay a random card from your opponent’s archives as if it were yours.\n",
             "locale": {
+                "de": {
+                    "name": "Verstärkter B4-RRY"
+                },
                 "en": {
+                    "name": "Boosted B4-RRY"
+                },
+                "es": {
+                    "name": "Boosted B4-RRY"
+                },
+                "fr": {
+                    "name": "T0-N10 les Bons Pistons"
+                },
+                "it": {
+                    "name": "Boosted B4-RRY"
+                },
+                "pl": {
+                    "name": "Boosted B4-RRY"
+                },
+                "pt": {
+                    "name": "Boosted B4-RRY"
+                },
+                "th": {
+                    "name": "Boosted B4-RRY"
+                },
+                "vi": {
+                    "name": "Boosted B4-RRY"
+                },
+                "zhhans": {
+                    "name": "Boosted B4-RRY"
+                },
+                "zhhant": {
                     "name": "Boosted B4-RRY"
                 }
             }
         },
         {
-            "id": "boosted-b4-rry2",
+            "id": "boosted-b4-rry22222222222",
             "name": "Boosted B4-RRY",
             "number": "160",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_160_67897e890546_en.png",
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": [],
+            "traits": [
+                "robot"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
             "armor": null,
-            "power": null,
-            "text": "",
+            "power": 7,
+            "text": "(Play only with the other half of Boosted B4-RRY.)\nPlay/After Fight/After Reap: Choose one:\nTake control of an enemy artifact. While under your control, it belongs to house Shadows (instead of its original house).\nPlay a random card from your opponent’s archives as if it were yours.\n",
             "locale": {
+                "de": {
+                    "name": "Verstärkter B4-RRY"
+                },
                 "en": {
+                    "name": "Boosted B4-RRY"
+                },
+                "es": {
+                    "name": "Boosted B4-RRY"
+                },
+                "fr": {
+                    "name": "T0-N10 les Bons Pistons"
+                },
+                "it": {
+                    "name": "Boosted B4-RRY"
+                },
+                "pl": {
+                    "name": "Boosted B4-RRY"
+                },
+                "pt": {
+                    "name": "Boosted B4-RRY"
+                },
+                "th": {
+                    "name": "Boosted B4-RRY"
+                },
+                "vi": {
+                    "name": "Boosted B4-RRY"
+                },
+                "zhhans": {
+                    "name": "Boosted B4-RRY"
+                },
+                "zhhant": {
                     "name": "Boosted B4-RRY"
                 }
             }
@@ -3855,8 +9642,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_161_b2748bc619b2_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": ["elusive"],
-            "traits": ["elf", "thief"],
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "elf",
+                "thief"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3864,7 +9656,37 @@
             "power": 2,
             "text": "Elusive. (The first time this creature is attacked each turn, no damage is dealt.)\nAfter Reap: Destroy a flank creature.",
             "locale": {
+                "de": {
+                    "name": "Scharfauge"
+                },
                 "en": {
+                    "name": "Bulleteye"
+                },
+                "es": {
+                    "name": "Bulleteye"
+                },
+                "fr": {
+                    "name": "Ciblette"
+                },
+                "it": {
+                    "name": "Bulleteye"
+                },
+                "pl": {
+                    "name": "Bulleteye"
+                },
+                "pt": {
+                    "name": "Bulleteye"
+                },
+                "th": {
+                    "name": "Bulleteye"
+                },
+                "vi": {
+                    "name": "Bulleteye"
+                },
+                "zhhans": {
+                    "name": "Bulleteye"
+                },
+                "zhhant": {
                     "name": "Bulleteye"
                 }
             }
@@ -3877,7 +9699,9 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": ["item"],
+            "traits": [
+                "item"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -3885,7 +9709,37 @@
             "power": null,
             "text": "Enhance .\nEach friendly Shadows creature gains hazardous 2.\n",
             "locale": {
+                "de": {
+                    "name": "Cheval-de-Frise"
+                },
                 "en": {
+                    "name": "Cheval de Frise"
+                },
+                "es": {
+                    "name": "Cheval de Frise"
+                },
+                "fr": {
+                    "name": "Cheval de Frise"
+                },
+                "it": {
+                    "name": "Cheval de Frise"
+                },
+                "pl": {
+                    "name": "Cheval de Frise"
+                },
+                "pt": {
+                    "name": "Cheval de Frise"
+                },
+                "th": {
+                    "name": "Cheval de Frise"
+                },
+                "vi": {
+                    "name": "Cheval de Frise"
+                },
+                "zhhans": {
+                    "name": "Cheval de Frise"
+                },
+                "zhhant": {
                     "name": "Cheval de Frise"
                 }
             }
@@ -3906,7 +9760,37 @@
             "power": null,
             "text": "Play: Exalt each damaged enemy creature.",
             "locale": {
+                "de": {
+                    "name": "Leichte Opfer"
+                },
                 "en": {
+                    "name": "Easy Marks"
+                },
+                "es": {
+                    "name": "Easy Marks"
+                },
+                "fr": {
+                    "name": "Marques Faciles"
+                },
+                "it": {
+                    "name": "Easy Marks"
+                },
+                "pl": {
+                    "name": "Easy Marks"
+                },
+                "pt": {
+                    "name": "Easy Marks"
+                },
+                "th": {
+                    "name": "Easy Marks"
+                },
+                "vi": {
+                    "name": "Easy Marks"
+                },
+                "zhhans": {
+                    "name": "Easy Marks"
+                },
+                "zhhant": {
                     "name": "Easy Marks"
                 }
             }
@@ -3927,7 +9811,37 @@
             "power": null,
             "text": "Play: Destroy a damaged creature. If you do, steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Todesstoß"
+                },
                 "en": {
+                    "name": "Finishing Blow"
+                },
+                "es": {
+                    "name": "Finishing Blow"
+                },
+                "fr": {
+                    "name": "Coup de Grâce"
+                },
+                "it": {
+                    "name": "Finishing Blow"
+                },
+                "pl": {
+                    "name": "Finishing Blow"
+                },
+                "pt": {
+                    "name": "Finishing Blow"
+                },
+                "th": {
+                    "name": "Finishing Blow"
+                },
+                "vi": {
+                    "name": "Finishing Blow"
+                },
+                "zhhans": {
+                    "name": "Finishing Blow"
+                },
+                "zhhant": {
                     "name": "Finishing Blow"
                 }
             }
@@ -3939,8 +9853,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_165_a52b46ee6548_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": ["elusive"],
-            "traits": ["elf", "politician"],
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "elf",
+                "politician"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3948,7 +9867,37 @@
             "power": 2,
             "text": "Elusive.\nYou may spend up to 3 from your opponent’s pool when forging keys.\n",
             "locale": {
+                "de": {
+                    "name": "Ehrenwerter Abagnale"
+                },
                 "en": {
+                    "name": "Honorable Abagnale"
+                },
+                "es": {
+                    "name": "Honorable Abagnale"
+                },
+                "fr": {
+                    "name": "Abagnale l’Honorable"
+                },
+                "it": {
+                    "name": "Honorable Abagnale"
+                },
+                "pl": {
+                    "name": "Honorable Abagnale"
+                },
+                "pt": {
+                    "name": "Honorable Abagnale"
+                },
+                "th": {
+                    "name": "Honorable Abagnale"
+                },
+                "vi": {
+                    "name": "Honorable Abagnale"
+                },
+                "zhhans": {
+                    "name": "Honorable Abagnale"
+                },
+                "zhhant": {
                     "name": "Honorable Abagnale"
                 }
             }
@@ -3969,20 +9918,55 @@
             "power": null,
             "text": "Play: Pay your opponent up to 6. For each  paid this way, draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Der Rest ist für dich"
+                },
                 "en": {
+                    "name": "Keep the Change"
+                },
+                "es": {
+                    "name": "Keep the Change"
+                },
+                "fr": {
+                    "name": "Garde la Monnaie"
+                },
+                "it": {
+                    "name": "Keep the Change"
+                },
+                "pl": {
+                    "name": "Keep the Change"
+                },
+                "pt": {
+                    "name": "Keep the Change"
+                },
+                "th": {
+                    "name": "Keep the Change"
+                },
+                "vi": {
+                    "name": "Keep the Change"
+                },
+                "zhhans": {
+                    "name": "Keep the Change"
+                },
+                "zhhant": {
                     "name": "Keep the Change"
                 }
             }
         },
         {
-            "id": "luis-compere",
+            "id": "luis-compère",
             "name": "Luis Compère",
             "number": "167",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_167_03b2dc801255_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": ["elusive"],
-            "traits": ["elf", "thief"],
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "elf",
+                "thief"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -3990,7 +9974,37 @@
             "power": 4,
             "text": "Elusive.\nAt the end of your opponent's turn, if they drew 2 or more cards during their “draw cards” step, steal 2.\n",
             "locale": {
+                "de": {
+                    "name": "Luis Compère"
+                },
                 "en": {
+                    "name": "Luis Compère"
+                },
+                "es": {
+                    "name": "Luis Compère"
+                },
+                "fr": {
+                    "name": "Compère Louis"
+                },
+                "it": {
+                    "name": "Luis Compère"
+                },
+                "pl": {
+                    "name": "Luis Compère"
+                },
+                "pt": {
+                    "name": "Luis Compère"
+                },
+                "th": {
+                    "name": "Luis Compère"
+                },
+                "vi": {
+                    "name": "Luis Compère"
+                },
+                "zhhans": {
+                    "name": "Luis Compère"
+                },
+                "zhhant": {
                     "name": "Luis Compère"
                 }
             }
@@ -4011,7 +10025,37 @@
             "power": null,
             "text": "This creature cannot be used and gains, “At the start of your turn, you may pay your opponent 2. If you do, destroy Ransom.”\n",
             "locale": {
+                "de": {
+                    "name": "Lösegeld"
+                },
                 "en": {
+                    "name": "Ransom"
+                },
+                "es": {
+                    "name": "Ransom"
+                },
+                "fr": {
+                    "name": "Rançon"
+                },
+                "it": {
+                    "name": "Ransom"
+                },
+                "pl": {
+                    "name": "Ransom"
+                },
+                "pt": {
+                    "name": "Ransom"
+                },
+                "th": {
+                    "name": "Ransom"
+                },
+                "vi": {
+                    "name": "Ransom"
+                },
+                "zhhans": {
+                    "name": "Ransom"
+                },
+                "zhhant": {
                     "name": "Ransom"
                 }
             }
@@ -4032,7 +10076,37 @@
             "power": null,
             "text": "Play: Pay your opponent 1. If you do, take control of an enemy creature or artifact.\n",
             "locale": {
+                "de": {
+                    "name": "Gas geben und greifen"
+                },
                 "en": {
+                    "name": "Rein and Cycle"
+                },
+                "es": {
+                    "name": "Rein and Cycle"
+                },
+                "fr": {
+                    "name": "Gagner au Change"
+                },
+                "it": {
+                    "name": "Rein and Cycle"
+                },
+                "pl": {
+                    "name": "Rein and Cycle"
+                },
+                "pt": {
+                    "name": "Rein and Cycle"
+                },
+                "th": {
+                    "name": "Rein and Cycle"
+                },
+                "vi": {
+                    "name": "Rein and Cycle"
+                },
+                "zhhans": {
+                    "name": "Rein and Cycle"
+                },
+                "zhhant": {
                     "name": "Rein and Cycle"
                 }
             }
@@ -4053,7 +10127,37 @@
             "power": null,
             "text": "Play: Each player discards the top 5 cards of their deck. For each Shadows card discarded, its owner gains 1.\n",
             "locale": {
+                "de": {
+                    "name": "Manipulierte Lotterie"
+                },
                 "en": {
+                    "name": "Rigged Lottery"
+                },
+                "es": {
+                    "name": "Rigged Lottery"
+                },
+                "fr": {
+                    "name": "Loterie Truquée"
+                },
+                "it": {
+                    "name": "Rigged Lottery"
+                },
+                "pl": {
+                    "name": "Rigged Lottery"
+                },
+                "pt": {
+                    "name": "Rigged Lottery"
+                },
+                "th": {
+                    "name": "Rigged Lottery"
+                },
+                "vi": {
+                    "name": "Rigged Lottery"
+                },
+                "zhhans": {
+                    "name": "Rigged Lottery"
+                },
+                "zhhant": {
                     "name": "Rigged Lottery"
                 }
             }
@@ -4074,7 +10178,37 @@
             "power": null,
             "text": "Play: Steal 1. Then, steal 1 for each copy of Routine Job in your discard pile.",
             "locale": {
+                "de": {
+                    "name": "Routinearbeit"
+                },
                 "en": {
+                    "name": "Routine Job"
+                },
+                "es": {
+                    "name": "Routine Job"
+                },
+                "fr": {
+                    "name": "Travail de Routine"
+                },
+                "it": {
+                    "name": "Routine Job"
+                },
+                "pl": {
+                    "name": "Routine Job"
+                },
+                "pt": {
+                    "name": "Routine Job"
+                },
+                "th": {
+                    "name": "Routine Job"
+                },
+                "vi": {
+                    "name": "Routine Job"
+                },
+                "zhhans": {
+                    "name": "Routine Job"
+                },
+                "zhhant": {
                     "name": "Routine Job"
                 }
             }
@@ -4087,7 +10221,10 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": ["elf", "thief"],
+            "traits": [
+                "elf",
+                "thief"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -4095,7 +10232,37 @@
             "power": 3,
             "text": "After Fight/After Reap: Move 1 from a friendly card to your pool.",
             "locale": {
+                "de": {
+                    "name": "Selwyn die Hehlerin"
+                },
                 "en": {
+                    "name": "Selwyn the Fence"
+                },
+                "es": {
+                    "name": "Selwyn the Fence"
+                },
+                "fr": {
+                    "name": "Selwyn la Receleuse"
+                },
+                "it": {
+                    "name": "Selwyn the Fence"
+                },
+                "pl": {
+                    "name": "Selwyn the Fence"
+                },
+                "pt": {
+                    "name": "Selwyn the Fence"
+                },
+                "th": {
+                    "name": "Selwyn the Fence"
+                },
+                "vi": {
+                    "name": "Selwyn the Fence"
+                },
+                "zhhans": {
+                    "name": "Selwyn the Fence"
+                },
+                "zhhant": {
                     "name": "Selwyn the Fence"
                 }
             }
@@ -4108,7 +10275,10 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": ["elf", "thief"],
+            "traits": [
+                "elf",
+                "thief"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -4116,7 +10286,37 @@
             "power": 2,
             "text": "Play: Take control of an enemy artifact. While under your control, if it does not belong to one of your three houses, it belongs to house Shadows.",
             "locale": {
+                "de": {
+                    "name": "Schlangenstehler"
+                },
                 "en": {
+                    "name": "Sneklifter"
+                },
+                "es": {
+                    "name": "Sneklifter"
+                },
+                "fr": {
+                    "name": "Crotale la Détale"
+                },
+                "it": {
+                    "name": "Sneklifter"
+                },
+                "pl": {
+                    "name": "Sneklifter"
+                },
+                "pt": {
+                    "name": "Sneklifter"
+                },
+                "th": {
+                    "name": "Sneklifter"
+                },
+                "vi": {
+                    "name": "Sneklifter"
+                },
+                "zhhans": {
+                    "name": "Sneklifter"
+                },
+                "zhhant": {
                     "name": "Sneklifter"
                 }
             }
@@ -4129,7 +10329,9 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": ["power"],
+            "traits": [
+                "power"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 1,
@@ -4137,7 +10339,37 @@
             "power": null,
             "text": "After a player gains  by reaping, a creature they do not control captures that .\n",
             "locale": {
+                "de": {
+                    "name": "Weitverbreitete Korruption"
+                },
                 "en": {
+                    "name": "Widespread Corruption"
+                },
+                "es": {
+                    "name": "Widespread Corruption"
+                },
+                "fr": {
+                    "name": "Corruption Généralisée"
+                },
+                "it": {
+                    "name": "Widespread Corruption"
+                },
+                "pl": {
+                    "name": "Widespread Corruption"
+                },
+                "pt": {
+                    "name": "Widespread Corruption"
+                },
+                "th": {
+                    "name": "Widespread Corruption"
+                },
+                "vi": {
+                    "name": "Widespread Corruption"
+                },
+                "zhhans": {
+                    "name": "Widespread Corruption"
+                },
+                "zhhant": {
                     "name": "Widespread Corruption"
                 }
             }
@@ -4158,7 +10390,37 @@
             "power": null,
             "text": "Play: Each player shuffles their archives and discard pile into their deck. Discard the top 5 cards of your opponent’s deck. Play the top card of their deck as if it were yours.\n",
             "locale": {
+                "de": {
+                    "name": "Blankoscheck"
+                },
                 "en": {
+                    "name": "Blank Check"
+                },
+                "es": {
+                    "name": "Blank Check"
+                },
+                "fr": {
+                    "name": "Chèque en Blanc"
+                },
+                "it": {
+                    "name": "Blank Check"
+                },
+                "pl": {
+                    "name": "Blank Check"
+                },
+                "pt": {
+                    "name": "Blank Check"
+                },
+                "th": {
+                    "name": "Blank Check"
+                },
+                "vi": {
+                    "name": "Blank Check"
+                },
+                "zhhans": {
+                    "name": "Blank Check"
+                },
+                "zhhant": {
                     "name": "Blank Check"
                 }
             }
@@ -4179,7 +10441,37 @@
             "power": null,
             "text": "Play: Enrage an enemy creature. Move all  from that creature to your pool.\n",
             "locale": {
+                "de": {
+                    "name": "Dreister Diebstahl"
+                },
                 "en": {
+                    "name": "Blatant Thievery"
+                },
+                "es": {
+                    "name": "Blatant Thievery"
+                },
+                "fr": {
+                    "name": "Flagrant Délit"
+                },
+                "it": {
+                    "name": "Blatant Thievery"
+                },
+                "pl": {
+                    "name": "Blatant Thievery"
+                },
+                "pt": {
+                    "name": "Blatant Thievery"
+                },
+                "th": {
+                    "name": "Blatant Thievery"
+                },
+                "vi": {
+                    "name": "Blatant Thievery"
+                },
+                "zhhans": {
+                    "name": "Blatant Thievery"
+                },
+                "zhhant": {
                     "name": "Blatant Thievery"
                 }
             }
@@ -4192,7 +10484,10 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": ["elf", "thief"],
+            "traits": [
+                "elf",
+                "thief"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -4200,7 +10495,37 @@
             "power": 3,
             "text": "After you play Subtle Chain, ready Chain Gang. \nAction: Steal 1. Shuffle a Subtle Chain from your discard pile into your deck.\n",
             "locale": {
+                "de": {
+                    "name": "Ketten-Bande"
+                },
                 "en": {
+                    "name": "Chain Gang"
+                },
+                "es": {
+                    "name": "Chain Gang"
+                },
+                "fr": {
+                    "name": "Récidivistes en Chaîne"
+                },
+                "it": {
+                    "name": "Chain Gang"
+                },
+                "pl": {
+                    "name": "Chain Gang"
+                },
+                "pt": {
+                    "name": "Chain Gang"
+                },
+                "th": {
+                    "name": "Chain Gang"
+                },
+                "vi": {
+                    "name": "Chain Gang"
+                },
+                "zhhans": {
+                    "name": "Chain Gang"
+                },
+                "zhhant": {
                     "name": "Chain Gang"
                 }
             }
@@ -4221,7 +10546,37 @@
             "power": null,
             "text": "Play: If your opponent has more  than you, they lose half of their  (rounding down the loss).\n",
             "locale": {
+                "de": {
+                    "name": "Falschgeld-Affäre"
+                },
                 "en": {
+                    "name": "Counterfeit Controversy"
+                },
+                "es": {
+                    "name": "Counterfeit Controversy"
+                },
+                "fr": {
+                    "name": "Contrefaçon Controversée"
+                },
+                "it": {
+                    "name": "Counterfeit Controversy"
+                },
+                "pl": {
+                    "name": "Counterfeit Controversy"
+                },
+                "pt": {
+                    "name": "Counterfeit Controversy"
+                },
+                "th": {
+                    "name": "Counterfeit Controversy"
+                },
+                "vi": {
+                    "name": "Counterfeit Controversy"
+                },
+                "zhhans": {
+                    "name": "Counterfeit Controversy"
+                },
+                "zhhant": {
                     "name": "Counterfeit Controversy"
                 }
             }
@@ -4242,7 +10597,37 @@
             "power": null,
             "text": "Enhance .\nPlay: Move all  from one creature to another creature.\n",
             "locale": {
+                "de": {
+                    "name": "Beute loswerden"
+                },
                 "en": {
+                    "name": "Ditch the Loot"
+                },
+                "es": {
+                    "name": "Ditch the Loot"
+                },
+                "fr": {
+                    "name": "Bazarder le Butin"
+                },
+                "it": {
+                    "name": "Ditch the Loot"
+                },
+                "pl": {
+                    "name": "Ditch the Loot"
+                },
+                "pt": {
+                    "name": "Ditch the Loot"
+                },
+                "th": {
+                    "name": "Ditch the Loot"
+                },
+                "vi": {
+                    "name": "Ditch the Loot"
+                },
+                "zhhans": {
+                    "name": "Ditch the Loot"
+                },
+                "zhhant": {
                     "name": "Ditch the Loot"
                 }
             }
@@ -4255,7 +10640,10 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": ["elf", "politician"],
+            "traits": [
+                "elf",
+                "politician"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -4263,7 +10651,37 @@
             "power": 2,
             "text": "Each enemy creature gains, “After Fight/After Reap: Exhaust each friendly creature that shares a house with this creature.”\n",
             "locale": {
+                "de": {
+                    "name": "Ox Sarbane"
+                },
                 "en": {
+                    "name": "Ox Sarbane"
+                },
+                "es": {
+                    "name": "Ox Sarbane"
+                },
+                "fr": {
+                    "name": "Ox Sarbane"
+                },
+                "it": {
+                    "name": "Ox Sarbane"
+                },
+                "pl": {
+                    "name": "Ox Sarbane"
+                },
+                "pt": {
+                    "name": "Ox Sarbane"
+                },
+                "th": {
+                    "name": "Ox Sarbane"
+                },
+                "vi": {
+                    "name": "Ox Sarbane"
+                },
+                "zhhans": {
+                    "name": "Ox Sarbane"
+                },
+                "zhhant": {
                     "name": "Ox Sarbane"
                 }
             }
@@ -4284,7 +10702,37 @@
             "power": null,
             "text": "Play: If you have more  than your opponent, they discard a random card from their hand and you draw a card.",
             "locale": {
+                "de": {
+                    "name": "Verwirrende Klügelei"
+                },
                 "en": {
+                    "name": "Perplexing Sophistry"
+                },
+                "es": {
+                    "name": "Perplexing Sophistry"
+                },
+                "fr": {
+                    "name": "Sophisme Troublant"
+                },
+                "it": {
+                    "name": "Perplexing Sophistry"
+                },
+                "pl": {
+                    "name": "Perplexing Sophistry"
+                },
+                "pt": {
+                    "name": "Perplexing Sophistry"
+                },
+                "th": {
+                    "name": "Perplexing Sophistry"
+                },
+                "vi": {
+                    "name": "Perplexing Sophistry"
+                },
+                "zhhans": {
+                    "name": "Perplexing Sophistry"
+                },
+                "zhhant": {
                     "name": "Perplexing Sophistry"
                 }
             }
@@ -4296,8 +10744,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_182_89d39b7724d5_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": ["elusive"],
-            "traits": ["elf", "thief"],
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "elf",
+                "thief"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -4305,7 +10758,37 @@
             "power": 1,
             "text": "Elusive. (The first time this creature is attacked each turn, no damage is dealt.)\nAction: Steal 2. Until the start of your next turn, Reckless Rizzo loses elusive.",
             "locale": {
+                "de": {
+                    "name": "Waghalsige Rizzo"
+                },
                 "en": {
+                    "name": "Reckless Rizzo"
+                },
+                "es": {
+                    "name": "Reckless Rizzo"
+                },
+                "fr": {
+                    "name": "Rizzo Sans Repos"
+                },
+                "it": {
+                    "name": "Reckless Rizzo"
+                },
+                "pl": {
+                    "name": "Reckless Rizzo"
+                },
+                "pt": {
+                    "name": "Reckless Rizzo"
+                },
+                "th": {
+                    "name": "Reckless Rizzo"
+                },
+                "vi": {
+                    "name": "Reckless Rizzo"
+                },
+                "zhhans": {
+                    "name": "Reckless Rizzo"
+                },
+                "zhhant": {
                     "name": "Reckless Rizzo"
                 }
             }
@@ -4326,7 +10809,37 @@
             "power": null,
             "text": "Play: Your opponent discards a random card from their hand. \n",
             "locale": {
+                "de": {
+                    "name": "Subtile Kette"
+                },
                 "en": {
+                    "name": "Subtle Chain"
+                },
+                "es": {
+                    "name": "Subtle Chain"
+                },
+                "fr": {
+                    "name": "Chaîne Subtile"
+                },
+                "it": {
+                    "name": "Subtle Chain"
+                },
+                "pl": {
+                    "name": "Subtle Chain"
+                },
+                "pt": {
+                    "name": "Subtle Chain"
+                },
+                "th": {
+                    "name": "Subtle Chain"
+                },
+                "vi": {
+                    "name": "Subtle Chain"
+                },
+                "zhhans": {
+                    "name": "Subtle Chain"
+                },
+                "zhhant": {
                     "name": "Subtle Chain"
                 }
             }
@@ -4338,8 +10851,14 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_184_35b3374fb0e1_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": ["elusive", "entrench"],
-            "traits": ["elf", "cyborg"],
+            "keywords": [
+                "elusive",
+                "entrench"
+            ],
+            "traits": [
+                "elf",
+                "cyborg"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -4347,7 +10866,37 @@
             "power": 2,
             "text": "Elusive. Entrench.\nWhile The Watch is exhausted, your  cannot be stolen.\n",
             "locale": {
+                "de": {
+                    "name": "Die Wache"
+                },
                 "en": {
+                    "name": "The Watch"
+                },
+                "es": {
+                    "name": "The Watch"
+                },
+                "fr": {
+                    "name": "Le Veilleur"
+                },
+                "it": {
+                    "name": "The Watch"
+                },
+                "pl": {
+                    "name": "The Watch"
+                },
+                "pt": {
+                    "name": "The Watch"
+                },
+                "th": {
+                    "name": "The Watch"
+                },
+                "vi": {
+                    "name": "The Watch"
+                },
+                "zhhans": {
+                    "name": "The Watch"
+                },
+                "zhhant": {
                     "name": "The Watch"
                 }
             }
@@ -4368,7 +10917,37 @@
             "power": null,
             "text": "Play: Steal all but 6 of your\nopponent’s .\n",
             "locale": {
+                "de": {
+                    "name": "Zu viel zu bewachen"
+                },
                 "en": {
+                    "name": "Too Much to Protect"
+                },
+                "es": {
+                    "name": "Too Much to Protect"
+                },
+                "fr": {
+                    "name": "Trop à Protéger"
+                },
+                "it": {
+                    "name": "Too Much to Protect"
+                },
+                "pl": {
+                    "name": "Too Much to Protect"
+                },
+                "pt": {
+                    "name": "Too Much to Protect"
+                },
+                "th": {
+                    "name": "Too Much to Protect"
+                },
+                "vi": {
+                    "name": "Too Much to Protect"
+                },
+                "zhhans": {
+                    "name": "Too Much to Protect"
+                },
+                "zhhant": {
                     "name": "Too Much to Protect"
                 }
             }
@@ -4381,7 +10960,10 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": ["elf", "thief"],
+            "traits": [
+                "elf",
+                "thief"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -4389,7 +10971,37 @@
             "power": 3,
             "text": "After your opponent plays a creature, deal 2 to it.\n",
             "locale": {
+                "de": {
+                    "name": "Vaelra Flüsterfang"
+                },
                 "en": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "es": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "fr": {
+                    "name": "Vaelra Quenottes"
+                },
+                "it": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "pl": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "pt": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "th": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "vi": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "zhhans": {
+                    "name": "Vaelra Whisperfang"
+                },
+                "zhhant": {
                     "name": "Vaelra Whisperfang"
                 }
             }
@@ -4402,7 +11014,10 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": ["human", "scientist"],
+            "traits": [
+                "human",
+                "scientist"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -4410,7 +11025,37 @@
             "power": 3,
             "text": "After Reap: Purge a card from your discard pile. If you do, until the start of your next turn, your opponent cannot play cards of the purged card’s type.\n",
             "locale": {
+                "de": {
+                    "name": "Victor Flux"
+                },
                 "en": {
+                    "name": "Victor Flux"
+                },
+                "es": {
+                    "name": "Victor Flux"
+                },
+                "fr": {
+                    "name": "Victor Flux"
+                },
+                "it": {
+                    "name": "Victor Flux"
+                },
+                "pl": {
+                    "name": "Victor Flux"
+                },
+                "pt": {
+                    "name": "Victor Flux"
+                },
+                "th": {
+                    "name": "Victor Flux"
+                },
+                "vi": {
+                    "name": "Victor Flux"
+                },
+                "zhhans": {
+                    "name": "Victor Flux"
+                },
+                "zhhant": {
                     "name": "Victor Flux"
                 }
             }
@@ -4422,8 +11067,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_188_842763412b46_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": ["skirmish"],
-            "traits": ["beast"],
+            "keywords": [
+                "skirmish"
+            ],
+            "traits": [
+                "beast"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -4431,7 +11080,37 @@
             "power": 2,
             "text": "Skirmish.\nAfter Fight: Exhaust an enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Achromatischer Basilisk"
+                },
                 "en": {
+                    "name": "Achromatic Basilisk"
+                },
+                "es": {
+                    "name": "Achromatic Basilisk"
+                },
+                "fr": {
+                    "name": "Basilic Achromatique"
+                },
+                "it": {
+                    "name": "Achromatic Basilisk"
+                },
+                "pl": {
+                    "name": "Achromatic Basilisk"
+                },
+                "pt": {
+                    "name": "Achromatic Basilisk"
+                },
+                "th": {
+                    "name": "Achromatic Basilisk"
+                },
+                "vi": {
+                    "name": "Achromatic Basilisk"
+                },
+                "zhhans": {
+                    "name": "Achromatic Basilisk"
+                },
+                "zhhant": {
                     "name": "Achromatic Basilisk"
                 }
             }
@@ -4452,7 +11131,37 @@
             "power": null,
             "text": "Play: If you are overwhelmed, exhaust an enemy creature. Steal 1 for each exhausted enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Kalt erwischt"
+                },
                 "en": {
+                    "name": "Caught You Napping"
+                },
+                "es": {
+                    "name": "Caught You Napping"
+                },
+                "fr": {
+                    "name": "Choppé à Roupiller"
+                },
+                "it": {
+                    "name": "Caught You Napping"
+                },
+                "pl": {
+                    "name": "Caught You Napping"
+                },
+                "pt": {
+                    "name": "Caught You Napping"
+                },
+                "th": {
+                    "name": "Caught You Napping"
+                },
+                "vi": {
+                    "name": "Caught You Napping"
+                },
+                "zhhans": {
+                    "name": "Caught You Napping"
+                },
+                "zhhant": {
                     "name": "Caught You Napping"
                 }
             }
@@ -4465,7 +11174,10 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": ["elf", "soldier"],
+            "traits": [
+                "elf",
+                "soldier"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -4473,7 +11185,37 @@
             "power": 1,
             "text": "Enhance .\nDestroyed: Deal 2 to each enemy flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Knall E. More"
+                },
                 "en": {
+                    "name": "Clay More"
+                },
+                "es": {
+                    "name": "Clay More"
+                },
+                "fr": {
+                    "name": "Bonne Mine"
+                },
+                "it": {
+                    "name": "Clay More"
+                },
+                "pl": {
+                    "name": "Clay More"
+                },
+                "pt": {
+                    "name": "Clay More"
+                },
+                "th": {
+                    "name": "Clay More"
+                },
+                "vi": {
+                    "name": "Clay More"
+                },
+                "zhhans": {
+                    "name": "Clay More"
+                },
+                "zhhant": {
                     "name": "Clay More"
                 }
             }
@@ -4486,7 +11228,10 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": ["elf", "thief"],
+            "traits": [
+                "elf",
+                "thief"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -4494,7 +11239,37 @@
             "power": 2,
             "text": "Enhance .\nPlay: For each +1 power counter on each creature, deal 1 to a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Colt Slevin"
+                },
                 "en": {
+                    "name": "Colt Sleven"
+                },
+                "es": {
+                    "name": "Colt Sleven"
+                },
+                "fr": {
+                    "name": "Colt Sleven"
+                },
+                "it": {
+                    "name": "Colt Sleven"
+                },
+                "pl": {
+                    "name": "Colt Sleven"
+                },
+                "pt": {
+                    "name": "Colt Sleven"
+                },
+                "th": {
+                    "name": "Colt Sleven"
+                },
+                "vi": {
+                    "name": "Colt Sleven"
+                },
+                "zhhans": {
+                    "name": "Colt Sleven"
+                },
+                "zhhant": {
                     "name": "Colt Sleven"
                 }
             }
@@ -4506,8 +11281,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_192_67159b61a030_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": ["taunt"],
-            "traits": ["elf"],
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "elf"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -4515,7 +11294,37 @@
             "power": 2,
             "text": "Taunt.\nDestroyed: Steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Sündenbock"
+                },
                 "en": {
+                    "name": "Fallguy"
+                },
+                "es": {
+                    "name": "Fallguy"
+                },
+                "fr": {
+                    "name": "Bouc Émissaire"
+                },
+                "it": {
+                    "name": "Fallguy"
+                },
+                "pl": {
+                    "name": "Fallguy"
+                },
+                "pt": {
+                    "name": "Fallguy"
+                },
+                "th": {
+                    "name": "Fallguy"
+                },
+                "vi": {
+                    "name": "Fallguy"
+                },
+                "zhhans": {
+                    "name": "Fallguy"
+                },
+                "zhhant": {
                     "name": "Fallguy"
                 }
             }
@@ -4527,8 +11336,14 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_193_b8611631dec2_en.png",
             "expansion": 928,
             "house": "shadows",
-            "keywords": ["elusive", "entrench"],
-            "traits": ["elf", "thief"],
+            "keywords": [
+                "elusive",
+                "entrench"
+            ],
+            "traits": [
+                "elf",
+                "thief"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -4536,7 +11351,37 @@
             "power": 2,
             "text": "Elusive. Entrench.\nWhile Grammy Taps is exhausted, each of its neighbors gains elusive.\n",
             "locale": {
+                "de": {
+                    "name": "Omi Taps"
+                },
                 "en": {
+                    "name": "Grammy Taps"
+                },
+                "es": {
+                    "name": "Grammy Taps"
+                },
+                "fr": {
+                    "name": "Mamy Blue"
+                },
+                "it": {
+                    "name": "Grammy Taps"
+                },
+                "pl": {
+                    "name": "Grammy Taps"
+                },
+                "pt": {
+                    "name": "Grammy Taps"
+                },
+                "th": {
+                    "name": "Grammy Taps"
+                },
+                "vi": {
+                    "name": "Grammy Taps"
+                },
+                "zhhans": {
+                    "name": "Grammy Taps"
+                },
+                "zhhant": {
                     "name": "Grammy Taps"
                 }
             }
@@ -4557,7 +11402,37 @@
             "power": null,
             "text": "Play: Destroy a friendly creature. If you do, deal 6 to a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Ein Leben für ein Leben"
+                },
                 "en": {
+                    "name": "Life for a Life"
+                },
+                "es": {
+                    "name": "Life for a Life"
+                },
+                "fr": {
+                    "name": "Une Vie contre une Vie"
+                },
+                "it": {
+                    "name": "Life for a Life"
+                },
+                "pl": {
+                    "name": "Life for a Life"
+                },
+                "pt": {
+                    "name": "Life for a Life"
+                },
+                "th": {
+                    "name": "Life for a Life"
+                },
+                "vi": {
+                    "name": "Life for a Life"
+                },
+                "zhhans": {
+                    "name": "Life for a Life"
+                },
+                "zhhant": {
                     "name": "Life for a Life"
                 }
             }
@@ -4570,7 +11445,10 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": ["elf", "thief"],
+            "traits": [
+                "elf",
+                "thief"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -4578,7 +11456,37 @@
             "power": 2,
             "text": "After Reap: If you are overwhelmed, steal 2. Otherwise, steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Albtraum-Straßenkind"
+                },
                 "en": {
+                    "name": "Nightmare Urchin"
+                },
+                "es": {
+                    "name": "Nightmare Urchin"
+                },
+                "fr": {
+                    "name": "Orphelin Endiablé"
+                },
+                "it": {
+                    "name": "Nightmare Urchin"
+                },
+                "pl": {
+                    "name": "Nightmare Urchin"
+                },
+                "pt": {
+                    "name": "Nightmare Urchin"
+                },
+                "th": {
+                    "name": "Nightmare Urchin"
+                },
+                "vi": {
+                    "name": "Nightmare Urchin"
+                },
+                "zhhans": {
+                    "name": "Nightmare Urchin"
+                },
+                "zhhant": {
                     "name": "Nightmare Urchin"
                 }
             }
@@ -4591,7 +11499,10 @@
             "expansion": 928,
             "house": "shadows",
             "keywords": [],
-            "traits": ["elf", "thief"],
+            "traits": [
+                "elf",
+                "thief"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -4599,7 +11510,37 @@
             "power": 2,
             "text": "Play: If your opponent has more  than you, steal 2.\n",
             "locale": {
+                "de": {
+                    "name": "Buchhalter Malloy"
+                },
                 "en": {
+                    "name": "Pincher Malloy"
+                },
+                "es": {
+                    "name": "Pincher Malloy"
+                },
+                "fr": {
+                    "name": "Malo le Faussaire"
+                },
+                "it": {
+                    "name": "Pincher Malloy"
+                },
+                "pl": {
+                    "name": "Pincher Malloy"
+                },
+                "pt": {
+                    "name": "Pincher Malloy"
+                },
+                "th": {
+                    "name": "Pincher Malloy"
+                },
+                "vi": {
+                    "name": "Pincher Malloy"
+                },
+                "zhhans": {
+                    "name": "Pincher Malloy"
+                },
+                "zhhant": {
                     "name": "Pincher Malloy"
                 }
             }
@@ -4620,7 +11561,37 @@
             "power": null,
             "text": "Play: Deal 2 to a creature, with 1 splash. If this damage destroys 2 or more creatures, steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Pyrotechnischer Blitz"
+                },
                 "en": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "es": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "fr": {
+                    "name": "Éclair Pyrotechnique"
+                },
+                "it": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "pl": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "pt": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "th": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "vi": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "zhhans": {
+                    "name": "Pyrotechnic Flash"
+                },
+                "zhhant": {
                     "name": "Pyrotechnic Flash"
                 }
             }
@@ -4641,7 +11612,37 @@
             "power": null,
             "text": "Play: Exhaust the least powerful enemy creature and each of its neighbors.\n",
             "locale": {
+                "de": {
+                    "name": "Mach mal Pause"
+                },
                 "en": {
+                    "name": "Take a Break"
+                },
+                "es": {
+                    "name": "Take a Break"
+                },
+                "fr": {
+                    "name": "Prends une Pause"
+                },
+                "it": {
+                    "name": "Take a Break"
+                },
+                "pl": {
+                    "name": "Take a Break"
+                },
+                "pt": {
+                    "name": "Take a Break"
+                },
+                "th": {
+                    "name": "Take a Break"
+                },
+                "vi": {
+                    "name": "Take a Break"
+                },
+                "zhhans": {
+                    "name": "Take a Break"
+                },
+                "zhhant": {
                     "name": "Take a Break"
                 }
             }
@@ -4662,7 +11663,37 @@
             "power": null,
             "text": "Play: Deal 1 to up to three creatures. Gain 1 for each creature destroyed this way.",
             "locale": {
+                "de": {
+                    "name": "Wurfsterne"
+                },
                 "en": {
+                    "name": "Throwing Stars"
+                },
+                "es": {
+                    "name": "Throwing Stars"
+                },
+                "fr": {
+                    "name": "Étoiles de Lancer"
+                },
+                "it": {
+                    "name": "Throwing Stars"
+                },
+                "pl": {
+                    "name": "Throwing Stars"
+                },
+                "pt": {
+                    "name": "Throwing Stars"
+                },
+                "th": {
+                    "name": "Throwing Stars"
+                },
+                "vi": {
+                    "name": "Throwing Stars"
+                },
+                "zhhans": {
+                    "name": "Throwing Stars"
+                },
+                "zhhant": {
                     "name": "Throwing Stars"
                 }
             }
@@ -4674,8 +11705,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_200_54d9e0fd8302_en.png",
             "expansion": 928,
             "house": "skyborn",
-            "keywords": ["deploy"],
-            "traits": ["alien", "halyard"],
+            "keywords": [
+                "deploy"
+            ],
+            "traits": [
+                "alien",
+                "halyard"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -4683,7 +11719,37 @@
             "power": 3,
             "text": "Deploy.\nPlay: Exhaust each non-flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Aviatrix Virtuosa"
+                },
                 "en": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "es": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "fr": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "it": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "pl": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "pt": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "th": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "vi": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "zhhans": {
+                    "name": "Aviatrix Virtuosa"
+                },
+                "zhhant": {
                     "name": "Aviatrix Virtuosa"
                 }
             }
@@ -4696,7 +11762,9 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["location"],
+            "traits": [
+                "location"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -4704,7 +11772,37 @@
             "power": null,
             "text": "Your opponent’s keys cost +1 for each Skyborn creature on a flank.\n",
             "locale": {
+                "de": {
+                    "name": "Wolkenbruch-Befehl"
+                },
                 "en": {
+                    "name": "Cloudburst Command"
+                },
+                "es": {
+                    "name": "Cloudburst Command"
+                },
+                "fr": {
+                    "name": "Régie Cumulo-Blastus"
+                },
+                "it": {
+                    "name": "Cloudburst Command"
+                },
+                "pl": {
+                    "name": "Cloudburst Command"
+                },
+                "pt": {
+                    "name": "Cloudburst Command"
+                },
+                "th": {
+                    "name": "Cloudburst Command"
+                },
+                "vi": {
+                    "name": "Cloudburst Command"
+                },
+                "zhhans": {
+                    "name": "Cloudburst Command"
+                },
+                "zhhant": {
                     "name": "Cloudburst Command"
                 }
             }
@@ -4717,7 +11815,9 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["raptrix"],
+            "traits": [
+                "raptrix"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -4725,7 +11825,37 @@
             "power": 4,
             "text": "Each enemy creature loses each of its destroyed abilities.\n",
             "locale": {
+                "de": {
+                    "name": "Flipp Stahl­hart"
+                },
                 "en": {
+                    "name": "Flip Stallard"
+                },
+                "es": {
+                    "name": "Flip Stallard"
+                },
+                "fr": {
+                    "name": "Flip Stallard"
+                },
+                "it": {
+                    "name": "Flip Stallard"
+                },
+                "pl": {
+                    "name": "Flip Stallard"
+                },
+                "pt": {
+                    "name": "Flip Stallard"
+                },
+                "th": {
+                    "name": "Flip Stallard"
+                },
+                "vi": {
+                    "name": "Flip Stallard"
+                },
+                "zhhans": {
+                    "name": "Flip Stallard"
+                },
+                "zhhant": {
                     "name": "Flip Stallard"
                 }
             }
@@ -4746,7 +11876,37 @@
             "power": null,
             "text": "Play: Deal 1 to each creature for each forged key.\n",
             "locale": {
+                "de": {
+                    "name": "Geschmiedeter Blitz"
+                },
                 "en": {
+                    "name": "Forged Bolt"
+                },
+                "es": {
+                    "name": "Forged Bolt"
+                },
+                "fr": {
+                    "name": "Forgedroyer"
+                },
+                "it": {
+                    "name": "Forged Bolt"
+                },
+                "pl": {
+                    "name": "Forged Bolt"
+                },
+                "pt": {
+                    "name": "Forged Bolt"
+                },
+                "th": {
+                    "name": "Forged Bolt"
+                },
+                "vi": {
+                    "name": "Forged Bolt"
+                },
+                "zhhans": {
+                    "name": "Forged Bolt"
+                },
+                "zhhant": {
                     "name": "Forged Bolt"
                 }
             }
@@ -4759,7 +11919,10 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["dinosaur", "stormkin"],
+            "traits": [
+                "dinosaur",
+                "stormkin"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -4767,7 +11930,37 @@
             "power": 6,
             "text": "After Fight/After Reap: You may exalt Han Peregrine. If you do, fully heal a damaged creature and move it to either flank of its controller's battleline.\n",
             "locale": {
+                "de": {
+                    "name": "Han der Wanderer"
+                },
                 "en": {
+                    "name": "Han Peregrine"
+                },
+                "es": {
+                    "name": "Han Peregrine"
+                },
+                "fr": {
+                    "name": "Han Peregrine"
+                },
+                "it": {
+                    "name": "Han Peregrine"
+                },
+                "pl": {
+                    "name": "Han Peregrine"
+                },
+                "pt": {
+                    "name": "Han Peregrine"
+                },
+                "th": {
+                    "name": "Han Peregrine"
+                },
+                "vi": {
+                    "name": "Han Peregrine"
+                },
+                "zhhans": {
+                    "name": "Han Peregrine"
+                },
+                "zhhant": {
                     "name": "Han Peregrine"
                 }
             }
@@ -4788,7 +11981,37 @@
             "power": null,
             "text": "Play: Put each friendly Skyborn creature into its owner’s archives.\n",
             "locale": {
+                "de": {
+                    "name": "Ein langer Weg nach Hause"
+                },
                 "en": {
+                    "name": "Long Way Home"
+                },
+                "es": {
+                    "name": "Long Way Home"
+                },
+                "fr": {
+                    "name": "Long Détour"
+                },
+                "it": {
+                    "name": "Long Way Home"
+                },
+                "pl": {
+                    "name": "Long Way Home"
+                },
+                "pt": {
+                    "name": "Long Way Home"
+                },
+                "th": {
+                    "name": "Long Way Home"
+                },
+                "vi": {
+                    "name": "Long Way Home"
+                },
+                "zhhans": {
+                    "name": "Long Way Home"
+                },
+                "zhhant": {
                     "name": "Long Way Home"
                 }
             }
@@ -4800,8 +12023,14 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_206_7927e522d310_en.png",
             "expansion": 928,
             "house": "skyborn",
-            "keywords": ["treachery", "versatile"],
-            "traits": ["beast", "cyborg"],
+            "keywords": [
+                "treachery",
+                "versatile"
+            ],
+            "traits": [
+                "beast",
+                "cyborg"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -4809,7 +12038,37 @@
             "power": 5,
             "text": "Treachery. Versatile.\nYou cannot forge keys.\nAt the end of your turn, deal 2 to Malforge.\n",
             "locale": {
+                "de": {
+                    "name": "Fehlschmiede"
+                },
                 "en": {
+                    "name": "Malforge"
+                },
+                "es": {
+                    "name": "Malforge"
+                },
+                "fr": {
+                    "name": "Malforge"
+                },
+                "it": {
+                    "name": "Malforge"
+                },
+                "pl": {
+                    "name": "Malforge"
+                },
+                "pt": {
+                    "name": "Malforge"
+                },
+                "th": {
+                    "name": "Malforge"
+                },
+                "vi": {
+                    "name": "Malforge"
+                },
+                "zhhans": {
+                    "name": "Malforge"
+                },
+                "zhhant": {
                     "name": "Malforge"
                 }
             }
@@ -4830,7 +12089,37 @@
             "power": null,
             "text": "Play: Gain control of an enemy flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Maqui-Expedition"
+                },
                 "en": {
+                    "name": "Maqui Expedition"
+                },
+                "es": {
+                    "name": "Maqui Expedition"
+                },
+                "fr": {
+                    "name": "Expédition Maquis"
+                },
+                "it": {
+                    "name": "Maqui Expedition"
+                },
+                "pl": {
+                    "name": "Maqui Expedition"
+                },
+                "pt": {
+                    "name": "Maqui Expedition"
+                },
+                "th": {
+                    "name": "Maqui Expedition"
+                },
+                "vi": {
+                    "name": "Maqui Expedition"
+                },
+                "zhhans": {
+                    "name": "Maqui Expedition"
+                },
+                "zhhant": {
                     "name": "Maqui Expedition"
                 }
             }
@@ -4843,7 +12132,9 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["item"],
+            "traits": [
+                "item"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 0,
@@ -4851,7 +12142,37 @@
             "power": null,
             "text": "Enhance  . (These icons have already been added to cards in your deck.)\nAction: Ready and fight with a friendly Skyborn creature. If your blue key is forged, repeat the preceding effect.\n",
             "locale": {
+                "de": {
+                    "name": "Rasierer-Gambit"
+                },
                 "en": {
+                    "name": "Razor’s Gambit"
+                },
+                "es": {
+                    "name": "Razor’s Gambit"
+                },
+                "fr": {
+                    "name": "Stratagème du Rasoir"
+                },
+                "it": {
+                    "name": "Razor’s Gambit"
+                },
+                "pl": {
+                    "name": "Razor’s Gambit"
+                },
+                "pt": {
+                    "name": "Razor’s Gambit"
+                },
+                "th": {
+                    "name": "Razor’s Gambit"
+                },
+                "vi": {
+                    "name": "Razor’s Gambit"
+                },
+                "zhhans": {
+                    "name": "Razor’s Gambit"
+                },
+                "zhhant": {
                     "name": "Razor’s Gambit"
                 }
             }
@@ -4872,7 +12193,37 @@
             "power": null,
             "text": "Play: Discard a card. Resolve its bonus icons as if you had played it. If a yellow key is forged, repeat the preceding effect.\n",
             "locale": {
+                "de": {
+                    "name": "Fröhliches Überbordwerfen"
+                },
                 "en": {
+                    "name": "Recreational Jettison"
+                },
+                "es": {
+                    "name": "Recreational Jettison"
+                },
+                "fr": {
+                    "name": "Délestage Récréatif"
+                },
+                "it": {
+                    "name": "Recreational Jettison"
+                },
+                "pl": {
+                    "name": "Recreational Jettison"
+                },
+                "pt": {
+                    "name": "Recreational Jettison"
+                },
+                "th": {
+                    "name": "Recreational Jettison"
+                },
+                "vi": {
+                    "name": "Recreational Jettison"
+                },
+                "zhhans": {
+                    "name": "Recreational Jettison"
+                },
+                "zhhant": {
                     "name": "Recreational Jettison"
                 }
             }
@@ -4893,7 +12244,37 @@
             "power": null,
             "text": "Each time a card would be discarded from a player's hand, reveal the card and put it facedown under this creature instead.\n",
             "locale": {
+                "de": {
+                    "name": "Hochwertiger Klebstoff"
+                },
                 "en": {
+                    "name": "Refined Adhesive"
+                },
+                "es": {
+                    "name": "Refined Adhesive"
+                },
+                "fr": {
+                    "name": "Adhésif Raffiné"
+                },
+                "it": {
+                    "name": "Refined Adhesive"
+                },
+                "pl": {
+                    "name": "Refined Adhesive"
+                },
+                "pt": {
+                    "name": "Refined Adhesive"
+                },
+                "th": {
+                    "name": "Refined Adhesive"
+                },
+                "vi": {
+                    "name": "Refined Adhesive"
+                },
+                "zhhans": {
+                    "name": "Refined Adhesive"
+                },
+                "zhhant": {
                     "name": "Refined Adhesive"
                 }
             }
@@ -4914,7 +12295,37 @@
             "power": null,
             "text": "Play: Take control of the enemy creature in the center of your opponent’s battleline.\n",
             "locale": {
+                "de": {
+                    "name": "Willkommenskultur"
+                },
                 "en": {
+                    "name": "Universal Welcome"
+                },
+                "es": {
+                    "name": "Universal Welcome"
+                },
+                "fr": {
+                    "name": "Accueil Universel"
+                },
+                "it": {
+                    "name": "Universal Welcome"
+                },
+                "pl": {
+                    "name": "Universal Welcome"
+                },
+                "pt": {
+                    "name": "Universal Welcome"
+                },
+                "th": {
+                    "name": "Universal Welcome"
+                },
+                "vi": {
+                    "name": "Universal Welcome"
+                },
+                "zhhans": {
+                    "name": "Universal Welcome"
+                },
+                "zhhant": {
                     "name": "Universal Welcome"
                 }
             }
@@ -4927,7 +12338,10 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["adagion", "artisan"],
+            "traits": [
+                "adagion",
+                "artisan"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -4935,28 +12349,91 @@
             "power": 2,
             "text": "While your yellow key is forged, each enemy creature enters play stunned. \nPlay: If your yellow key is forged, stun each enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Vicomte von Aerys"
+                },
                 "en": {
+                    "name": "Viscount of Aerys"
+                },
+                "es": {
+                    "name": "Viscount of Aerys"
+                },
+                "fr": {
+                    "name": "Vicomte d’Aerys"
+                },
+                "it": {
+                    "name": "Viscount of Aerys"
+                },
+                "pl": {
+                    "name": "Viscount of Aerys"
+                },
+                "pt": {
+                    "name": "Viscount of Aerys"
+                },
+                "th": {
+                    "name": "Viscount of Aerys"
+                },
+                "vi": {
+                    "name": "Viscount of Aerys"
+                },
+                "zhhans": {
+                    "name": "Viscount of Aerys"
+                },
+                "zhhant": {
                     "name": "Viscount of Aerys"
                 }
             }
         },
         {
-            "id": "zomok2",
+            "id": "zomok22222222222",
             "name": "Zomok",
             "number": "213",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_213_02de64b9d6a8_en.png",
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": [],
+            "traits": [
+                "beast",
+                "cyborg"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
             "armor": null,
-            "power": null,
-            "text": "",
+            "power": 16,
+            "text": "(Play only with the other half of Zomok.)\nWhile Zomok is attacking, ignore taunt, elusive, poison, hazardous, and invulnerable.\nAfter Fight: Deal 2 to a creature for each forged key.\n",
             "locale": {
+                "de": {
+                    "name": "Zomok"
+                },
                 "en": {
+                    "name": "Zomok"
+                },
+                "es": {
+                    "name": "Zomok"
+                },
+                "fr": {
+                    "name": "Zomok"
+                },
+                "it": {
+                    "name": "Zomok"
+                },
+                "pl": {
+                    "name": "Zomok"
+                },
+                "pt": {
+                    "name": "Zomok"
+                },
+                "th": {
+                    "name": "Zomok"
+                },
+                "vi": {
+                    "name": "Zomok"
+                },
+                "zhhans": {
+                    "name": "Zomok"
+                },
+                "zhhant": {
                     "name": "Zomok"
                 }
             }
@@ -4969,7 +12446,10 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["beast", "cyborg"],
+            "traits": [
+                "beast",
+                "cyborg"
+            ],
             "type": "creature",
             "rarity": "Special",
             "amber": 0,
@@ -4977,7 +12457,37 @@
             "power": 16,
             "text": "(Play only with the other half of Zomok.)\nWhile Zomok is attacking, ignore taunt, elusive, poison, hazardous, and invulnerable.\nAfter Fight: Deal 2 to a creature for each forged key.\n",
             "locale": {
+                "de": {
+                    "name": "Zomok"
+                },
                 "en": {
+                    "name": "Zomok"
+                },
+                "es": {
+                    "name": "Zomok"
+                },
+                "fr": {
+                    "name": "Zomok"
+                },
+                "it": {
+                    "name": "Zomok"
+                },
+                "pl": {
+                    "name": "Zomok"
+                },
+                "pt": {
+                    "name": "Zomok"
+                },
+                "th": {
+                    "name": "Zomok"
+                },
+                "vi": {
+                    "name": "Zomok"
+                },
+                "zhhans": {
+                    "name": "Zomok"
+                },
+                "zhhant": {
                     "name": "Zomok"
                 }
             }
@@ -4990,7 +12500,10 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["getrookya", "pilot"],
+            "traits": [
+                "getrookya",
+                "pilot"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 1,
@@ -4998,7 +12511,37 @@
             "power": 2,
             "text": "After Fight/After Reap: Shuffle Æmber Airhart into its owner’s deck.\n",
             "locale": {
+                "de": {
+                    "name": "Æmber-Flughart"
+                },
                 "en": {
+                    "name": "Æmber Airhart"
+                },
+                "es": {
+                    "name": "Æmber Airhart"
+                },
+                "fr": {
+                    "name": "Amelia Aombrehart"
+                },
+                "it": {
+                    "name": "Æmber Airhart"
+                },
+                "pl": {
+                    "name": "Æmber Airhart"
+                },
+                "pt": {
+                    "name": "Æmber Airhart"
+                },
+                "th": {
+                    "name": "Æmber Airhart"
+                },
+                "vi": {
+                    "name": "Æmber Airhart"
+                },
+                "zhhans": {
+                    "name": "Æmber Airhart"
+                },
+                "zhhant": {
                     "name": "Æmber Airhart"
                 }
             }
@@ -5010,8 +12553,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_215_27bb4ff395af_en.png",
             "expansion": 928,
             "house": "skyborn",
-            "keywords": ["entrench"],
-            "traits": ["halyard", "cyborg"],
+            "keywords": [
+                "entrench"
+            ],
+            "traits": [
+                "halyard",
+                "cyborg"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -5019,7 +12567,37 @@
             "power": 3,
             "text": "Entrench.\nAt the start of your turn, if Cabochon is exhausted, gain 1 for each friendly Skyborn flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Cabochon"
+                },
                 "en": {
+                    "name": "Cabochon"
+                },
+                "es": {
+                    "name": "Cabochon"
+                },
+                "fr": {
+                    "name": "Cabochon"
+                },
+                "it": {
+                    "name": "Cabochon"
+                },
+                "pl": {
+                    "name": "Cabochon"
+                },
+                "pt": {
+                    "name": "Cabochon"
+                },
+                "th": {
+                    "name": "Cabochon"
+                },
+                "vi": {
+                    "name": "Cabochon"
+                },
+                "zhhans": {
+                    "name": "Cabochon"
+                },
+                "zhhant": {
                     "name": "Cabochon"
                 }
             }
@@ -5040,7 +12618,37 @@
             "power": null,
             "text": "Play: Move a creature to a flank of its controller’s battleline. Steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Rand der Welt"
+                },
                 "en": {
+                    "name": "Edge of the World"
+                },
+                "es": {
+                    "name": "Edge of the World"
+                },
+                "fr": {
+                    "name": "Bout du Monde"
+                },
+                "it": {
+                    "name": "Edge of the World"
+                },
+                "pl": {
+                    "name": "Edge of the World"
+                },
+                "pt": {
+                    "name": "Edge of the World"
+                },
+                "th": {
+                    "name": "Edge of the World"
+                },
+                "vi": {
+                    "name": "Edge of the World"
+                },
+                "zhhans": {
+                    "name": "Edge of the World"
+                },
+                "zhhant": {
                     "name": "Edge of the World"
                 }
             }
@@ -5061,7 +12669,37 @@
             "power": null,
             "text": "Play: Steal 1 for each ready Skyborn creature in play.\n",
             "locale": {
+                "de": {
+                    "name": "Glutbeutel"
+                },
                 "en": {
+                    "name": "Embered Purse"
+                },
+                "es": {
+                    "name": "Embered Purse"
+                },
+                "fr": {
+                    "name": "Bourse Embrasée"
+                },
+                "it": {
+                    "name": "Embered Purse"
+                },
+                "pl": {
+                    "name": "Embered Purse"
+                },
+                "pt": {
+                    "name": "Embered Purse"
+                },
+                "th": {
+                    "name": "Embered Purse"
+                },
+                "vi": {
+                    "name": "Embered Purse"
+                },
+                "zhhans": {
+                    "name": "Embered Purse"
+                },
+                "zhhant": {
                     "name": "Embered Purse"
                 }
             }
@@ -5082,7 +12720,37 @@
             "power": null,
             "text": "Play: Each friendly flank creature captures 1. If a yellow key is forged, repeat the preceding effect.\n",
             "locale": {
+                "de": {
+                    "name": "Vergoldet sie!"
+                },
                 "en": {
+                    "name": "Gilt ’Em Good"
+                },
+                "es": {
+                    "name": "Gilt ’Em Good"
+                },
+                "fr": {
+                    "name": "Couverts d'Or"
+                },
+                "it": {
+                    "name": "Gilt ’Em Good"
+                },
+                "pl": {
+                    "name": "Gilt ’Em Good"
+                },
+                "pt": {
+                    "name": "Gilt ’Em Good"
+                },
+                "th": {
+                    "name": "Gilt ’Em Good"
+                },
+                "vi": {
+                    "name": "Gilt ’Em Good"
+                },
+                "zhhans": {
+                    "name": "Gilt ’Em Good"
+                },
+                "zhhant": {
                     "name": "Gilt ’Em Good"
                 }
             }
@@ -5103,7 +12771,37 @@
             "power": null,
             "text": "Play: Take control of an enemy flank creature and give it three +1 power counters. While under your control, it belongs to house Skyborn. (Instead of its original house.)\n",
             "locale": {
+                "de": {
+                    "name": "Hannibals Mal"
+                },
                 "en": {
+                    "name": "Hannibal’s Mark"
+                },
+                "es": {
+                    "name": "Hannibal’s Mark"
+                },
+                "fr": {
+                    "name": "Marque d’Hannibal"
+                },
+                "it": {
+                    "name": "Hannibal’s Mark"
+                },
+                "pl": {
+                    "name": "Hannibal’s Mark"
+                },
+                "pt": {
+                    "name": "Hannibal’s Mark"
+                },
+                "th": {
+                    "name": "Hannibal’s Mark"
+                },
+                "vi": {
+                    "name": "Hannibal’s Mark"
+                },
+                "zhhans": {
+                    "name": "Hannibal’s Mark"
+                },
+                "zhhant": {
                     "name": "Hannibal’s Mark"
                 }
             }
@@ -5116,7 +12814,9 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["j'reen"],
+            "traits": [
+                "j'reen"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -5124,7 +12824,37 @@
             "power": 3,
             "text": "After Reap: If Navigator Ketarr is on a flank, draw 2 cards and archive a card.\n",
             "locale": {
+                "de": {
+                    "name": "Navigator Ketarr"
+                },
                 "en": {
+                    "name": "Navigator Ketarr"
+                },
+                "es": {
+                    "name": "Navigator Ketarr"
+                },
+                "fr": {
+                    "name": "Navigateur Ketarr"
+                },
+                "it": {
+                    "name": "Navigator Ketarr"
+                },
+                "pl": {
+                    "name": "Navigator Ketarr"
+                },
+                "pt": {
+                    "name": "Navigator Ketarr"
+                },
+                "th": {
+                    "name": "Navigator Ketarr"
+                },
+                "vi": {
+                    "name": "Navigator Ketarr"
+                },
+                "zhhans": {
+                    "name": "Navigator Ketarr"
+                },
+                "zhhant": {
                     "name": "Navigator Ketarr"
                 }
             }
@@ -5136,8 +12866,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_221_e01ccd3b42f8_en.png",
             "expansion": 928,
             "house": "skyborn",
-            "keywords": ["taunt"],
-            "traits": ["stormkin"],
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "stormkin"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -5145,7 +12879,37 @@
             "power": 6,
             "text": "Taunt.\nAfter Fight: You may move Pirate Champion to a flank.\n",
             "locale": {
+                "de": {
+                    "name": "Piratenmeister"
+                },
                 "en": {
+                    "name": "Pirate Champion"
+                },
+                "es": {
+                    "name": "Pirate Champion"
+                },
+                "fr": {
+                    "name": "Champion Pirate"
+                },
+                "it": {
+                    "name": "Pirate Champion"
+                },
+                "pl": {
+                    "name": "Pirate Champion"
+                },
+                "pt": {
+                    "name": "Pirate Champion"
+                },
+                "th": {
+                    "name": "Pirate Champion"
+                },
+                "vi": {
+                    "name": "Pirate Champion"
+                },
+                "zhhans": {
+                    "name": "Pirate Champion"
+                },
+                "zhhant": {
                     "name": "Pirate Champion"
                 }
             }
@@ -5166,7 +12930,37 @@
             "power": null,
             "text": "Play: Move a friendly Skyborn creature to a flank and ready it. If a red key is forged, repeat the preceding effect.\n",
             "locale": {
+                "de": {
+                    "name": "Abendrot"
+                },
                 "en": {
+                    "name": "Red Skies"
+                },
+                "es": {
+                    "name": "Red Skies"
+                },
+                "fr": {
+                    "name": "Ciels Rouges"
+                },
+                "it": {
+                    "name": "Red Skies"
+                },
+                "pl": {
+                    "name": "Red Skies"
+                },
+                "pt": {
+                    "name": "Red Skies"
+                },
+                "th": {
+                    "name": "Red Skies"
+                },
+                "vi": {
+                    "name": "Red Skies"
+                },
+                "zhhans": {
+                    "name": "Red Skies"
+                },
+                "zhhant": {
                     "name": "Red Skies"
                 }
             }
@@ -5187,7 +12981,37 @@
             "power": null,
             "text": "Play: Gain 1 for each house represented among friendly flank creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Silberstreifen"
+                },
                 "en": {
+                    "name": "Silver Linings"
+                },
+                "es": {
+                    "name": "Silver Linings"
+                },
+                "fr": {
+                    "name": "Lueur d’Espoir"
+                },
+                "it": {
+                    "name": "Silver Linings"
+                },
+                "pl": {
+                    "name": "Silver Linings"
+                },
+                "pt": {
+                    "name": "Silver Linings"
+                },
+                "th": {
+                    "name": "Silver Linings"
+                },
+                "vi": {
+                    "name": "Silver Linings"
+                },
+                "zhhans": {
+                    "name": "Silver Linings"
+                },
+                "zhhant": {
                     "name": "Silver Linings"
                 }
             }
@@ -5200,7 +13024,10 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["human", "knight"],
+            "traits": [
+                "human",
+                "knight"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -5208,7 +13035,37 @@
             "power": 5,
             "text": "If your red key is forged, Sir Lorcas gains skirmish. \nIf your yellow key is forged, Sir Lorcas gains elusive. \nIf your blue key is forged, Sir Lorcas gains taunt.\n",
             "locale": {
+                "de": {
+                    "name": "Sir Lorcas"
+                },
                 "en": {
+                    "name": "Sir Lorcas"
+                },
+                "es": {
+                    "name": "Sir Lorcas"
+                },
+                "fr": {
+                    "name": "Sire Lorcas"
+                },
+                "it": {
+                    "name": "Sir Lorcas"
+                },
+                "pl": {
+                    "name": "Sir Lorcas"
+                },
+                "pt": {
+                    "name": "Sir Lorcas"
+                },
+                "th": {
+                    "name": "Sir Lorcas"
+                },
+                "vi": {
+                    "name": "Sir Lorcas"
+                },
+                "zhhans": {
+                    "name": "Sir Lorcas"
+                },
+                "zhhant": {
                     "name": "Sir Lorcas"
                 }
             }
@@ -5221,7 +13078,10 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["robot", "halyard"],
+            "traits": [
+                "robot",
+                "halyard"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -5229,7 +13089,37 @@
             "power": 4,
             "text": "After Reap: If a blue key is forged, draw 2 cards. Otherwise, draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Tur-bo-prop"
+                },
                 "en": {
+                    "name": "Tur-bo-prop"
+                },
+                "es": {
+                    "name": "Tur-bo-prop"
+                },
+                "fr": {
+                    "name": "Tur-bo-prop"
+                },
+                "it": {
+                    "name": "Tur-bo-prop"
+                },
+                "pl": {
+                    "name": "Tur-bo-prop"
+                },
+                "pt": {
+                    "name": "Tur-bo-prop"
+                },
+                "th": {
+                    "name": "Tur-bo-prop"
+                },
+                "vi": {
+                    "name": "Tur-bo-prop"
+                },
+                "zhhans": {
+                    "name": "Tur-bo-prop"
+                },
+                "zhhant": {
                     "name": "Tur-bo-prop"
                 }
             }
@@ -5242,7 +13132,10 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["human", "halyard"],
+            "traits": [
+                "human",
+                "halyard"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -5250,7 +13143,37 @@
             "power": 3,
             "text": "After your opponent discards a card from their hand, gain 1.\n",
             "locale": {
+                "de": {
+                    "name": "Ty Lourd"
+                },
                 "en": {
+                    "name": "Ty Lourd"
+                },
+                "es": {
+                    "name": "Ty Lourd"
+                },
+                "fr": {
+                    "name": "Ty Lourd"
+                },
+                "it": {
+                    "name": "Ty Lourd"
+                },
+                "pl": {
+                    "name": "Ty Lourd"
+                },
+                "pt": {
+                    "name": "Ty Lourd"
+                },
+                "th": {
+                    "name": "Ty Lourd"
+                },
+                "vi": {
+                    "name": "Ty Lourd"
+                },
+                "zhhans": {
+                    "name": "Ty Lourd"
+                },
+                "zhhant": {
                     "name": "Ty Lourd"
                 }
             }
@@ -5271,7 +13194,37 @@
             "power": null,
             "text": "Play: Steal 2 if any flank creature shares a house with another flank creature. Otherwise, steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Gegen alle Flaggen"
+                },
                 "en": {
+                    "name": "Against All Flags"
+                },
+                "es": {
+                    "name": "Against All Flags"
+                },
+                "fr": {
+                    "name": "À l’Abordage !"
+                },
+                "it": {
+                    "name": "Against All Flags"
+                },
+                "pl": {
+                    "name": "Against All Flags"
+                },
+                "pt": {
+                    "name": "Against All Flags"
+                },
+                "th": {
+                    "name": "Against All Flags"
+                },
+                "vi": {
+                    "name": "Against All Flags"
+                },
+                "zhhans": {
+                    "name": "Against All Flags"
+                },
+                "zhhant": {
                     "name": "Against All Flags"
                 }
             }
@@ -5292,7 +13245,37 @@
             "power": null,
             "text": "Play: Move a creature to a flank of its controller’s battleline and exhaust it.\n",
             "locale": {
+                "de": {
+                    "name": "Fassrolle"
+                },
                 "en": {
+                    "name": "Barrel Roll"
+                },
+                "es": {
+                    "name": "Barrel Roll"
+                },
+                "fr": {
+                    "name": "Tonneau"
+                },
+                "it": {
+                    "name": "Barrel Roll"
+                },
+                "pl": {
+                    "name": "Barrel Roll"
+                },
+                "pt": {
+                    "name": "Barrel Roll"
+                },
+                "th": {
+                    "name": "Barrel Roll"
+                },
+                "vi": {
+                    "name": "Barrel Roll"
+                },
+                "zhhans": {
+                    "name": "Barrel Roll"
+                },
+                "zhhant": {
                     "name": "Barrel Roll"
                 }
             }
@@ -5305,7 +13288,9 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["beast"],
+            "traits": [
+                "beast"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -5313,7 +13298,37 @@
             "power": 2,
             "text": "Enhance .\nAfter Fight/After Reap: Put a +1 power counter on each friendly flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Blutschwinge"
+                },
                 "en": {
+                    "name": "Bloodwing"
+                },
+                "es": {
+                    "name": "Bloodwing"
+                },
+                "fr": {
+                    "name": "Piruche"
+                },
+                "it": {
+                    "name": "Bloodwing"
+                },
+                "pl": {
+                    "name": "Bloodwing"
+                },
+                "pt": {
+                    "name": "Bloodwing"
+                },
+                "th": {
+                    "name": "Bloodwing"
+                },
+                "vi": {
+                    "name": "Bloodwing"
+                },
+                "zhhans": {
+                    "name": "Bloodwing"
+                },
+                "zhhant": {
                     "name": "Bloodwing"
                 }
             }
@@ -5334,7 +13349,37 @@
             "power": null,
             "text": "Play: If you are overwhelmed, put an enemy creature on the bottom of its owner’s deck. Otherwise, move an enemy creature to a flank of its controller’s battleline and exhaust it.\n",
             "locale": {
+                "de": {
+                    "name": "Eiskalte Fesseln"
+                },
                 "en": {
+                    "name": "Cold Ropes"
+                },
+                "es": {
+                    "name": "Cold Ropes"
+                },
+                "fr": {
+                    "name": "Coup de Froid"
+                },
+                "it": {
+                    "name": "Cold Ropes"
+                },
+                "pl": {
+                    "name": "Cold Ropes"
+                },
+                "pt": {
+                    "name": "Cold Ropes"
+                },
+                "th": {
+                    "name": "Cold Ropes"
+                },
+                "vi": {
+                    "name": "Cold Ropes"
+                },
+                "zhhans": {
+                    "name": "Cold Ropes"
+                },
+                "zhhant": {
                     "name": "Cold Ropes"
                 }
             }
@@ -5347,7 +13392,10 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["human", "cyborg"],
+            "traits": [
+                "human",
+                "cyborg"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -5355,7 +13403,37 @@
             "power": 4,
             "text": "After Fight: Steal 1. If a blue key is forged, ward Deep Blue Bryn.\n",
             "locale": {
+                "de": {
+                    "name": "Tief Blauer Bryn"
+                },
                 "en": {
+                    "name": "Deep Blue Bryn"
+                },
+                "es": {
+                    "name": "Deep Blue Bryn"
+                },
+                "fr": {
+                    "name": "Bryn Barbacier"
+                },
+                "it": {
+                    "name": "Deep Blue Bryn"
+                },
+                "pl": {
+                    "name": "Deep Blue Bryn"
+                },
+                "pt": {
+                    "name": "Deep Blue Bryn"
+                },
+                "th": {
+                    "name": "Deep Blue Bryn"
+                },
+                "vi": {
+                    "name": "Deep Blue Bryn"
+                },
+                "zhhans": {
+                    "name": "Deep Blue Bryn"
+                },
+                "zhhant": {
                     "name": "Deep Blue Bryn"
                 }
             }
@@ -5368,7 +13446,10 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["cyborg", "stormkin"],
+            "traits": [
+                "cyborg",
+                "stormkin"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -5376,7 +13457,37 @@
             "power": 4,
             "text": "After Reap: If Jeen Peary is on a flank, steal 1.\n",
             "locale": {
+                "de": {
+                    "name": "Jeen Peary"
+                },
                 "en": {
+                    "name": "Jeen Peary"
+                },
+                "es": {
+                    "name": "Jeen Peary"
+                },
+                "fr": {
+                    "name": "Jeanne Peary"
+                },
+                "it": {
+                    "name": "Jeen Peary"
+                },
+                "pl": {
+                    "name": "Jeen Peary"
+                },
+                "pt": {
+                    "name": "Jeen Peary"
+                },
+                "th": {
+                    "name": "Jeen Peary"
+                },
+                "vi": {
+                    "name": "Jeen Peary"
+                },
+                "zhhans": {
+                    "name": "Jeen Peary"
+                },
+                "zhhant": {
                     "name": "Jeen Peary"
                 }
             }
@@ -5397,7 +13508,37 @@
             "power": null,
             "text": "Play: Ready and use a friendly flank creature. If you are overwhelmed, repeat the preceding effect.\n",
             "locale": {
+                "de": {
+                    "name": "Starthilfe"
+                },
                 "en": {
+                    "name": "Jump Start"
+                },
+                "es": {
+                    "name": "Jump Start"
+                },
+                "fr": {
+                    "name": "Catapultage"
+                },
+                "it": {
+                    "name": "Jump Start"
+                },
+                "pl": {
+                    "name": "Jump Start"
+                },
+                "pt": {
+                    "name": "Jump Start"
+                },
+                "th": {
+                    "name": "Jump Start"
+                },
+                "vi": {
+                    "name": "Jump Start"
+                },
+                "zhhans": {
+                    "name": "Jump Start"
+                },
+                "zhhant": {
                     "name": "Jump Start"
                 }
             }
@@ -5410,7 +13551,10 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["human", "stormkin"],
+            "traits": [
+                "human",
+                "stormkin"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -5418,7 +13562,37 @@
             "power": 5,
             "text": "After Fight: If you are overwhelmed, steal 2. Otherwise capture 1.\n",
             "locale": {
+                "de": {
+                    "name": "Leutnant Chars"
+                },
                 "en": {
+                    "name": "Leftenant Chars"
+                },
+                "es": {
+                    "name": "Leftenant Chars"
+                },
+                "fr": {
+                    "name": "Lieutenant Charles"
+                },
+                "it": {
+                    "name": "Leftenant Chars"
+                },
+                "pl": {
+                    "name": "Leftenant Chars"
+                },
+                "pt": {
+                    "name": "Leftenant Chars"
+                },
+                "th": {
+                    "name": "Leftenant Chars"
+                },
+                "vi": {
+                    "name": "Leftenant Chars"
+                },
+                "zhhans": {
+                    "name": "Leftenant Chars"
+                },
+                "zhhant": {
                     "name": "Leftenant Chars"
                 }
             }
@@ -5439,7 +13613,37 @@
             "power": null,
             "text": "Play: Destroy an enemy flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Die Propeller abstauben"
+                },
                 "en": {
+                    "name": "Prop Dusting"
+                },
+                "es": {
+                    "name": "Prop Dusting"
+                },
+                "fr": {
+                    "name": "Dépoussiérer les Hélices"
+                },
+                "it": {
+                    "name": "Prop Dusting"
+                },
+                "pl": {
+                    "name": "Prop Dusting"
+                },
+                "pt": {
+                    "name": "Prop Dusting"
+                },
+                "th": {
+                    "name": "Prop Dusting"
+                },
+                "vi": {
+                    "name": "Prop Dusting"
+                },
+                "zhhans": {
+                    "name": "Prop Dusting"
+                },
+                "zhhant": {
                     "name": "Prop Dusting"
                 }
             }
@@ -5451,8 +13655,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_236_f8c0933a3ed9_en.png",
             "expansion": 928,
             "house": "skyborn",
-            "keywords": ["entrench"],
-            "traits": ["dinosaur", "halyard"],
+            "keywords": [
+                "entrench"
+            ],
+            "traits": [
+                "dinosaur",
+                "halyard"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -5460,7 +13669,37 @@
             "power": 3,
             "text": "Entrench.\nWhile Remmi Hound is exhausted, each friendly flank creature gets +4 power.\n\n",
             "locale": {
+                "de": {
+                    "name": "Remmi-Hund"
+                },
                 "en": {
+                    "name": "Remmi Hound"
+                },
+                "es": {
+                    "name": "Remmi Hound"
+                },
+                "fr": {
+                    "name": "Rémi le Limier"
+                },
+                "it": {
+                    "name": "Remmi Hound"
+                },
+                "pl": {
+                    "name": "Remmi Hound"
+                },
+                "pt": {
+                    "name": "Remmi Hound"
+                },
+                "th": {
+                    "name": "Remmi Hound"
+                },
+                "vi": {
+                    "name": "Remmi Hound"
+                },
+                "zhhans": {
+                    "name": "Remmi Hound"
+                },
+                "zhhant": {
                     "name": "Remmi Hound"
                 }
             }
@@ -5473,7 +13712,10 @@
             "expansion": 928,
             "house": "skyborn",
             "keywords": [],
-            "traits": ["human", "stormkin"],
+            "traits": [
+                "human",
+                "stormkin"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -5481,7 +13723,37 @@
             "power": 3,
             "text": "After Fight: If a red key is forged, deal 4 to each enemy flank creature. Otherwise, deal 1 to each enemy flank creature.\n",
             "locale": {
+                "de": {
+                    "name": "Ruby Rackham"
+                },
                 "en": {
+                    "name": "Ruby Rackham"
+                },
+                "es": {
+                    "name": "Ruby Rackham"
+                },
+                "fr": {
+                    "name": "Rackham la Rouge"
+                },
+                "it": {
+                    "name": "Ruby Rackham"
+                },
+                "pl": {
+                    "name": "Ruby Rackham"
+                },
+                "pt": {
+                    "name": "Ruby Rackham"
+                },
+                "th": {
+                    "name": "Ruby Rackham"
+                },
+                "vi": {
+                    "name": "Ruby Rackham"
+                },
+                "zhhans": {
+                    "name": "Ruby Rackham"
+                },
+                "zhhant": {
                     "name": "Ruby Rackham"
                 }
             }
@@ -5493,8 +13765,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_238_80fde38668eb_en.png",
             "expansion": 928,
             "house": "skyborn",
-            "keywords": ["elusive"],
-            "traits": ["stormkin"],
+            "keywords": [
+                "elusive"
+            ],
+            "traits": [
+                "stormkin"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -5502,7 +13778,37 @@
             "power": 2,
             "text": "Elusive.\nAfter Reap: If your red key is forged, destroy an enemy creature. If your yellow key is forged, destroy an enemy artifact. If your blue key is forged, destroy an enemy upgrade.\n",
             "locale": {
+                "de": {
+                    "name": "Schleichende Saboteure"
+                },
                 "en": {
+                    "name": "Skulking Saboteurs"
+                },
+                "es": {
+                    "name": "Skulking Saboteurs"
+                },
+                "fr": {
+                    "name": "Saboteurs Inventifs"
+                },
+                "it": {
+                    "name": "Skulking Saboteurs"
+                },
+                "pl": {
+                    "name": "Skulking Saboteurs"
+                },
+                "pt": {
+                    "name": "Skulking Saboteurs"
+                },
+                "th": {
+                    "name": "Skulking Saboteurs"
+                },
+                "vi": {
+                    "name": "Skulking Saboteurs"
+                },
+                "zhhans": {
+                    "name": "Skulking Saboteurs"
+                },
+                "zhhant": {
                     "name": "Skulking Saboteurs"
                 }
             }
@@ -5515,7 +13821,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["location"],
+            "traits": [
+                "location"
+            ],
             "type": "artifact",
             "rarity": "Rare",
             "amber": 1,
@@ -5523,7 +13831,37 @@
             "power": null,
             "text": "After a creature fights, it doesn’t ready during the “ready cards” step this turn.\n",
             "locale": {
+                "de": {
+                    "name": "Brackwasserküste"
+                },
                 "en": {
+                    "name": "Brackish Shoreline"
+                },
+                "es": {
+                    "name": "Brackish Shoreline"
+                },
+                "fr": {
+                    "name": "Rivage Saumâtre"
+                },
+                "it": {
+                    "name": "Brackish Shoreline"
+                },
+                "pl": {
+                    "name": "Brackish Shoreline"
+                },
+                "pt": {
+                    "name": "Brackish Shoreline"
+                },
+                "th": {
+                    "name": "Brackish Shoreline"
+                },
+                "vi": {
+                    "name": "Brackish Shoreline"
+                },
+                "zhhans": {
+                    "name": "Brackish Shoreline"
+                },
+                "zhhant": {
                     "name": "Brackish Shoreline"
                 }
             }
@@ -5544,7 +13882,37 @@
             "power": null,
             "text": "Play: Choose one:\nDestroy an artifact.\nDestroy an upgrade.\nDestroy a creature with armor.\n",
             "locale": {
+                "de": {
+                    "name": "Rosten"
+                },
                 "en": {
+                    "name": "Corrode"
+                },
+                "es": {
+                    "name": "Corrode"
+                },
+                "fr": {
+                    "name": "Corroder"
+                },
+                "it": {
+                    "name": "Corrode"
+                },
+                "pl": {
+                    "name": "Corrode"
+                },
+                "pt": {
+                    "name": "Corrode"
+                },
+                "th": {
+                    "name": "Corrode"
+                },
+                "vi": {
+                    "name": "Corrode"
+                },
+                "zhhans": {
+                    "name": "Corrode"
+                },
+                "zhhant": {
                     "name": "Corrode"
                 }
             }
@@ -5565,7 +13933,37 @@
             "power": null,
             "text": "Play: Exhaust a creature and each of its neighbors. Stun 2 exhausted creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Benommen und verwirrt"
+                },
                 "en": {
+                    "name": "Dazed and Confused"
+                },
+                "es": {
+                    "name": "Dazed and Confused"
+                },
+                "fr": {
+                    "name": "Confus et Perdus"
+                },
+                "it": {
+                    "name": "Dazed and Confused"
+                },
+                "pl": {
+                    "name": "Dazed and Confused"
+                },
+                "pt": {
+                    "name": "Dazed and Confused"
+                },
+                "th": {
+                    "name": "Dazed and Confused"
+                },
+                "vi": {
+                    "name": "Dazed and Confused"
+                },
+                "zhhans": {
+                    "name": "Dazed and Confused"
+                },
+                "zhhant": {
                     "name": "Dazed and Confused"
                 }
             }
@@ -5578,7 +13976,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["aquan"],
+            "traits": [
+                "aquan"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -5586,7 +13986,37 @@
             "power": 5,
             "text": "After you play an Aquan creature, exhaust an enemy creature.\n",
             "locale": {
+                "de": {
+                    "name": "Tiefenpriester Glebe"
+                },
                 "en": {
+                    "name": "Deep Priest Glebe"
+                },
+                "es": {
+                    "name": "Deep Priest Glebe"
+                },
+                "fr": {
+                    "name": "Prêtre des Profondeurs Glebe"
+                },
+                "it": {
+                    "name": "Deep Priest Glebe"
+                },
+                "pl": {
+                    "name": "Deep Priest Glebe"
+                },
+                "pt": {
+                    "name": "Deep Priest Glebe"
+                },
+                "th": {
+                    "name": "Deep Priest Glebe"
+                },
+                "vi": {
+                    "name": "Deep Priest Glebe"
+                },
+                "zhhans": {
+                    "name": "Deep Priest Glebe"
+                },
+                "zhhant": {
                     "name": "Deep Priest Glebe"
                 }
             }
@@ -5607,28 +14037,91 @@
             "power": null,
             "text": "Play: For the remainder of the turn, after you play another card, exhaust a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Blitzeis"
+                },
                 "en": {
+                    "name": "Flash Freeze"
+                },
+                "es": {
+                    "name": "Flash Freeze"
+                },
+                "fr": {
+                    "name": "Gel Éclair"
+                },
+                "it": {
+                    "name": "Flash Freeze"
+                },
+                "pl": {
+                    "name": "Flash Freeze"
+                },
+                "pt": {
+                    "name": "Flash Freeze"
+                },
+                "th": {
+                    "name": "Flash Freeze"
+                },
+                "vi": {
+                    "name": "Flash Freeze"
+                },
+                "zhhans": {
+                    "name": "Flash Freeze"
+                },
+                "zhhant": {
                     "name": "Flash Freeze"
                 }
             }
         },
         {
-            "id": "hydrogan2",
+            "id": "hydrogan22222222222",
             "name": "Hydrogan",
             "number": "244",
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_244_6fbbb8715d70_en.png",
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": [],
+            "traits": [
+                "beast",
+                "leviathan"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
             "armor": null,
-            "power": null,
-            "text": "",
+            "power": 10,
+            "text": "(Play only with the other half of Hydrogan.)\nPlay: Put each other creature faceup under Hydrogan.\nAfter Fight/After Reap: Put a creature from under Hydrogan into play under your control.\nDestroyed: Purge each card under Hydrogan.\n",
             "locale": {
+                "de": {
+                    "name": "Hydrogan"
+                },
                 "en": {
+                    "name": "Hydrogan"
+                },
+                "es": {
+                    "name": "Hydrogan"
+                },
+                "fr": {
+                    "name": "Hydrogand"
+                },
+                "it": {
+                    "name": "Hydrogan"
+                },
+                "pl": {
+                    "name": "Hydrogan"
+                },
+                "pt": {
+                    "name": "Hydrogan"
+                },
+                "th": {
+                    "name": "Hydrogan"
+                },
+                "vi": {
+                    "name": "Hydrogan"
+                },
+                "zhhans": {
+                    "name": "Hydrogan"
+                },
+                "zhhant": {
                     "name": "Hydrogan"
                 }
             }
@@ -5641,7 +14134,10 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["beast", "leviathan"],
+            "traits": [
+                "beast",
+                "leviathan"
+            ],
             "type": "creature",
             "rarity": "Special",
             "amber": 0,
@@ -5649,7 +14145,37 @@
             "power": 10,
             "text": "(Play only with the other half of Hydrogan.)\nPlay: Put each other creature faceup under Hydrogan.\nAfter Fight/After Reap: Put a creature from under Hydrogan into play under your control.\nDestroyed: Purge each card under Hydrogan.\n",
             "locale": {
+                "de": {
+                    "name": "Hydrogan"
+                },
                 "en": {
+                    "name": "Hydrogan"
+                },
+                "es": {
+                    "name": "Hydrogan"
+                },
+                "fr": {
+                    "name": "Hydrogand"
+                },
+                "it": {
+                    "name": "Hydrogan"
+                },
+                "pl": {
+                    "name": "Hydrogan"
+                },
+                "pt": {
+                    "name": "Hydrogan"
+                },
+                "th": {
+                    "name": "Hydrogan"
+                },
+                "vi": {
+                    "name": "Hydrogan"
+                },
+                "zhhans": {
+                    "name": "Hydrogan"
+                },
+                "zhhant": {
                     "name": "Hydrogan"
                 }
             }
@@ -5670,7 +14196,37 @@
             "power": null,
             "text": "Play: Look at your opponent’s hand. Play a card from that hand as if it were yours.\n",
             "locale": {
+                "de": {
+                    "name": "Lateralverschiebung"
+                },
                 "en": {
+                    "name": "Lateral Shift"
+                },
+                "es": {
+                    "name": "Lateral Shift"
+                },
+                "fr": {
+                    "name": "Décalage Latéral"
+                },
+                "it": {
+                    "name": "Lateral Shift"
+                },
+                "pl": {
+                    "name": "Lateral Shift"
+                },
+                "pt": {
+                    "name": "Lateral Shift"
+                },
+                "th": {
+                    "name": "Lateral Shift"
+                },
+                "vi": {
+                    "name": "Lateral Shift"
+                },
+                "zhhans": {
+                    "name": "Lateral Shift"
+                },
+                "zhhant": {
                     "name": "Lateral Shift"
                 }
             }
@@ -5691,7 +14247,37 @@
             "power": null,
             "text": "Play: Reveal a random unrevealed card from your opponent’s hand. Then, you may either repeat this effect or your opponent discards the last revealed card.",
             "locale": {
+                "de": {
+                    "name": "Plünderung"
+                },
                 "en": {
+                    "name": "Plunder"
+                },
+                "es": {
+                    "name": "Plunder"
+                },
+                "fr": {
+                    "name": "Pillage"
+                },
+                "it": {
+                    "name": "Plunder"
+                },
+                "pl": {
+                    "name": "Plunder"
+                },
+                "pt": {
+                    "name": "Plunder"
+                },
+                "th": {
+                    "name": "Plunder"
+                },
+                "vi": {
+                    "name": "Plunder"
+                },
+                "zhhans": {
+                    "name": "Plunder"
+                },
+                "zhhant": {
                     "name": "Plunder"
                 }
             }
@@ -5712,7 +14298,37 @@
             "power": null,
             "text": "Play: Exhaust a creature. Draw a card for each exhausted creature. Destroy each exhausted creature.\n",
             "locale": {
+                "de": {
+                    "name": "Sand ins Auge"
+                },
                 "en": {
+                    "name": "Sand In Your Eye"
+                },
+                "es": {
+                    "name": "Sand In Your Eye"
+                },
+                "fr": {
+                    "name": "Du Sable dans l'Œil"
+                },
+                "it": {
+                    "name": "Sand In Your Eye"
+                },
+                "pl": {
+                    "name": "Sand In Your Eye"
+                },
+                "pt": {
+                    "name": "Sand In Your Eye"
+                },
+                "th": {
+                    "name": "Sand In Your Eye"
+                },
+                "vi": {
+                    "name": "Sand In Your Eye"
+                },
+                "zhhans": {
+                    "name": "Sand In Your Eye"
+                },
+                "zhhant": {
                     "name": "Sand In Your Eye"
                 }
             }
@@ -5725,7 +14341,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["aquan"],
+            "traits": [
+                "aquan"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -5733,7 +14351,37 @@
             "power": 5,
             "text": "At the start of your opponent’s turn, that player discards the top card of their deck and exhausts each creature of that card’s house.\n",
             "locale": {
+                "de": {
+                    "name": "Sibyl Waimare"
+                },
                 "en": {
+                    "name": "Sibyl Waimare"
+                },
+                "es": {
+                    "name": "Sibyl Waimare"
+                },
+                "fr": {
+                    "name": "Sybille Waimare"
+                },
+                "it": {
+                    "name": "Sibyl Waimare"
+                },
+                "pl": {
+                    "name": "Sibyl Waimare"
+                },
+                "pt": {
+                    "name": "Sibyl Waimare"
+                },
+                "th": {
+                    "name": "Sibyl Waimare"
+                },
+                "vi": {
+                    "name": "Sibyl Waimare"
+                },
+                "zhhans": {
+                    "name": "Sibyl Waimare"
+                },
+                "zhhant": {
                     "name": "Sibyl Waimare"
                 }
             }
@@ -5754,7 +14402,37 @@
             "power": null,
             "text": "Enhance .\nThis creature gains, “At the start of your turn, if this creature is exhausted, purge another creature that shares a house with it.”\n",
             "locale": {
+                "de": {
+                    "name": "Sternenmal"
+                },
                 "en": {
+                    "name": "Starpatch"
+                },
+                "es": {
+                    "name": "Starpatch"
+                },
+                "fr": {
+                    "name": "Souffre-Chef"
+                },
+                "it": {
+                    "name": "Starpatch"
+                },
+                "pl": {
+                    "name": "Starpatch"
+                },
+                "pt": {
+                    "name": "Starpatch"
+                },
+                "th": {
+                    "name": "Starpatch"
+                },
+                "vi": {
+                    "name": "Starpatch"
+                },
+                "zhhans": {
+                    "name": "Starpatch"
+                },
+                "zhhant": {
                     "name": "Starpatch"
                 }
             }
@@ -5775,7 +14453,37 @@
             "power": null,
             "text": "Play: Discard the top 10 cards of your opponent’s deck.",
             "locale": {
+                "de": {
+                    "name": "Thalassophobie"
+                },
                 "en": {
+                    "name": "Thalassophobia"
+                },
+                "es": {
+                    "name": "Thalassophobia"
+                },
+                "fr": {
+                    "name": "Thalassophobie"
+                },
+                "it": {
+                    "name": "Thalassophobia"
+                },
+                "pl": {
+                    "name": "Thalassophobia"
+                },
+                "pt": {
+                    "name": "Thalassophobia"
+                },
+                "th": {
+                    "name": "Thalassophobia"
+                },
+                "vi": {
+                    "name": "Thalassophobia"
+                },
+                "zhhans": {
+                    "name": "Thalassophobia"
+                },
+                "zhhant": {
                     "name": "Thalassophobia"
                 }
             }
@@ -5788,7 +14496,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["aquan"],
+            "traits": [
+                "aquan"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -5796,7 +14506,37 @@
             "power": 9,
             "text": "Instead of readying creatures they control during their “ready cards” step, your opponent deals 1 to The Chosen One for each exhausted creature they control.",
             "locale": {
+                "de": {
+                    "name": "Der Auserwählte"
+                },
                 "en": {
+                    "name": "The Chosen One"
+                },
+                "es": {
+                    "name": "The Chosen One"
+                },
+                "fr": {
+                    "name": "L’Élu"
+                },
+                "it": {
+                    "name": "The Chosen One"
+                },
+                "pl": {
+                    "name": "The Chosen One"
+                },
+                "pt": {
+                    "name": "The Chosen One"
+                },
+                "th": {
+                    "name": "The Chosen One"
+                },
+                "vi": {
+                    "name": "The Chosen One"
+                },
+                "zhhans": {
+                    "name": "The Chosen One"
+                },
+                "zhhant": {
                     "name": "The Chosen One"
                 }
             }
@@ -5809,7 +14549,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["beast"],
+            "traits": [
+                "beast"
+            ],
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
@@ -5817,7 +14559,37 @@
             "power": 30,
             "text": "Thing from the Deep cannot be played unless Open the Seal is in your discard pile.\nAfter Fight: Steal 2.\n",
             "locale": {
+                "de": {
+                    "name": "Das Ding aus der Tiefe"
+                },
                 "en": {
+                    "name": "Thing from the Deep"
+                },
+                "es": {
+                    "name": "Thing from the Deep"
+                },
+                "fr": {
+                    "name": "Chose des Profondeurs"
+                },
+                "it": {
+                    "name": "Thing from the Deep"
+                },
+                "pl": {
+                    "name": "Thing from the Deep"
+                },
+                "pt": {
+                    "name": "Thing from the Deep"
+                },
+                "th": {
+                    "name": "Thing from the Deep"
+                },
+                "vi": {
+                    "name": "Thing from the Deep"
+                },
+                "zhhans": {
+                    "name": "Thing from the Deep"
+                },
+                "zhhant": {
                     "name": "Thing from the Deep"
                 }
             }
@@ -5838,7 +14610,37 @@
             "power": null,
             "text": "This creature gains, “While this creature is exhausted, your keys cost +6.”\n",
             "locale": {
+                "de": {
+                    "name": "Schwachstelle"
+                },
                 "en": {
+                    "name": "Weak Link"
+                },
+                "es": {
+                    "name": "Weak Link"
+                },
+                "fr": {
+                    "name": "Maillon Faible"
+                },
+                "it": {
+                    "name": "Weak Link"
+                },
+                "pl": {
+                    "name": "Weak Link"
+                },
+                "pt": {
+                    "name": "Weak Link"
+                },
+                "th": {
+                    "name": "Weak Link"
+                },
+                "vi": {
+                    "name": "Weak Link"
+                },
+                "zhhans": {
+                    "name": "Weak Link"
+                },
+                "zhhant": {
                     "name": "Weak Link"
                 }
             }
@@ -5851,7 +14653,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["beast"],
+            "traits": [
+                "beast"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -5859,7 +14663,37 @@
             "power": 5,
             "text": "After Fight: Your opponent discards\n2 random cards from their hand.\n",
             "locale": {
+                "de": {
+                    "name": "Verderbensfisch"
+                },
                 "en": {
+                    "name": "Addlefish"
+                },
+                "es": {
+                    "name": "Addlefish"
+                },
+                "fr": {
+                    "name": "Poisson Iridescent"
+                },
+                "it": {
+                    "name": "Addlefish"
+                },
+                "pl": {
+                    "name": "Addlefish"
+                },
+                "pt": {
+                    "name": "Addlefish"
+                },
+                "th": {
+                    "name": "Addlefish"
+                },
+                "vi": {
+                    "name": "Addlefish"
+                },
+                "zhhans": {
+                    "name": "Addlefish"
+                },
+                "zhhant": {
                     "name": "Addlefish"
                 }
             }
@@ -5880,7 +14714,37 @@
             "power": null,
             "text": "Play: Choose a house on your opponent’s identity card. If your opponent does not choose that house as their active house on their next turn, gain 3.",
             "locale": {
+                "de": {
+                    "name": "Dezenter Größenwahn"
+                },
                 "en": {
+                    "name": "Allusions of Grandeur"
+                },
+                "es": {
+                    "name": "Allusions of Grandeur"
+                },
+                "fr": {
+                    "name": "Allusions de Grandeur"
+                },
+                "it": {
+                    "name": "Allusions of Grandeur"
+                },
+                "pl": {
+                    "name": "Allusions of Grandeur"
+                },
+                "pt": {
+                    "name": "Allusions of Grandeur"
+                },
+                "th": {
+                    "name": "Allusions of Grandeur"
+                },
+                "vi": {
+                    "name": "Allusions of Grandeur"
+                },
+                "zhhans": {
+                    "name": "Allusions of Grandeur"
+                },
+                "zhhant": {
                     "name": "Allusions of Grandeur"
                 }
             }
@@ -5893,7 +14757,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["location"],
+            "traits": [
+                "location"
+            ],
             "type": "artifact",
             "rarity": "Uncommon",
             "amber": 1,
@@ -5901,7 +14767,37 @@
             "power": null,
             "text": "Action: Put a friendly creature on the bottom of its owner’s deck. If you do, exhaust 3 enemy creatures.",
             "locale": {
+                "de": {
+                    "name": "Azur-Becken-Außenposten"
+                },
                 "en": {
+                    "name": "Azure Basin Outpost"
+                },
+                "es": {
+                    "name": "Azure Basin Outpost"
+                },
+                "fr": {
+                    "name": "Avant-Poste Azuréen"
+                },
+                "it": {
+                    "name": "Azure Basin Outpost"
+                },
+                "pl": {
+                    "name": "Azure Basin Outpost"
+                },
+                "pt": {
+                    "name": "Azure Basin Outpost"
+                },
+                "th": {
+                    "name": "Azure Basin Outpost"
+                },
+                "vi": {
+                    "name": "Azure Basin Outpost"
+                },
+                "zhhans": {
+                    "name": "Azure Basin Outpost"
+                },
+                "zhhant": {
                     "name": "Azure Basin Outpost"
                 }
             }
@@ -5922,7 +14818,37 @@
             "power": null,
             "text": "Play: Return each creature to its owner’s hand. Each player discards random cards from their hand until they have 6 or fewer cards in hand. Gain 2 chains.",
             "locale": {
+                "de": {
+                    "name": "Fangen und Freilassen"
+                },
                 "en": {
+                    "name": "Catch and Release"
+                },
+                "es": {
+                    "name": "Catch and Release"
+                },
+                "fr": {
+                    "name": "Attrapé-Relâché"
+                },
+                "it": {
+                    "name": "Catch and Release"
+                },
+                "pl": {
+                    "name": "Catch and Release"
+                },
+                "pt": {
+                    "name": "Catch and Release"
+                },
+                "th": {
+                    "name": "Catch and Release"
+                },
+                "vi": {
+                    "name": "Catch and Release"
+                },
+                "zhhans": {
+                    "name": "Catch and Release"
+                },
+                "zhhant": {
                     "name": "Catch and Release"
                 }
             }
@@ -5943,7 +14869,37 @@
             "power": null,
             "text": "Play: Exhaust a creature. For each copy of Dreamcall in your discard pile, exhaust another creature and draw a card.\n",
             "locale": {
+                "de": {
+                    "name": "Traumruf"
+                },
                 "en": {
+                    "name": "Dreamcall"
+                },
+                "es": {
+                    "name": "Dreamcall"
+                },
+                "fr": {
+                    "name": "Chant des Sirènes"
+                },
+                "it": {
+                    "name": "Dreamcall"
+                },
+                "pl": {
+                    "name": "Dreamcall"
+                },
+                "pt": {
+                    "name": "Dreamcall"
+                },
+                "th": {
+                    "name": "Dreamcall"
+                },
+                "vi": {
+                    "name": "Dreamcall"
+                },
+                "zhhans": {
+                    "name": "Dreamcall"
+                },
+                "zhhant": {
                     "name": "Dreamcall"
                 }
             }
@@ -5964,7 +14920,37 @@
             "power": null,
             "text": "Play: Capture half of your opponent’s  (rounding down), distributed among any number of friendly creatures.\n",
             "locale": {
+                "de": {
+                    "name": "Tiefenteilung"
+                },
                 "en": {
+                    "name": "Fathomshare"
+                },
+                "es": {
+                    "name": "Fathomshare"
+                },
+                "fr": {
+                    "name": "Partage Sous le Rivage"
+                },
+                "it": {
+                    "name": "Fathomshare"
+                },
+                "pl": {
+                    "name": "Fathomshare"
+                },
+                "pt": {
+                    "name": "Fathomshare"
+                },
+                "th": {
+                    "name": "Fathomshare"
+                },
+                "vi": {
+                    "name": "Fathomshare"
+                },
+                "zhhans": {
+                    "name": "Fathomshare"
+                },
+                "zhhant": {
                     "name": "Fathomshare"
                 }
             }
@@ -5977,7 +14963,10 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["aquan", "scientist"],
+            "traits": [
+                "aquan",
+                "scientist"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -5985,7 +14974,37 @@
             "power": 3,
             "text": "After Reap: Choose a house. Exhaust each creature of that house.\nScrap: Exhaust a creature or an artifact.\n",
             "locale": {
+                "de": {
+                    "name": "Hukaru Eisflosse"
+                },
                 "en": {
+                    "name": "Hukaru Icefin"
+                },
+                "es": {
+                    "name": "Hukaru Icefin"
+                },
+                "fr": {
+                    "name": "Hukaru Congèleron"
+                },
+                "it": {
+                    "name": "Hukaru Icefin"
+                },
+                "pl": {
+                    "name": "Hukaru Icefin"
+                },
+                "pt": {
+                    "name": "Hukaru Icefin"
+                },
+                "th": {
+                    "name": "Hukaru Icefin"
+                },
+                "vi": {
+                    "name": "Hukaru Icefin"
+                },
+                "zhhans": {
+                    "name": "Hukaru Icefin"
+                },
+                "zhhant": {
                     "name": "Hukaru Icefin"
                 }
             }
@@ -5997,8 +15016,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_261_4e89d2db94ef_en.png",
             "expansion": 928,
             "house": "unfathomable",
-            "keywords": ["taunt"],
-            "traits": ["aquan"],
+            "keywords": [
+                "taunt"
+            ],
+            "traits": [
+                "aquan"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -6006,7 +15029,37 @@
             "power": 5,
             "text": "Taunt.\nAt the end of your turn, fully heal each of Kaipo’s neighbors.\n",
             "locale": {
+                "de": {
+                    "name": "Kaipo"
+                },
                 "en": {
+                    "name": "Kaipo"
+                },
+                "es": {
+                    "name": "Kaipo"
+                },
+                "fr": {
+                    "name": "Kayto"
+                },
+                "it": {
+                    "name": "Kaipo"
+                },
+                "pl": {
+                    "name": "Kaipo"
+                },
+                "pt": {
+                    "name": "Kaipo"
+                },
+                "th": {
+                    "name": "Kaipo"
+                },
+                "vi": {
+                    "name": "Kaipo"
+                },
+                "zhhans": {
+                    "name": "Kaipo"
+                },
+                "zhhant": {
                     "name": "Kaipo"
                 }
             }
@@ -6018,8 +15071,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_262_c1336dc81704_en.png",
             "expansion": 928,
             "house": "unfathomable",
-            "keywords": ["entrench"],
-            "traits": ["aquan"],
+            "keywords": [
+                "entrench"
+            ],
+            "traits": [
+                "aquan"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -6027,7 +15084,37 @@
             "power": 4,
             "text": "Entrench.\nWhile Malina is exhausted, your opponent cannot play creatures more powerful than the most powerful creature in play.\n",
             "locale": {
+                "de": {
+                    "name": "Malina"
+                },
                 "en": {
+                    "name": "Malina"
+                },
+                "es": {
+                    "name": "Malina"
+                },
+                "fr": {
+                    "name": "Mannina"
+                },
+                "it": {
+                    "name": "Malina"
+                },
+                "pl": {
+                    "name": "Malina"
+                },
+                "pt": {
+                    "name": "Malina"
+                },
+                "th": {
+                    "name": "Malina"
+                },
+                "vi": {
+                    "name": "Malina"
+                },
+                "zhhans": {
+                    "name": "Malina"
+                },
+                "zhhant": {
                     "name": "Malina"
                 }
             }
@@ -6039,8 +15126,12 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_263_ca130e963324_en.png",
             "expansion": 928,
             "house": "unfathomable",
-            "keywords": ["skirmish"],
-            "traits": ["aquan"],
+            "keywords": [
+                "skirmish"
+            ],
+            "traits": [
+                "aquan"
+            ],
             "type": "creature",
             "rarity": "Uncommon",
             "amber": 0,
@@ -6048,7 +15139,37 @@
             "power": 2,
             "text": "Skirmish. (When you use this creature to fight, it is dealt no damage in return.)\nAfter Fight: Stun and exhaust the creature Sparkfist fights.",
             "locale": {
+                "de": {
+                    "name": "Funkelfaust"
+                },
                 "en": {
+                    "name": "Sparkfist"
+                },
+                "es": {
+                    "name": "Sparkfist"
+                },
+                "fr": {
+                    "name": "Poing-Étincelle"
+                },
+                "it": {
+                    "name": "Sparkfist"
+                },
+                "pl": {
+                    "name": "Sparkfist"
+                },
+                "pt": {
+                    "name": "Sparkfist"
+                },
+                "th": {
+                    "name": "Sparkfist"
+                },
+                "vi": {
+                    "name": "Sparkfist"
+                },
+                "zhhans": {
+                    "name": "Sparkfist"
+                },
+                "zhhant": {
                     "name": "Sparkfist"
                 }
             }
@@ -6069,7 +15190,37 @@
             "power": null,
             "text": "Play: Deal 4 to each ready creature.\n",
             "locale": {
+                "de": {
+                    "name": "Tsunami"
+                },
                 "en": {
+                    "name": "Tsunami"
+                },
+                "es": {
+                    "name": "Tsunami"
+                },
+                "fr": {
+                    "name": "Tsunami"
+                },
+                "it": {
+                    "name": "Tsunami"
+                },
+                "pl": {
+                    "name": "Tsunami"
+                },
+                "pt": {
+                    "name": "Tsunami"
+                },
+                "th": {
+                    "name": "Tsunami"
+                },
+                "vi": {
+                    "name": "Tsunami"
+                },
+                "zhhans": {
+                    "name": "Tsunami"
+                },
+                "zhhant": {
                     "name": "Tsunami"
                 }
             }
@@ -6090,7 +15241,37 @@
             "power": null,
             "text": "This creature cannot ready.\n",
             "locale": {
+                "de": {
+                    "name": "Unter Druck"
+                },
                 "en": {
+                    "name": "Under Pressure"
+                },
+                "es": {
+                    "name": "Under Pressure"
+                },
+                "fr": {
+                    "name": "Sous Pression"
+                },
+                "it": {
+                    "name": "Under Pressure"
+                },
+                "pl": {
+                    "name": "Under Pressure"
+                },
+                "pt": {
+                    "name": "Under Pressure"
+                },
+                "th": {
+                    "name": "Under Pressure"
+                },
+                "vi": {
+                    "name": "Under Pressure"
+                },
+                "zhhans": {
+                    "name": "Under Pressure"
+                },
+                "zhhant": {
                     "name": "Under Pressure"
                 }
             }
@@ -6111,7 +15292,37 @@
             "power": null,
             "text": "Play: Destroy a friendly creature. If you do, look at your opponent’s hand and choose a card from it. That player discards that card.\n",
             "locale": {
+                "de": {
+                    "name": "Blick aus dem Abgrund"
+                },
                 "en": {
+                    "name": "Abyssal Sight"
+                },
+                "es": {
+                    "name": "Abyssal Sight"
+                },
+                "fr": {
+                    "name": "Vision Abyssale"
+                },
+                "it": {
+                    "name": "Abyssal Sight"
+                },
+                "pl": {
+                    "name": "Abyssal Sight"
+                },
+                "pt": {
+                    "name": "Abyssal Sight"
+                },
+                "th": {
+                    "name": "Abyssal Sight"
+                },
+                "vi": {
+                    "name": "Abyssal Sight"
+                },
+                "zhhans": {
+                    "name": "Abyssal Sight"
+                },
+                "zhhant": {
                     "name": "Abyssal Sight"
                 }
             }
@@ -6132,7 +15343,37 @@
             "power": null,
             "text": "Play: Each player discards the top 5 cards of their deck.\n",
             "locale": {
+                "de": {
+                    "name": "Brackwasser-Abrechnung"
+                },
                 "en": {
+                    "name": "Brine Reckoning"
+                },
+                "es": {
+                    "name": "Brine Reckoning"
+                },
+                "fr": {
+                    "name": "Montée des Eaux"
+                },
+                "it": {
+                    "name": "Brine Reckoning"
+                },
+                "pl": {
+                    "name": "Brine Reckoning"
+                },
+                "pt": {
+                    "name": "Brine Reckoning"
+                },
+                "th": {
+                    "name": "Brine Reckoning"
+                },
+                "vi": {
+                    "name": "Brine Reckoning"
+                },
+                "zhhans": {
+                    "name": "Brine Reckoning"
+                },
+                "zhhant": {
                     "name": "Brine Reckoning"
                 }
             }
@@ -6153,7 +15394,37 @@
             "power": null,
             "text": "Play: Exhaust a creature. If it was already exhausted, destroy it instead and its controller loses 1.\n",
             "locale": {
+                "de": {
+                    "name": "Ruf der Leere"
+                },
                 "en": {
+                    "name": "Call of the Void"
+                },
+                "es": {
+                    "name": "Call of the Void"
+                },
+                "fr": {
+                    "name": "Appel du Vide"
+                },
+                "it": {
+                    "name": "Call of the Void"
+                },
+                "pl": {
+                    "name": "Call of the Void"
+                },
+                "pt": {
+                    "name": "Call of the Void"
+                },
+                "th": {
+                    "name": "Call of the Void"
+                },
+                "vi": {
+                    "name": "Call of the Void"
+                },
+                "zhhans": {
+                    "name": "Call of the Void"
+                },
+                "zhhant": {
                     "name": "Call of the Void"
                 }
             }
@@ -6166,7 +15437,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["item"],
+            "traits": [
+                "item"
+            ],
             "type": "artifact",
             "rarity": "Common",
             "amber": 1,
@@ -6174,7 +15447,37 @@
             "power": null,
             "text": "Action: Exhaust a creature or artifact.\n",
             "locale": {
+                "de": {
+                    "name": "Stab der Kälte"
+                },
                 "en": {
+                    "name": "Frigorific Rod"
+                },
+                "es": {
+                    "name": "Frigorific Rod"
+                },
+                "fr": {
+                    "name": "Baguette Frigorifique"
+                },
+                "it": {
+                    "name": "Frigorific Rod"
+                },
+                "pl": {
+                    "name": "Frigorific Rod"
+                },
+                "pt": {
+                    "name": "Frigorific Rod"
+                },
+                "th": {
+                    "name": "Frigorific Rod"
+                },
+                "vi": {
+                    "name": "Frigorific Rod"
+                },
+                "zhhans": {
+                    "name": "Frigorific Rod"
+                },
+                "zhhant": {
                     "name": "Frigorific Rod"
                 }
             }
@@ -6187,7 +15490,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["beast"],
+            "traits": [
+                "beast"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -6195,7 +15500,37 @@
             "power": 2,
             "text": "Play: If there are no enemy exhausted creatures, your opponent loses 2.\n",
             "locale": {
+                "de": {
+                    "name": "Hermogrith"
+                },
                 "en": {
+                    "name": "Hemogrith"
+                },
+                "es": {
+                    "name": "Hemogrith"
+                },
+                "fr": {
+                    "name": "Hémogritte"
+                },
+                "it": {
+                    "name": "Hemogrith"
+                },
+                "pl": {
+                    "name": "Hemogrith"
+                },
+                "pt": {
+                    "name": "Hemogrith"
+                },
+                "th": {
+                    "name": "Hemogrith"
+                },
+                "vi": {
+                    "name": "Hemogrith"
+                },
+                "zhhans": {
+                    "name": "Hemogrith"
+                },
+                "zhhant": {
                     "name": "Hemogrith"
                 }
             }
@@ -6208,7 +15543,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["aquan"],
+            "traits": [
+                "aquan"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -6216,7 +15553,37 @@
             "power": 2,
             "text": "Enhance .\nPlay: Choose an enemy creature with no +1 power counters on it. Exhaust that creature and each of its neighbors.\n",
             "locale": {
+                "de": {
+                    "name": "Keenu"
+                },
                 "en": {
+                    "name": "Keenu"
+                },
+                "es": {
+                    "name": "Keenu"
+                },
+                "fr": {
+                    "name": "Keenu"
+                },
+                "it": {
+                    "name": "Keenu"
+                },
+                "pl": {
+                    "name": "Keenu"
+                },
+                "pt": {
+                    "name": "Keenu"
+                },
+                "th": {
+                    "name": "Keenu"
+                },
+                "vi": {
+                    "name": "Keenu"
+                },
+                "zhhans": {
+                    "name": "Keenu"
+                },
+                "zhhant": {
                     "name": "Keenu"
                 }
             }
@@ -6228,8 +15595,13 @@
             "image": "https://mastervault-storage-prod.s3.amazonaws.com/media/card_front/en/928_272_4fc0eb72b696_en.png",
             "expansion": 928,
             "house": "unfathomable",
-            "keywords": ["deploy", "entrench"],
-            "traits": ["beast"],
+            "keywords": [
+                "deploy",
+                "entrench"
+            ],
+            "traits": [
+                "beast"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -6237,7 +15609,37 @@
             "power": 3,
             "text": "Deploy. Entrench.\nWhile Knuckler is exhausted, each of its neighbors gets +2 armor.\n",
             "locale": {
+                "de": {
+                    "name": "Knöchelkriecher"
+                },
                 "en": {
+                    "name": "Knuckler"
+                },
+                "es": {
+                    "name": "Knuckler"
+                },
+                "fr": {
+                    "name": "Petite Frappe"
+                },
+                "it": {
+                    "name": "Knuckler"
+                },
+                "pl": {
+                    "name": "Knuckler"
+                },
+                "pt": {
+                    "name": "Knuckler"
+                },
+                "th": {
+                    "name": "Knuckler"
+                },
+                "vi": {
+                    "name": "Knuckler"
+                },
+                "zhhans": {
+                    "name": "Knuckler"
+                },
+                "zhhant": {
                     "name": "Knuckler"
                 }
             }
@@ -6250,7 +15652,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["beast"],
+            "traits": [
+                "beast"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -6258,7 +15662,37 @@
             "power": 3,
             "text": "After Reap: Stun, enrage, and exhaust a creature.\n",
             "locale": {
+                "de": {
+                    "name": "Lähmender Steinfisch"
+                },
                 "en": {
+                    "name": "Paralysis Synan"
+                },
+                "es": {
+                    "name": "Paralysis Synan"
+                },
+                "fr": {
+                    "name": "Synan le Curarisant"
+                },
+                "it": {
+                    "name": "Paralysis Synan"
+                },
+                "pl": {
+                    "name": "Paralysis Synan"
+                },
+                "pt": {
+                    "name": "Paralysis Synan"
+                },
+                "th": {
+                    "name": "Paralysis Synan"
+                },
+                "vi": {
+                    "name": "Paralysis Synan"
+                },
+                "zhhans": {
+                    "name": "Paralysis Synan"
+                },
+                "zhhant": {
                     "name": "Paralysis Synan"
                 }
             }
@@ -6271,7 +15705,10 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["aquan", "priest"],
+            "traits": [
+                "aquan",
+                "priest"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -6279,7 +15716,37 @@
             "power": 3,
             "text": "After Reap: Exhaust an enemy creature. If you do, ready a non-Priest creature.\n",
             "locale": {
+                "de": {
+                    "name": "Priesterin Leilani"
+                },
                 "en": {
+                    "name": "Priestess Leilani"
+                },
+                "es": {
+                    "name": "Priestess Leilani"
+                },
+                "fr": {
+                    "name": "Prêtresse Leilani"
+                },
+                "it": {
+                    "name": "Priestess Leilani"
+                },
+                "pl": {
+                    "name": "Priestess Leilani"
+                },
+                "pt": {
+                    "name": "Priestess Leilani"
+                },
+                "th": {
+                    "name": "Priestess Leilani"
+                },
+                "vi": {
+                    "name": "Priestess Leilani"
+                },
+                "zhhans": {
+                    "name": "Priestess Leilani"
+                },
+                "zhhant": {
                     "name": "Priestess Leilani"
                 }
             }
@@ -6292,7 +15759,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["vehicle"],
+            "traits": [
+                "vehicle"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -6300,7 +15769,37 @@
             "power": 4,
             "text": "After Fight/After Reap: Discard the top card of a player’s deck. For each bonus icon on the discarded card, your opponent loses 1.\n",
             "locale": {
+                "de": {
+                    "name": "Siphonrachen"
+                },
                 "en": {
+                    "name": "Siphon Maw"
+                },
+                "es": {
+                    "name": "Siphon Maw"
+                },
+                "fr": {
+                    "name": "Gueule à Siphon"
+                },
+                "it": {
+                    "name": "Siphon Maw"
+                },
+                "pl": {
+                    "name": "Siphon Maw"
+                },
+                "pt": {
+                    "name": "Siphon Maw"
+                },
+                "th": {
+                    "name": "Siphon Maw"
+                },
+                "vi": {
+                    "name": "Siphon Maw"
+                },
+                "zhhans": {
+                    "name": "Siphon Maw"
+                },
+                "zhhant": {
                     "name": "Siphon Maw"
                 }
             }
@@ -6313,7 +15812,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["item"],
+            "traits": [
+                "item"
+            ],
             "type": "artifact",
             "rarity": "Common",
             "amber": 0,
@@ -6321,7 +15822,37 @@
             "power": null,
             "text": "At the start of your turn, destroy each card with a corrosion counter on it.\nAction: Put a corrosion counter on a card in play.\n",
             "locale": {
+                "de": {
+                    "name": "Pfuschlack"
+                },
                 "en": {
+                    "name": "Slapdash Enamel"
+                },
+                "es": {
+                    "name": "Slapdash Enamel"
+                },
+                "fr": {
+                    "name": "Eaux Corrosives"
+                },
+                "it": {
+                    "name": "Slapdash Enamel"
+                },
+                "pl": {
+                    "name": "Slapdash Enamel"
+                },
+                "pt": {
+                    "name": "Slapdash Enamel"
+                },
+                "th": {
+                    "name": "Slapdash Enamel"
+                },
+                "vi": {
+                    "name": "Slapdash Enamel"
+                },
+                "zhhans": {
+                    "name": "Slapdash Enamel"
+                },
+                "zhhant": {
                     "name": "Slapdash Enamel"
                 }
             }
@@ -6334,7 +15865,9 @@
             "expansion": 928,
             "house": "unfathomable",
             "keywords": [],
-            "traits": ["aquan"],
+            "traits": [
+                "aquan"
+            ],
             "type": "creature",
             "rarity": "Common",
             "amber": 0,
@@ -6342,7 +15875,37 @@
             "power": 5,
             "text": "Play: Put an enemy creature on top of its owner’s deck.\n",
             "locale": {
+                "de": {
+                    "name": "„Blubber“"
+                },
                 "en": {
+                    "name": "“Bubbles”"
+                },
+                "es": {
+                    "name": "“Bubbles”"
+                },
+                "fr": {
+                    "name": "« Bubulles »"
+                },
+                "it": {
+                    "name": "“Bubbles”"
+                },
+                "pl": {
+                    "name": "“Bubbles”"
+                },
+                "pt": {
+                    "name": "“Bubbles”"
+                },
+                "th": {
+                    "name": "“Bubbles”"
+                },
+                "vi": {
+                    "name": "“Bubbles”"
+                },
+                "zhhans": {
+                    "name": "“Bubbles”"
+                },
+                "zhhant": {
                     "name": "“Bubbles”"
                 }
             }
@@ -6363,7 +15926,37 @@
             "power": null,
             "text": "Enhance . (These icons have already been added to cards in your deck.)\n",
             "locale": {
+                "de": {
+                    "name": "Öffnet das Siegel"
+                },
                 "en": {
+                    "name": "Open the Seal"
+                },
+                "es": {
+                    "name": "Open the Seal"
+                },
+                "fr": {
+                    "name": "Briser le Sceau"
+                },
+                "it": {
+                    "name": "Open the Seal"
+                },
+                "pl": {
+                    "name": "Open the Seal"
+                },
+                "pt": {
+                    "name": "Open the Seal"
+                },
+                "th": {
+                    "name": "Open the Seal"
+                },
+                "vi": {
+                    "name": "Open the Seal"
+                },
+                "zhhans": {
+                    "name": "Open the Seal"
+                },
+                "zhhant": {
                     "name": "Open the Seal"
                 }
             }

--- a/src/KeyforgeApiToKeytekiConverter.js
+++ b/src/KeyforgeApiToKeytekiConverter.js
@@ -288,7 +288,9 @@ class KeyforgeApiToKeytekiConverter {
                 card.type = 'creature';
             } else if (card.type === 'creature2') {
                 card.type = 'creature';
-                card.id += '2';
+                if (!card.id.endsWith('2')) {
+                    card.id += '2';
+                }
 
                 let cardKey = `${card.number}/Creature1/${
                     card.house.charAt(0).toUpperCase() + card.house.slice(1)
@@ -305,7 +307,9 @@ class KeyforgeApiToKeytekiConverter {
                 card.type = 'creature';
             } else if (card.type === 'gigantic creature art') {
                 card.type = 'creature';
-                card.id += '2';
+                if (!card.id.endsWith('2')) {
+                    card.id += '2';
+                }
             } else if (card.text.includes('Play only with the other half') && card.type === 'creature' && card.rarity === 'Special') {
                 // Gigantics in More Mutation don't have the
                 // "creature1"/"creature2" types.  Card text is the only way to
@@ -338,7 +342,9 @@ class KeyforgeApiToKeytekiConverter {
                     topHalf.amber = card.amber;
                     topHalf.armor = card.armor;
                     topHalf.traits = card.traits;
-                    topHalf.id += '2';
+                    if (!topHalf.id.endsWith('2')) {
+                        topHalf.id += '2';
+                    }
                 } else {
                     console.info('No card found', keys[0]);
                 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the offline card import/conversion script, but could affect generated pack JSON (card matching and locale keys) if the API returns unexpected types/rarities.
> 
> **Overview**
> Extends the `KeyforgeApiToKeytekiConverter` import to persist **per-language card name translations** under a `locale` map, with English as the base and additional languages appended using normalized language codes.
> 
> Adjusts card-key matching for non-English imports (notably creature/gigantic variants) and keeps `locale` entries deterministically ordered to reduce churn in generated pack JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9805bd0ab4aec0f4e474e3d511752339a4725a55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->