### PR TITLE
DM: fix gigantic armor

### DIFF
--- a/packs/DM.json
+++ b/packs/DM.json
@@ -9543,7 +9543,7 @@
             "type": "creature",
             "rarity": "Special",
             "amber": 0,
-            "armor": null,
+            "armor": 2,
             "power": 7,
             "text": "(Play only with the other half of Boosted B4-RRY.)\nPlay/After Fight/After Reap: Choose one:\nTake control of an enemy artifact. While under your control, it belongs to house Shadows (instead of its original house).\nPlay a random card from your opponent’s archives as if it were yours.\n",
             "locale": {
@@ -9596,7 +9596,7 @@
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
-            "armor": null,
+            "armor": 2,
             "power": 7,
             "text": "(Play only with the other half of Boosted B4-RRY.)\nPlay/After Fight/After Reap: Choose one:\nTake control of an enemy artifact. While under your control, it belongs to house Shadows (instead of its original house).\nPlay a random card from your opponent’s archives as if it were yours.\n",
             "locale": {
@@ -12399,7 +12399,7 @@
             "type": "creature",
             "rarity": "Rare",
             "amber": 0,
-            "armor": null,
+            "armor": 2,
             "power": 16,
             "text": "(Play only with the other half of Zomok.)\nWhile Zomok is attacking, ignore taunt, elusive, poison, hazardous, and invulnerable.\nAfter Fight: Deal 2 to a creature for each forged key.\n",
             "locale": {
@@ -12453,7 +12453,7 @@
             "type": "creature",
             "rarity": "Special",
             "amber": 0,
-            "armor": null,
+            "armor": 2,
             "power": 16,
             "text": "(Play only with the other half of Zomok.)\nWhile Zomok is attacking, ignore taunt, elusive, poison, hazardous, and invulnerable.\nAfter Fight: Deal 2 to a creature for each forged key.\n",
             "locale": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk data-only change that updates card metadata; impact is limited to displaying/using armor values for the affected cards.
> 
> **Overview**
> Updates `packs/DM.json` to set `armor: 2` (instead of `null`) for both entries of the gigantic creatures `Boosted B4-RRY` and `Zomok`, ensuring their printed armor is represented correctly in the DM card data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faa69f07a5695de2c19073c4d160d82f7be3086a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->